### PR TITLE
feat: zero out output fields on hashTransaction

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -15,9 +15,11 @@
     "@fuel-ts/providers": "^0.0.1",
     "@fuel-ts/testcases": "^0.0.1",
     "@fuel-ts/transactions": "^0.0.1",
-    "elliptic": "^6.5.4"
+    "elliptic": "^6.5.4",
+    "lodash.clonedeep": "^4.5.0"
   },
   "devDependencies": {
-    "@types/elliptic": "^6.4.14"
+    "@types/elliptic": "^6.4.14",
+    "@types/lodash.clonedeep": "^4.5.6"
   }
 }


### PR DESCRIPTION
# Summary

- Set to zero on `hashTransaction` the defined `outputs`.
- Add `lodash.deepClone` to remove reference from `transactionRequest` param.