### PR TITLE
feat: add sendTransaction

### DIFF
--- a/packages/testcases/src/sendTransaction.json
+++ b/packages/testcases/src/sendTransaction.json
@@ -1,0 +1,41 @@
+{
+  "transaction": {
+    "type": 0,
+    "gasPrice": "0x00",
+    "gasLimit": "0x0F4240",
+    "script": "0x24400000",
+    "scriptData": "0x",
+    "inputs": [
+      {
+        "type": 0,
+        "id": "0x000000000000000000000000000000000000000000000000000000000000000000",
+        "color": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "amount": "0x01",
+        "owner": "0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e",
+        "maturity": 0,
+        "witnessIndex": 0,
+        "predicate": "0x",
+        "predicateData": "0x"
+      }
+    ],
+    "outputs": [
+      {
+        "type": 0,
+        "to": "0xc7862855b418ba8f58878db434b21053a61a2025209889cc115989e8040ff077",
+        "color": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "amount": "0x01"
+      }
+    ],
+    "witnesses": []
+  },
+  "privateKey": "0x5f70feeff1f229e4a95e1056e8b4d80d0b24b565674860cc213bdb07127ce1b1",
+  "publicKey": "0x2f34bc0df4db0ec391792cedb05768832b49b1aa3a2dd8c30054d1af00f67d00b74b7acbbf3087c8e0b1a4c343db50aa471d21f278ff5ce09f07795d541fb47e",
+  "address": "0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e",
+  "hashedTransaction": "0x1181ada1d07028b76e241502fd64107e6305a2010f86442de16dafd397fe755d",
+  "signedTransaction": "0xa3f3174d5c75352e2e762530c59a7486a06f4f23940667d1e099f90f8bd374684e9925e5e4fbbe04afad8eb42cc282de3ad97c9014019d644cb975c108a94206",
+  "getCoins": {
+    "color": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "amount": 1,
+    "owner": "0xc7862855b418ba8f58878db434b21053a61a2025209889cc115989e8040ff077"
+  }
+}

--- a/packages/wallet/src/wallet.test.ts
+++ b/packages/wallet/src/wallet.test.ts
@@ -1,10 +1,15 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { hexlify } from '@ethersproject/bytes';
 import type { ScriptTransactionRequest } from '@fuel-ts/providers';
+import sendTransactionTest from '@fuel-ts/testcases/src/sendTransaction.json';
 import signMessageTest from '@fuel-ts/testcases/src/signMessage.json';
 import signTransactionTest from '@fuel-ts/testcases/src/signTransaction.json';
 
 import { hashMessage, hashTransaction } from './hasher';
 import Signer from './signer';
 import Wallet from './wallet';
+
+const genBytes32 = () => hexlify(new Uint8Array(32).map(() => Math.floor(Math.random() * 256)));
 
 describe('Wallet', () => {
   it('Instantiate a new wallet', async () => {
@@ -37,5 +42,52 @@ describe('Wallet', () => {
 
     expect(signedTransaction).toEqual(signTransactionTest.signedTransaction);
     expect(verifiedAddress).toEqual(wallet.address);
+  });
+
+  it('Populate transaction witenesses signature using wallet instance', async () => {
+    const wallet = new Wallet(signTransactionTest.privateKey);
+    const transactionRequest: ScriptTransactionRequest = signTransactionTest.transaction;
+    const signedTransaction = wallet.signTransaction(transactionRequest);
+    const populatedTransaction = wallet.populateTransactionWitnessesSignature(transactionRequest);
+
+    expect(populatedTransaction.witnesses?.[0]).toBe(signedTransaction);
+  });
+
+  it('Populate transaction multi-witenesses signature using wallet instance', async () => {
+    const wallet = new Wallet(signTransactionTest.privateKey);
+    const privateKey = genBytes32();
+    const otherWallet = new Wallet(privateKey);
+    const transactionRequest: ScriptTransactionRequest = signTransactionTest.transaction;
+    const signedTransaction = wallet.signTransaction(transactionRequest);
+    const otherSignedTransaction = otherWallet.signTransaction(transactionRequest);
+    const populatedTransaction = wallet.populateTransactionWitnessesSignature({
+      ...transactionRequest,
+      witnesses: [otherSignedTransaction],
+    });
+
+    expect(populatedTransaction.witnesses?.length).toBe(2);
+    expect(populatedTransaction.witnesses).toContain(signedTransaction);
+    expect(populatedTransaction.witnesses).toContain(otherSignedTransaction);
+  });
+
+  it('Send transaction with signature using wallet instance', async () => {
+    const wallet = new Wallet(signTransactionTest.privateKey);
+    const { owner, color } = sendTransactionTest.getCoins;
+    const transactionRequest: ScriptTransactionRequest = {
+      ...sendTransactionTest.transaction,
+      scriptData: genBytes32(),
+    };
+    const transactionResponse = await wallet.sendTransaction(transactionRequest);
+
+    // Wait transaction to end
+    await transactionResponse.wait();
+    const toCoins = await wallet.provider.getCoins(owner, color);
+
+    expect(toCoins[0]).toEqual(
+      expect.objectContaining({
+        ...sendTransactionTest.getCoins,
+        amount: BigNumber.from(sendTransactionTest.getCoins.amount),
+      })
+    );
   });
 });


### PR DESCRIPTION
# Summary

- Add `sendTransaction` on Wallet;
- Add `Provider` instance on Wallet;
- Add simple provider configuration on Wallet by enabling URL as a valid provider param;
- Add `senTransaction.json` object on `@fuel-ts/testcases`;
- Zero out `witnessesCount` before hashing/signing transaction;
- Populate signature on  `sendTransaction`.

# Notes

- On `witnessesCount` should be zeroed?
- `ZERO_B256` and `genBytes32`  could be used across packages. Maybe create a package `@fuel-ts/helpers`?
- `FUEL_NETWORK_URL` could be injected using `.env` or another strategy across packages.
