### PR TITLE
Add transaction coders

### DIFF
--- a/packages/abi-coder/coders/number.ts
+++ b/packages/abi-coder/coders/number.ts
@@ -29,7 +29,7 @@ export default class NumberCoder extends Coder {
     }
   }
 
-  encode(value: string | number): Uint8Array {
+  encode(value: string | number | BN): Uint8Array {
     let bytes = new Uint8Array();
 
     try {

--- a/packages/transactions/consts.ts
+++ b/packages/transactions/consts.ts
@@ -1,0 +1,33 @@
+// Maximum contract size, in bytes.
+export const CONTRACT_MAX_SIZE = 16 * 1024;
+
+// Maximum number of inputs.
+export const MAX_INPUTS = 8;
+
+// Maximum number of outputs.
+export const MAX_OUTPUTS = 8;
+
+// Maximum number of witnesses.
+export const MAX_WITNESSES = 16;
+
+// Maximum gas per transaction.
+export const MAX_GAS_PER_TX = 1000000;
+
+// TODO: set max script length const
+// Maximum length of script, in instructions.
+export const MAX_SCRIPT_LENGTH = 1024 * 1024 * 1024;
+
+// TODO: set max script length const
+// Maximum length of script data, in bytes.
+export const MAX_SCRIPT_DATA_LENGTH = 1024 * 1024 * 1024;
+
+// Maximum number of static contracts.
+export const MAX_STATIC_CONTRACTS = 255;
+
+// TODO: set max predicate length value
+// Maximum length of predicate, in instructions.
+export const MAX_PREDICATE_LENGTH = 1024 * 1024;
+
+// TODO: set max predicate data length value
+// Maximum length of predicate data, in bytes.
+export const MAX_PREDICATE_DATA_LENGTH = 1024 * 1024;

--- a/packages/transactions/input.test.ts
+++ b/packages/transactions/input.test.ts
@@ -1,0 +1,60 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { arrayify, hexlify } from '@ethersproject/bytes';
+import { expect } from 'chai';
+import { Input, InputCoder, InputType } from './input';
+
+const B256 = '0xd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b';
+
+describe('InputCoder', () => {
+  it('Can encode Coin', () => {
+    const input: Input = {
+      type: InputType.Coin,
+      data: {
+        utxoID: B256,
+        owner: B256,
+        amount: BigNumber.from(0),
+        color: B256,
+        witnessIndex: BigNumber.from(0),
+        maturity: BigNumber.from(0),
+        predicateLength: BigNumber.from(0),
+        predicateDataLength: BigNumber.from(0),
+        predicate: '0x',
+        predicateData: '0x',
+      },
+    };
+
+    const encoded = hexlify(new InputCoder('input').encode(input));
+
+    expect(encoded).to.equal(
+      '0x0000000000000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930bd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b0000000000000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b0000000000000000000000000000000000000000000000000000000000000000'
+    );
+
+    const [decoded, offset] = new InputCoder('input').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(input);
+  });
+
+  it('Can encode Contract', () => {
+    const input: Input = {
+      type: InputType.Contract,
+      data: {
+        utxoID: B256,
+        balanceRoot: B256,
+        stateRoot: B256,
+        contractID: B256,
+      },
+    };
+
+    const encoded = hexlify(new InputCoder('input').encode(input));
+
+    expect(encoded).to.equal(
+      '0x0000000000000001d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930bd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930bd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930bd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+    );
+
+    const [decoded, offset] = new InputCoder('input').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(input);
+  });
+});

--- a/packages/transactions/input.ts
+++ b/packages/transactions/input.ts
@@ -1,0 +1,235 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable max-classes-per-file */
+
+import { BigNumber } from '@ethersproject/bignumber';
+import { arrayify, concat, hexlify } from '@ethersproject/bytes';
+import Coder from '../abi-coder/coders/abstract-coder';
+import ArrayCoder from '../abi-coder/coders/array';
+import B256Coder from '../abi-coder/coders/b256';
+import ByteCoder from '../abi-coder/coders/byte';
+import NumberCoder from '../abi-coder/coders/number';
+
+export enum InputType /* u8 */ {
+  Coin = 0,
+  Contract = 1,
+}
+
+export type Input =
+  | {
+      type: InputType.Coin;
+      data: InputCoin;
+    }
+  | {
+      type: InputType.Contract;
+      data: InputContract;
+    };
+
+export class InputCoder extends Coder {
+  constructor(localName: string) {
+    super('Input', 'Input', localName);
+  }
+
+  encode(value: Input): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new NumberCoder('type', 'u8').encode(value.type));
+    switch (value.type) {
+      case InputType.Coin: {
+        parts.push(new InputCoinCoder('data').encode(value.data));
+        break;
+      }
+      case InputType.Contract: {
+        parts.push(new InputContractCoder('data').encode(value.data));
+        break;
+      }
+      default: {
+        throw new Error('Invalid Input type');
+      }
+    }
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [Input, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new NumberCoder('type', 'u8').decode(data, o);
+    const type = decoded.toNumber() as InputType;
+    switch (type) {
+      case InputType.Coin: {
+        [decoded, o] = new InputCoinCoder('data').decode(data, o);
+        return [
+          {
+            type,
+            data: decoded,
+          },
+          o,
+        ];
+      }
+      case InputType.Contract: {
+        [decoded, o] = new InputContractCoder('data').decode(data, o);
+        return [
+          {
+            type,
+            data: decoded,
+          },
+          o,
+        ];
+      }
+      default: {
+        throw new Error('Invalid Input type');
+      }
+    }
+  }
+}
+
+export type InputCoin = {
+  // UTXO ID (b256)
+  utxoID: string;
+  // Owning address or script hash (b256)
+  owner: string;
+  // Amount of coins (u64)
+  amount: BigNumber;
+  // Color of the coins (b256)
+  color: string;
+  // Index of witness that authorizes spending the coin (u8)
+  witnessIndex: BigNumber;
+  // UTXO being spent must have been created at least this many blocks ago (u64)
+  maturity: BigNumber;
+  // Length of predicate, in instructions (u16)
+  predicateLength: BigNumber;
+  // Length of predicate input data, in bytes (u16)
+  predicateDataLength: BigNumber;
+  // Predicate bytecode (byte[])
+  predicate: string;
+  // Predicate input data (parameters) (byte[])
+  predicateData: string;
+};
+
+export class InputCoinCoder extends Coder {
+  constructor(localName: string) {
+    super('InputCoin', 'InputCoin', localName);
+  }
+
+  encode(value: InputCoin): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new B256Coder('utxoID', 'b256').encode(value.utxoID));
+    parts.push(new B256Coder('owner', 'address').encode(value.owner));
+    parts.push(new NumberCoder('amount', 'u64').encode(value.amount));
+    parts.push(new B256Coder('color', 'b256').encode(value.color));
+    parts.push(new NumberCoder('witnessIndex', 'u8').encode(value.witnessIndex));
+    parts.push(new NumberCoder('maturity', 'u64').encode(value.maturity));
+    parts.push(new NumberCoder('predicateLength', 'u16').encode(value.predicateLength));
+    parts.push(new NumberCoder('predicateDataLength', 'u16').encode(value.predicateDataLength));
+    parts.push(arrayify(value.predicate));
+    parts.push(arrayify(value.predicateData));
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [InputCoin, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new B256Coder('utxoID', 'b256').decode(data, o);
+    const utxoID = decoded;
+    [decoded, o] = new B256Coder('owner', 'address').decode(data, o);
+    const owner = decoded;
+    [decoded, o] = new NumberCoder('amount', 'u64').decode(data, o);
+    const amount = decoded;
+    [decoded, o] = new B256Coder('color', 'b256').decode(data, o);
+    const color = decoded;
+    [decoded, o] = new NumberCoder('witnessIndex', 'u8').decode(data, o);
+    const witnessIndex = decoded;
+    [decoded, o] = new NumberCoder('maturity', 'u64').decode(data, o);
+    const maturity = decoded;
+    [decoded, o] = new NumberCoder('predicateLength', 'u16').decode(data, o);
+    const predicateLength = decoded;
+    [decoded, o] = new NumberCoder('predicateDataLength', 'u16').decode(data, o);
+    const predicateDataLength = decoded;
+    [decoded, o] = [
+      hexlify(data.slice(o, predicateLength.toNumber())),
+      o + predicateLength.toNumber(),
+    ];
+    const predicate = decoded;
+    [decoded, o] = [
+      hexlify(data.slice(o, predicateDataLength.toNumber())),
+      o + predicateDataLength.toNumber(),
+    ];
+    const predicateData = decoded;
+
+    return [
+      {
+        utxoID,
+        owner,
+        amount,
+        color,
+        witnessIndex,
+        maturity,
+        predicateLength,
+        predicateDataLength,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        predicate,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        predicateData,
+      },
+      o,
+    ];
+  }
+}
+
+export type InputContract = {
+  // UTXO ID (b256)
+  utxoID: string;
+  // Root of amount of coins owned by contract before transaction execution (b256)
+  balanceRoot: string;
+  // State root of contract before transaction execution (b256)
+  stateRoot: string;
+  // Contract ID (b256)
+  contractID: string;
+};
+
+export class InputContractCoder extends Coder {
+  constructor(localName: string) {
+    super('InputContract', 'InputContract', localName);
+  }
+
+  encode(value: InputContract): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new B256Coder('utxoID', 'b256').encode(value.utxoID));
+    parts.push(new B256Coder('balanceRoot', 'b256').encode(value.balanceRoot));
+    parts.push(new B256Coder('stateRoot', 'b256').encode(value.stateRoot));
+    parts.push(new B256Coder('contractID', 'b256').encode(value.contractID));
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [InputContract, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new B256Coder('utxoID', 'b256').decode(data, o);
+    const utxoID = decoded;
+    [decoded, o] = new B256Coder('balanceRoot', 'b256').decode(data, o);
+    const balanceRoot = decoded;
+    [decoded, o] = new B256Coder('stateRoot', 'b256').decode(data, o);
+    const stateRoot = decoded;
+    [decoded, o] = new B256Coder('contractID', 'b256').decode(data, o);
+    const contractID = decoded;
+
+    return [
+      {
+        utxoID,
+        balanceRoot,
+        stateRoot,
+        contractID,
+      },
+      o,
+    ];
+  }
+}

--- a/packages/transactions/output.test.ts
+++ b/packages/transactions/output.test.ts
@@ -1,0 +1,138 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { arrayify, hexlify } from '@ethersproject/bytes';
+import { expect } from 'chai';
+import { Output, OutputCoder, OutputType } from './output';
+
+const B256 = '0xd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b';
+
+describe('OutputCoder', () => {
+  it('Can encode Coin', () => {
+    const output: Output = {
+      type: OutputType.Coin,
+      data: {
+        to: B256,
+        amount: BigNumber.from(0),
+        color: B256,
+      },
+    };
+
+    const encoded = hexlify(new OutputCoder('output').encode(output));
+
+    expect(encoded).to.equal(
+      '0x0000000000000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b0000000000000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+    );
+
+    const [decoded, offset] = new OutputCoder('output').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(output);
+  });
+
+  it('Can encode Contract', () => {
+    const output: Output = {
+      type: OutputType.Contract,
+      data: {
+        inputIndex: BigNumber.from(0),
+        balanceRoot: B256,
+        stateRoot: B256,
+      },
+    };
+
+    const encoded = hexlify(new OutputCoder('output').encode(output));
+
+    expect(encoded).to.equal(
+      '0x00000000000000010000000000000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930bd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+    );
+
+    const [decoded, offset] = new OutputCoder('output').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(output);
+  });
+
+  it('Can encode Withdrawal', () => {
+    const output: Output = {
+      type: OutputType.Withdrawal,
+      data: {
+        to: B256,
+        amount: BigNumber.from(0),
+        color: B256,
+      },
+    };
+
+    const encoded = hexlify(new OutputCoder('output').encode(output));
+
+    expect(encoded).to.equal(
+      '0x0000000000000002d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b0000000000000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+    );
+
+    const [decoded, offset] = new OutputCoder('output').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(output);
+  });
+
+  it('Can encode Change', () => {
+    const output: Output = {
+      type: OutputType.Change,
+      data: {
+        to: B256,
+        amount: BigNumber.from(0),
+        color: B256,
+      },
+    };
+
+    const encoded = hexlify(new OutputCoder('output').encode(output));
+
+    expect(encoded).to.equal(
+      '0x0000000000000003d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b0000000000000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+    );
+
+    const [decoded, offset] = new OutputCoder('output').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(output);
+  });
+
+  it('Can encode Variable', () => {
+    const output: Output = {
+      type: OutputType.Variable,
+      data: {
+        to: B256,
+        amount: BigNumber.from(0),
+        color: B256,
+      },
+    };
+
+    const encoded = hexlify(new OutputCoder('output').encode(output));
+
+    expect(encoded).to.equal(
+      '0x0000000000000004d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b0000000000000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+    );
+
+    const [decoded, offset] = new OutputCoder('output').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(output);
+  });
+
+  it('Can encode ContractCreated', () => {
+    const output: Output = {
+      type: OutputType.ContractCreated,
+      data: {
+        contractId: B256,
+      },
+    };
+
+    const encoded = hexlify(new OutputCoder('output').encode(output));
+
+    expect(encoded).to.equal(
+      '0x0000000000000005d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+    );
+
+    const [decoded, offset] = new OutputCoder('output').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(output);
+  });
+});

--- a/packages/transactions/output.ts
+++ b/packages/transactions/output.ts
@@ -1,0 +1,423 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable max-classes-per-file */
+import { BigNumber } from '@ethersproject/bignumber';
+import { concat } from '@ethersproject/bytes';
+import Coder from '../abi-coder/coders/abstract-coder';
+import B256Coder from '../abi-coder/coders/b256';
+import NumberCoder from '../abi-coder/coders/number';
+
+export enum OutputType /* u8 */ {
+  Coin = 0,
+  Contract = 1,
+  Withdrawal = 2,
+  Change = 3,
+  Variable = 4,
+  ContractCreated = 5,
+}
+
+export type Output =
+  | {
+      type: OutputType.Coin;
+      data: OutputCoin;
+    }
+  | {
+      type: OutputType.Contract;
+      data: OutputContract;
+    }
+  | {
+      type: OutputType.Withdrawal;
+      data: OutputWithdrawal;
+    }
+  | {
+      type: OutputType.Change;
+      data: OutputChange;
+    }
+  | {
+      type: OutputType.Variable;
+      data: OutputVariable;
+    }
+  | {
+      type: OutputType.ContractCreated;
+      data: OutputContractCreated;
+    };
+
+export class OutputCoder extends Coder {
+  constructor(localName: string) {
+    super('Output', 'Output', localName);
+  }
+
+  encode(value: Output): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new NumberCoder('type', 'u8').encode(value.type));
+    switch (value.type) {
+      case OutputType.Coin: {
+        parts.push(new OutputCoinCoder('data').encode(value.data));
+        break;
+      }
+      case OutputType.Contract: {
+        parts.push(new OutputContractCoder('data').encode(value.data));
+        break;
+      }
+      case OutputType.Withdrawal: {
+        parts.push(new OutputWithdrawalCoder('data').encode(value.data));
+        break;
+      }
+      case OutputType.Change: {
+        parts.push(new OutputChangeCoder('data').encode(value.data));
+        break;
+      }
+      case OutputType.Variable: {
+        parts.push(new OutputVariableCoder('data').encode(value.data));
+        break;
+      }
+      case OutputType.ContractCreated: {
+        parts.push(new OutputContractCreatedCoder('data').encode(value.data));
+        break;
+      }
+      default: {
+        throw new Error('Invalid Output type');
+      }
+    }
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [Output, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new NumberCoder('type', 'u8').decode(data, o);
+    const type = decoded.toNumber() as OutputType;
+    switch (type) {
+      case OutputType.Coin: {
+        [decoded, o] = new OutputCoinCoder('data').decode(data, o);
+        return [
+          {
+            type,
+            data: decoded,
+          },
+          o,
+        ];
+      }
+      case OutputType.Contract: {
+        [decoded, o] = new OutputContractCoder('data').decode(data, o);
+        return [
+          {
+            type,
+            data: decoded,
+          },
+          o,
+        ];
+      }
+      case OutputType.Withdrawal: {
+        [decoded, o] = new OutputWithdrawalCoder('data').decode(data, o);
+        return [
+          {
+            type,
+            data: decoded,
+          },
+          o,
+        ];
+      }
+      case OutputType.Change: {
+        [decoded, o] = new OutputChangeCoder('data').decode(data, o);
+        return [
+          {
+            type,
+            data: decoded,
+          },
+          o,
+        ];
+      }
+      case OutputType.Variable: {
+        [decoded, o] = new OutputVariableCoder('data').decode(data, o);
+        return [
+          {
+            type,
+            data: decoded,
+          },
+          o,
+        ];
+      }
+      case OutputType.ContractCreated: {
+        [decoded, o] = new OutputContractCreatedCoder('data').decode(data, o);
+        return [
+          {
+            type,
+            data: decoded,
+          },
+          o,
+        ];
+      }
+      default: {
+        throw new Error('Invalid Output type');
+      }
+    }
+  }
+}
+
+type OutputCoin = {
+  // Receiving address or script hash (b256)
+  to: string;
+  // Amount of coins to send (u64)
+  amount: BigNumber;
+  // Color of coins (b256)
+  color: string;
+};
+
+export class OutputCoinCoder extends Coder {
+  constructor(localName: string) {
+    super('OutputCoin', 'OutputCoin', localName);
+  }
+
+  encode(value: OutputCoin): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new B256Coder('to', 'address').encode(value.to));
+    parts.push(new NumberCoder('amount', 'u64').encode(value.amount));
+    parts.push(new B256Coder('color', 'b256').encode(value.color));
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [OutputCoin, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new B256Coder('to', 'address').decode(data, o);
+    const to = decoded;
+    [decoded, o] = new NumberCoder('amount', 'u64').decode(data, o);
+    const amount = decoded;
+    [decoded, o] = new B256Coder('color', 'b256').decode(data, o);
+    const color = decoded;
+
+    return [
+      {
+        to,
+        amount,
+        color,
+      },
+      o,
+    ];
+  }
+}
+
+type OutputContract = {
+  // Index of input contract (u8)
+  inputIndex: BigNumber;
+  // Root of amount of coins owned by contract after transaction execution (b256)
+  balanceRoot: string;
+  // State root of contract after transaction execution (b256)
+  stateRoot: string;
+};
+
+export class OutputContractCoder extends Coder {
+  constructor(localName: string) {
+    super('OutputContract', 'OutputContract', localName);
+  }
+
+  encode(value: OutputContract): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new NumberCoder('inputIndex', 'u8').encode(value.inputIndex));
+    parts.push(new B256Coder('balanceRoot', 'b256').encode(value.balanceRoot));
+    parts.push(new B256Coder('stateRoot', 'b256').encode(value.stateRoot));
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [OutputContract, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new NumberCoder('inputIndex', 'u8').decode(data, o);
+    const inputIndex = decoded;
+    [decoded, o] = new B256Coder('balanceRoot', 'b256').decode(data, o);
+    const balanceRoot = decoded;
+    [decoded, o] = new B256Coder('stateRoot', 'b256').decode(data, o);
+    const stateRoot = decoded;
+
+    return [
+      {
+        inputIndex,
+        balanceRoot,
+        stateRoot,
+      },
+      o,
+    ];
+  }
+}
+
+type OutputWithdrawal = {
+  // Receiving address (b256)
+  to: string;
+  // Amount of coins to withdraw (u64)
+  amount: BigNumber;
+  // Color of coins (b256)
+  color: string;
+};
+
+export class OutputWithdrawalCoder extends Coder {
+  constructor(localName: string) {
+    super('OutputWithdrawal', 'OutputWithdrawal', localName);
+  }
+
+  encode(value: OutputWithdrawal): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new B256Coder('to', 'address').encode(value.to));
+    parts.push(new NumberCoder('amount', 'u64').encode(value.amount));
+    parts.push(new B256Coder('color', 'b256').encode(value.color));
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [OutputWithdrawal, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new B256Coder('to', 'address').decode(data, o);
+    const to = decoded;
+    [decoded, o] = new NumberCoder('amount', 'u64').decode(data, o);
+    const amount = decoded;
+    [decoded, o] = new B256Coder('color', 'b256').decode(data, o);
+    const color = decoded;
+
+    return [
+      {
+        to,
+        amount,
+        color,
+      },
+      o,
+    ];
+  }
+}
+
+type OutputChange = {
+  // Receiving address or script hash (b256)
+  to: string;
+  // Amount of coins to send (u64)
+  amount: BigNumber;
+  // Color of coins (b256)
+  color: string;
+};
+
+export class OutputChangeCoder extends Coder {
+  constructor(localName: string) {
+    super('OutputChange', 'OutputChange', localName);
+  }
+
+  encode(value: OutputChange): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new B256Coder('to', 'address').encode(value.to));
+    parts.push(new NumberCoder('amount', 'u64').encode(value.amount));
+    parts.push(new B256Coder('color', 'b256').encode(value.color));
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [OutputWithdrawal, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new B256Coder('to', 'address').decode(data, o);
+    const to = decoded;
+    [decoded, o] = new NumberCoder('amount', 'u64').decode(data, o);
+    const amount = decoded;
+    [decoded, o] = new B256Coder('color', 'b256').decode(data, o);
+    const color = decoded;
+
+    return [
+      {
+        to,
+        amount,
+        color,
+      },
+      o,
+    ];
+  }
+}
+
+type OutputVariable = {
+  // Receiving address or script hash (b256)
+  to: string;
+  // Amount of coins to send (u64)
+  amount: BigNumber;
+  // Color of coins (b256)
+  color: string;
+};
+
+export class OutputVariableCoder extends Coder {
+  constructor(localName: string) {
+    super('OutputVariable', 'OutputVariable', localName);
+  }
+
+  encode(value: OutputVariable): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new B256Coder('to', 'address').encode(value.to));
+    parts.push(new NumberCoder('amount', 'u64').encode(value.amount));
+    parts.push(new B256Coder('color', 'b256').encode(value.color));
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [OutputVariable, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new B256Coder('to', 'address').decode(data, o);
+    const to = decoded;
+    [decoded, o] = new NumberCoder('amount', 'u64').decode(data, o);
+    const amount = decoded;
+    [decoded, o] = new B256Coder('color', 'b256').decode(data, o);
+    const color = decoded;
+
+    return [
+      {
+        to,
+        amount,
+        color,
+      },
+      o,
+    ];
+  }
+}
+
+type OutputContractCreated = {
+  // Contract ID (b256)
+  contractId: string;
+};
+
+export class OutputContractCreatedCoder extends Coder {
+  constructor(localName: string) {
+    super('OutputContractCreated', 'OutputContractCreated', localName);
+  }
+
+  encode(value: OutputContractCreated): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new B256Coder('contractID', 'b256').encode(value.contractId));
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [OutputContractCreated, number] {
+    let decoded;
+    let o = offset;
+
+    // eslint-disable-next-line prefer-const
+    [decoded, o] = new B256Coder('contractId', 'b256').decode(data, o);
+    const contractId = decoded;
+
+    return [
+      {
+        contractId,
+      },
+      o,
+    ];
+  }
+}

--- a/packages/transactions/receipt.ts
+++ b/packages/transactions/receipt.ts
@@ -1,0 +1,13 @@
+/* eslint-disable import/prefer-default-export */
+
+export enum ReceiptType /* u8 */ {
+  Call = 0,
+  Return = 1,
+  ReturnData = 2,
+  Panic = 3,
+  Revert = 4,
+  Log = 5,
+  LogData = 6,
+  Transfer = 7,
+  TransferOut = 8,
+}

--- a/packages/transactions/transaction.test.ts
+++ b/packages/transactions/transaction.test.ts
@@ -1,0 +1,75 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { arrayify, hexlify } from '@ethersproject/bytes';
+import { expect } from 'chai';
+
+import { Transaction, TransactionCoder, TransactionType } from './transaction';
+
+const B256 = '0xd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b';
+
+describe('TransactionCoder', () => {
+  it('Can encode TransactionScript', () => {
+    const transaction: Transaction = {
+      type: TransactionType.Script,
+      data: {
+        gasPrice: BigNumber.from(0),
+        gasLimit: BigNumber.from(0),
+        maturity: BigNumber.from(0),
+        scriptLength: BigNumber.from(0),
+        scriptDataLength: BigNumber.from(0),
+        inputsCount: BigNumber.from(0),
+        outputsCount: BigNumber.from(0),
+        witnessesCount: BigNumber.from(0),
+        receiptsRoot: B256,
+        script: '0x',
+        scriptData: '0x',
+        inputs: [],
+        outputs: [],
+        witnesses: [],
+      },
+    };
+
+    const encoded = hexlify(new TransactionCoder('transaction').encode(transaction));
+
+    expect(encoded).to.equal(
+      '0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+    );
+
+    const [decoded, offset] = new TransactionCoder('transaction').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(transaction);
+  });
+
+  it('Can encode TransactionCreate', () => {
+    const transaction: Transaction = {
+      type: TransactionType.Create,
+      data: {
+        gasPrice: BigNumber.from(0),
+        gasLimit: BigNumber.from(0),
+        maturity: BigNumber.from(0),
+        bytecodeLength: BigNumber.from(0),
+        bytecodeWitnessIndex: BigNumber.from(0),
+        staticContractsCount: BigNumber.from(0),
+        inputsCount: BigNumber.from(0),
+        outputsCount: BigNumber.from(0),
+        witnessesCount: BigNumber.from(0),
+        salt: B256,
+        staticContracts: [],
+        inputs: [],
+        outputs: [],
+        witnesses: [],
+      },
+    };
+
+    const encoded = hexlify(new TransactionCoder('transaction').encode(transaction));
+
+    expect(encoded).to.equal(
+      '0x0000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+    );
+
+    const [decoded, offset] = new TransactionCoder('transaction').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(transaction);
+  });
+});

--- a/packages/transactions/transaction.ts
+++ b/packages/transactions/transaction.ts
@@ -1,0 +1,388 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable max-classes-per-file */
+
+import { BigNumber } from '@ethersproject/bignumber';
+import { arrayify, concat, hexlify } from '@ethersproject/bytes';
+import Coder from '../abi-coder/coders/abstract-coder';
+import ArrayCoder from '../abi-coder/coders/array';
+import B256Coder from '../abi-coder/coders/b256';
+import NumberCoder from '../abi-coder/coders/number';
+import { Input, InputCoder } from './input';
+import { Output, OutputCoder } from './output';
+import { Witness, WitnessCoder } from './witness';
+
+export enum TransactionType /* u8 */ {
+  Script = 0,
+  Create = 1,
+}
+
+export type Transaction =
+  | {
+      type: TransactionType.Script;
+      data: TransactionScript;
+    }
+  | {
+      type: TransactionType.Create;
+      data: TransactionCreate;
+    };
+
+export class TransactionCoder extends Coder {
+  constructor(localName: string) {
+    super('Transaction', 'Transaction', localName);
+  }
+
+  encode(value: Transaction): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new NumberCoder('type', 'u8').encode(value.type));
+    switch (value.type) {
+      case TransactionType.Script: {
+        parts.push(new TransactionScriptCoder('data').encode(value.data));
+        break;
+      }
+      case TransactionType.Create: {
+        parts.push(new TransactionCreateCoder('data').encode(value.data));
+        break;
+      }
+      default: {
+        throw new Error('Invalid Transaction type');
+      }
+    }
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [Transaction, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new NumberCoder('type', 'u8').decode(data, o);
+    const type = decoded.toNumber() as TransactionType;
+    switch (type) {
+      case TransactionType.Script: {
+        [decoded, o] = new TransactionScriptCoder('data').decode(data, o);
+        return [
+          {
+            type,
+            data: decoded,
+          },
+          o,
+        ];
+      }
+      case TransactionType.Create: {
+        [decoded, o] = new TransactionCreateCoder('data').decode(data, o);
+        return [
+          {
+            type,
+            data: decoded,
+          },
+          o,
+        ];
+      }
+      default: {
+        throw new Error('Invalid Input type');
+      }
+    }
+  }
+}
+
+type TransactionScript = {
+  // Gas price for transaction (u64)
+  gasPrice: BigNumber;
+  // Gas limit for transaction (u64)
+  gasLimit: BigNumber;
+  // Block until which tx cannot be included (u32)
+  maturity: BigNumber;
+  // Script length, in instructions (u16)
+  scriptLength: BigNumber;
+  // Length of script input data, in bytes (u16)
+  scriptDataLength: BigNumber;
+  // Number of inputs (u8)
+  inputsCount: BigNumber;
+  // Number of outputs (u8)
+  outputsCount: BigNumber;
+  // Number of witnesses (u8)
+  witnessesCount: BigNumber;
+  // Merkle root of receipts (b256)
+  receiptsRoot: string;
+  // Script to execute (byte[])
+  script: string;
+  // Script input data (parameters) (byte[])
+  scriptData: string;
+  // List of inputs (Input[])
+  inputs: Input[];
+  // List of outputs (Output[])
+  outputs: Output[];
+  // List of witnesses (Witness[])
+  witnesses: Witness[];
+};
+
+export class TransactionScriptCoder extends Coder {
+  constructor(localName: string) {
+    super('TransactionScript', 'TransactionScript', localName);
+  }
+
+  encode(value: TransactionScript): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new NumberCoder('gasPrice', 'u64').encode(value.gasPrice));
+    parts.push(new NumberCoder('gasLimit', 'u64').encode(value.gasLimit));
+    parts.push(new NumberCoder('maturity', 'u32').encode(value.maturity));
+    parts.push(new NumberCoder('scriptLength', 'u16').encode(value.scriptLength));
+    parts.push(new NumberCoder('scriptDataLength', 'u16').encode(value.scriptDataLength));
+    parts.push(new NumberCoder('inputsCount', 'u8').encode(value.inputsCount));
+    parts.push(new NumberCoder('outputsCount', 'u8').encode(value.outputsCount));
+    parts.push(new NumberCoder('witnessesCount', 'u8').encode(value.witnessesCount));
+    parts.push(new B256Coder('receiptsRoot', 'b256').encode(value.receiptsRoot));
+    parts.push(arrayify(value.script));
+    parts.push(arrayify(value.scriptData));
+    parts.push(
+      new ArrayCoder(new InputCoder('input'), value.inputsCount.toNumber(), 'inputs').encode(
+        value.inputs
+      )
+    );
+    parts.push(
+      new ArrayCoder(new OutputCoder('output'), value.outputsCount.toNumber(), 'outputs').encode(
+        value.outputs
+      )
+    );
+    parts.push(
+      new ArrayCoder(
+        new WitnessCoder('witness'),
+        value.witnessesCount.toNumber(),
+        'witnesses'
+      ).encode(value.witnesses)
+    );
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [TransactionScript, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new NumberCoder('gasPrice', 'u64').decode(data, o);
+    const gasPrice = decoded;
+    [decoded, o] = new NumberCoder('gasLimit', 'u64').decode(data, o);
+    const gasLimit = decoded;
+    [decoded, o] = new NumberCoder('maturity', 'u32').decode(data, o);
+    const maturity = decoded;
+    [decoded, o] = new NumberCoder('scriptLength', 'u16').decode(data, o);
+    const scriptLength = decoded;
+    [decoded, o] = new NumberCoder('scriptDataLength', 'u16').decode(data, o);
+    const scriptDataLength = decoded;
+    [decoded, o] = new NumberCoder('inputsCount', 'u8').decode(data, o);
+    const inputsCount = decoded;
+    [decoded, o] = new NumberCoder('outputsCount', 'u8').decode(data, o);
+    const outputsCount = decoded;
+    [decoded, o] = new NumberCoder('witnessesCount', 'u8').decode(data, o);
+    const witnessesCount = decoded;
+    [decoded, o] = new B256Coder('receiptsRoot', 'b256').decode(data, o);
+    const receiptsRoot = decoded;
+    [decoded, o] = [hexlify(data.slice(o, scriptLength.toNumber())), o + scriptLength.toNumber()];
+    const script = decoded;
+    [decoded, o] = [
+      hexlify(data.slice(o, scriptDataLength.toNumber())),
+      o + scriptDataLength.toNumber(),
+    ];
+    const scriptData = decoded;
+    [decoded, o] = new ArrayCoder(new InputCoder('input'), inputsCount.toNumber(), 'inputs').decode(
+      data,
+      o
+    );
+    const inputs = decoded;
+    [decoded, o] = new ArrayCoder(
+      new OutputCoder('output'),
+      outputsCount.toNumber(),
+      'outputs'
+    ).decode(data, o);
+    const outputs = decoded;
+    [decoded, o] = new ArrayCoder(
+      new WitnessCoder('witness'),
+      witnessesCount.toNumber(),
+      'witnesses'
+    ).decode(data, o);
+    const witnesses = decoded;
+
+    return [
+      {
+        gasPrice,
+        gasLimit,
+        maturity,
+        scriptLength,
+        scriptDataLength,
+        inputsCount,
+        outputsCount,
+        witnessesCount,
+        receiptsRoot,
+        script,
+        scriptData,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        inputs,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        outputs,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        witnesses,
+      },
+      o,
+    ];
+  }
+}
+
+type TransactionCreate = {
+  // Gas price for transaction (u64)
+  gasPrice: BigNumber;
+  // Gas limit for transaction (u64)
+  gasLimit: BigNumber;
+  // Block until which tx cannot be included (u32)
+  maturity: BigNumber;
+  // Contract bytecode length, in instructions (u16)
+  bytecodeLength: BigNumber;
+  // Witness index of contract bytecode to create (u8)
+  bytecodeWitnessIndex: BigNumber;
+  // Number of static contracts (u8)
+  staticContractsCount: BigNumber;
+  // Number of inputs (u8)
+  inputsCount: BigNumber;
+  // Number of outputs (u8)
+  outputsCount: BigNumber;
+  // Number of witnesses (u8)
+  witnessesCount: BigNumber;
+  // Salt (b256)
+  salt: string;
+  // List of static contracts (b256[])
+  staticContracts: string[];
+  // List of inputs (Input[])
+  inputs: Input[];
+  // List of outputs (Output[])
+  outputs: Output[];
+  // List of witnesses (Witness[])
+  witnesses: Witness[];
+};
+
+export class TransactionCreateCoder extends Coder {
+  constructor(localName: string) {
+    super('TransactionCreate', 'TransactionCreate', localName);
+  }
+
+  encode(value: TransactionCreate): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new NumberCoder('gasPrice', 'u64').encode(value.gasPrice));
+    parts.push(new NumberCoder('gasLimit', 'u64').encode(value.gasLimit));
+    parts.push(new NumberCoder('maturity', 'u32').encode(value.maturity));
+    parts.push(new NumberCoder('bytecodeLength', 'u16').encode(value.bytecodeLength));
+    parts.push(new NumberCoder('bytecodeWitnessIndex', 'u8').encode(value.bytecodeLength));
+    parts.push(new NumberCoder('staticContractsCount', 'u8').encode(value.staticContractsCount));
+    parts.push(new NumberCoder('inputsCount', 'u8').encode(value.inputsCount));
+    parts.push(new NumberCoder('outputsCount', 'u8').encode(value.outputsCount));
+    parts.push(new NumberCoder('witnessesCount', 'u8').encode(value.witnessesCount));
+    parts.push(new B256Coder('salt', 'b256').encode(value.salt));
+    parts.push(
+      new ArrayCoder(
+        new B256Coder('staticContract', 'b256'),
+        value.staticContractsCount.toNumber(),
+        'staticContracts'
+      ).encode(value.staticContracts)
+    );
+    parts.push(
+      new ArrayCoder(new InputCoder('input'), value.inputsCount.toNumber(), 'inputs').encode(
+        value.inputs
+      )
+    );
+    parts.push(
+      new ArrayCoder(new OutputCoder('output'), value.outputsCount.toNumber(), 'outputs').encode(
+        value.outputs
+      )
+    );
+    parts.push(
+      new ArrayCoder(
+        new WitnessCoder('witness'),
+        value.witnessesCount.toNumber(),
+        'witnesses'
+      ).encode(value.witnesses)
+    );
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [TransactionCreate, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new NumberCoder('gasPrice', 'u64').decode(data, o);
+    const gasPrice = decoded;
+    [decoded, o] = new NumberCoder('gasLimit', 'u64').decode(data, o);
+    const gasLimit = decoded;
+    [decoded, o] = new NumberCoder('maturity', 'u32').decode(data, o);
+    const maturity = decoded;
+    [decoded, o] = new NumberCoder('bytecodeLength', 'u16').decode(data, o);
+    const bytecodeLength = decoded;
+    [decoded, o] = new NumberCoder('bytecodeWitnessIndex', 'u8').decode(data, o);
+    const bytecodeWitnessIndex = decoded;
+    [decoded, o] = new NumberCoder('staticContractsCount', 'u8').decode(data, o);
+    const staticContractsCount = decoded;
+    [decoded, o] = new NumberCoder('inputsCount', 'u8').decode(data, o);
+    const inputsCount = decoded;
+    [decoded, o] = new NumberCoder('outputsCount', 'u8').decode(data, o);
+    const outputsCount = decoded;
+    [decoded, o] = new NumberCoder('witnessesCount', 'u8').decode(data, o);
+    const witnessesCount = decoded;
+    [decoded, o] = new B256Coder('salt', 'b256').decode(data, o);
+    const salt = decoded;
+    [decoded, o] = new ArrayCoder(
+      new B256Coder('staticContract', 'b256'),
+      staticContractsCount.toNumber(),
+      'staticContracts'
+    ).decode(data, o);
+    const staticContracts = decoded;
+    [decoded, o] = new ArrayCoder(new InputCoder('input'), inputsCount.toNumber(), 'inputs').decode(
+      data,
+      o
+    );
+    const inputs = decoded;
+    [decoded, o] = new ArrayCoder(
+      new OutputCoder('output'),
+      outputsCount.toNumber(),
+      'outputs'
+    ).decode(data, o);
+    const outputs = decoded;
+    [decoded, o] = new ArrayCoder(
+      new WitnessCoder('witness'),
+      witnessesCount.toNumber(),
+      'witnesses'
+    ).decode(data, o);
+    const witnesses = decoded;
+
+    return [
+      {
+        gasPrice,
+        gasLimit,
+        maturity,
+        bytecodeLength,
+        bytecodeWitnessIndex,
+        staticContractsCount,
+        inputsCount,
+        outputsCount,
+        witnessesCount,
+        salt,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignores
+        staticContracts,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        inputs,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        outputs,
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        witnesses,
+      },
+      o,
+    ];
+  }
+}

--- a/packages/transactions/witness.test.ts
+++ b/packages/transactions/witness.test.ts
@@ -1,0 +1,23 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { arrayify, hexlify } from '@ethersproject/bytes';
+import { expect } from 'chai';
+
+import { Witness, WitnessCoder } from './witness';
+
+describe('WitnessCoder', () => {
+  it('Can encode Witness', () => {
+    const witness: Witness = {
+      dataLength: BigNumber.from(0),
+      data: '0x',
+    };
+
+    const encoded = hexlify(new WitnessCoder('witness').encode(witness));
+
+    expect(encoded).to.equal('0x0000000000000000');
+
+    const [decoded, offset] = new WitnessCoder('witness').decode(arrayify(encoded), 0);
+
+    expect(offset).to.equal((encoded.length - 2) / 2);
+    expect(decoded).to.deep.equal(witness);
+  });
+});

--- a/packages/transactions/witness.ts
+++ b/packages/transactions/witness.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { BigNumber } from '@ethersproject/bignumber';
+import { arrayify, concat, hexlify } from '@ethersproject/bytes';
+import Coder from '../abi-coder/coders/abstract-coder';
+import NumberCoder from '../abi-coder/coders/number';
+
+export type Witness = {
+  // Length of witness data, in bytes (u16)
+  dataLength: BigNumber;
+  // Witness data (byte[])
+  data: string;
+};
+
+export class WitnessCoder extends Coder {
+  constructor(localName: string) {
+    super('Witness', 'Witness', localName);
+  }
+
+  encode(value: Witness): Uint8Array {
+    const parts: Uint8Array[] = [];
+
+    parts.push(new NumberCoder('dataLength', 'u16').encode(value.dataLength));
+    parts.push(arrayify(value.data));
+
+    return concat(parts);
+  }
+
+  decode(data: Uint8Array, offset: number): [Witness, number] {
+    let decoded;
+    let o = offset;
+
+    [decoded, o] = new NumberCoder('dataLength', 'u16').decode(data, o);
+    const dataLength = decoded;
+    [decoded, o] = [hexlify(data.slice(o, dataLength.toNumber())), o + dataLength.toNumber()];
+    const witnessData = decoded;
+
+    return [
+      {
+        dataLength,
+        data: witnessData,
+      },
+      o,
+    ];
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,13 @@
     "lib": ["es2019"]
   },
   "exclude": ["dist", "node_modules"],
-  "include": ["./scripts", "./packages/protocol", "test", "./typechain", "packages/abi-coder", "packages/contract"]
+  "include": [
+    "./scripts",
+    "./packages/protocol",
+    "test",
+    "./typechain",
+    "packages/abi-coder",
+    "packages/contract",
+    "packages/transactions"
+  ]
 }


### PR DESCRIPTION
This PR adds a new package called "transactions" that contains all types defined in [tx_format.md](https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md) and coders for them.

A few notes:
- Encoding is memory intensive since all parts are kept in memory before concatenation.
- Code is a bit ugly because I didn't want to commit to an abstraction at this time. Can be cleaned up later.
- Tests cover 98% of the code but they aren't that great. They can be improved as we actually start using the code.

Resolves #15 