### PR TITLE
Rename packages for public publishing

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,6 @@
 **/coverage/
 **/dist/
 /packages/example-contract/src/MyContract-types/
-/packages/example-contract/scripts/typechain-target.js
 /packages/providers/src/operations.ts
 /packages/typechain-target-fuels/static/
 /packages/typechain-target-fuels/example/

--- a/.github/workflows/publish-npm-master.yaml
+++ b/.github/workflows/publish-npm-master.yaml
@@ -1,4 +1,4 @@
-# This workflow publishes packages to NPM tag `master` when Git branch `master` is pushed.
+# This workflow publishes packages to NPM tag `master` when specified Git branches are pushed.
 #
 # Packages published by this workflow:
 # - are meant to be used for testing and experimentation
@@ -11,9 +11,11 @@ on:
     branches:
       - master
 name: "Publish to NPM Tag `master`"
+env:
+  NPM_TAG: master
 jobs:
   publish:
-    name: "Publish to NPM Tag `${{ github.ref_name }}`"
+    name: "Publish to NPM"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -40,6 +42,6 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
           npx lerna version "0.0.0-${{ github.ref_name }}-$(git rev-parse --short $GITHUB_SHA)" --no-push --exact --yes
-          npx lerna publish --dist-tag "${{ github.ref_name }}" from-package --no-verify-access --yes
+          npx lerna publish --dist-tag "${{ env.NPM_TAG }}" from-package --no-verify-access --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2038,10 +2038,6 @@
       "resolved": "packages/example-contract",
       "link": true
     },
-    "node_modules/@fuel-ts/fuels": {
-      "resolved": "packages/fuels",
-      "link": true
-    },
     "node_modules/@fuel-ts/merkle": {
       "resolved": "packages/merkle",
       "link": true
@@ -2064,10 +2060,6 @@
     },
     "node_modules/@fuel-ts/transactions": {
       "resolved": "packages/transactions",
-      "link": true
-    },
-    "node_modules/@fuel-ts/typechain-target-fuels": {
-      "resolved": "packages/typechain-target-fuels",
       "link": true
     },
     "node_modules/@fuel-ts/wallet": {
@@ -9121,6 +9113,10 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/fuels": {
+      "resolved": "packages/fuels",
+      "link": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -16381,6 +16377,10 @@
         "typechain": "dist/cli/cli.js"
       }
     },
+    "node_modules/typechain-target-fuels": {
+      "resolved": "packages/typechain-target-fuels",
+      "link": true
+    },
     "node_modules/typechain/node_modules/ts-essentials": {
       "version": "7.0.3",
       "dev": true,
@@ -17294,12 +17294,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/bytes": "^5.5.0",
-        "@fuel-ts/fuels": "^0.0.1"
+        "fuels": "^0.0.1"
       },
       "devDependencies": {
-        "@fuel-ts/typechain-target-fuels": "^0.0.1",
         "prettier": "^2.4.1",
-        "typechain": "^6.0.2"
+        "typechain": "^6.0.2",
+        "typechain-target-fuels": "^0.0.1"
       }
     },
     "packages/example-contract/node_modules/mkdirp": {
@@ -17345,7 +17345,6 @@
       }
     },
     "packages/fuels": {
-      "name": "@fuel-ts/fuels",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17655,7 +17654,6 @@
       "license": "MIT"
     },
     "packages/typechain-target-fuels": {
-      "name": "@fuel-ts/typechain-target-fuels",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -19017,10 +19015,10 @@
       "version": "file:packages/example-contract",
       "requires": {
         "@ethersproject/bytes": "^5.5.0",
-        "@fuel-ts/fuels": "^0.0.1",
-        "@fuel-ts/typechain-target-fuels": "^0.0.1",
+        "fuels": "^0.0.1",
         "prettier": "^2.4.1",
-        "typechain": "^6.0.2"
+        "typechain": "^6.0.2",
+        "typechain-target-fuels": "^0.0.1"
       },
       "dependencies": {
         "mkdirp": {
@@ -19048,16 +19046,6 @@
             "ts-essentials": "^7.0.1"
           }
         }
-      }
-    },
-    "@fuel-ts/fuels": {
-      "version": "file:packages/fuels",
-      "requires": {
-        "@fuel-ts/abi-coder": "^0.0.1",
-        "@fuel-ts/contract": "^0.0.1",
-        "@fuel-ts/providers": "^0.0.1",
-        "@fuel-ts/transactions": "^0.0.1",
-        "@fuel-ts/wallet": "^0.0.1"
       }
     },
     "@fuel-ts/merkle": {
@@ -19215,36 +19203,6 @@
         },
         "@ethersproject/logger": {
           "version": "5.5.0"
-        }
-      }
-    },
-    "@fuel-ts/typechain-target-fuels": {
-      "version": "file:packages/typechain-target-fuels",
-      "requires": {
-        "typechain": "^6.0.2"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4"
-        },
-        "ts-essentials": {
-          "version": "7.0.3",
-          "requires": {}
-        },
-        "typechain": {
-          "version": "6.0.2",
-          "requires": {
-            "@types/prettier": "^2.1.1",
-            "command-line-args": "^4.0.7",
-            "debug": "^4.1.1",
-            "fs-extra": "^7.0.0",
-            "glob": "^7.1.6",
-            "js-sha3": "^0.8.0",
-            "lodash": "^4.17.15",
-            "mkdirp": "^1.0.4",
-            "prettier": "^2.1.2",
-            "ts-essentials": "^7.0.1"
-          }
         }
       }
     },
@@ -24265,6 +24223,16 @@
       "dev": true,
       "optional": true
     },
+    "fuels": {
+      "version": "file:packages/fuels",
+      "requires": {
+        "@fuel-ts/abi-coder": "^0.0.1",
+        "@fuel-ts/contract": "^0.0.1",
+        "@fuel-ts/providers": "^0.0.1",
+        "@fuel-ts/transactions": "^0.0.1",
+        "@fuel-ts/wallet": "^0.0.1"
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "dev": true
@@ -29246,6 +29214,36 @@
           "version": "7.0.3",
           "dev": true,
           "requires": {}
+        }
+      }
+    },
+    "typechain-target-fuels": {
+      "version": "file:packages/typechain-target-fuels",
+      "requires": {
+        "typechain": "^6.0.2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4"
+        },
+        "ts-essentials": {
+          "version": "7.0.3",
+          "requires": {}
+        },
+        "typechain": {
+          "version": "6.0.2",
+          "requires": {
+            "@types/prettier": "^2.1.1",
+            "command-line-args": "^4.0.7",
+            "debug": "^4.1.1",
+            "fs-extra": "^7.0.0",
+            "glob": "^7.1.6",
+            "js-sha3": "^0.8.0",
+            "lodash": "^4.17.15",
+            "mkdirp": "^1.0.4",
+            "prettier": "^2.1.2",
+            "ts-essentials": "^7.0.1"
+          }
         }
       }
     },

--- a/packages/example-contract/package.json
+++ b/packages/example-contract/package.json
@@ -9,10 +9,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ethersproject/bytes": "^5.5.0",
-    "@fuel-ts/fuels": "^0.0.1"
+    "fuels": "^0.0.1"
   },
   "devDependencies": {
-    "@fuel-ts/typechain-target-fuels": "^0.0.1",
+    "typechain-target-fuels": "^0.0.1",
     "prettier": "^2.4.1",
     "typechain": "^6.0.2"
   }

--- a/packages/example-contract/scripts/build.sh
+++ b/packages/example-contract/scripts/build.sh
@@ -2,5 +2,5 @@
 
 # forc build -o src/MyContract.bin
 # forc json-abi | npx prettier --parser json | jq 'del(.[].inputs[0], .[].inputs[1], .[].inputs[2])' > src/MyContract.json
-npx typechain --target=scripts/typechain-target.js --out-dir=src/MyContract-types src/MyContract.json
+npx typechain --target=fuels --out-dir=src/MyContract-types src/MyContract.json
 # forc parse-bytecode src/MyContract.bin > src/MyContract.txt

--- a/packages/example-contract/src/MyContract.test.ts
+++ b/packages/example-contract/src/MyContract.test.ts
@@ -1,6 +1,6 @@
 import { hexlify } from '@ethersproject/bytes';
-import { Provider } from '@fuel-ts/fuels';
 import fs from 'fs';
+import { Provider } from 'fuels';
 import path from 'path';
 
 import { MyContract__factory } from './MyContract-types';

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fuel-ts/fuels",
+  "name": "fuels",
   "version": "0.0.1",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.sh/)",

--- a/packages/typechain-target-fuels/package.json
+++ b/packages/typechain-target-fuels/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fuel-ts/typechain-target-fuels",
+  "name": "typechain-target-fuels",
   "version": "0.0.1",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.sh/)",


### PR DESCRIPTION
We had to use scoped names for `fuels` and `typechain-target-fuels` (`@fuel-ts/fuels` and `@fuel-ts/typechain-target-fuels`) so we could publish them privately. We are now going public so I renamed the packages to their intended names.

I have invited @QuinnLee and `fuel-ci` as owners of the unscoped packages.