### PR TITLE
Provider configuration on `Wallet.generate`

### DIFF
--- a/packages/wallet/src/types/GenerateOptions.ts
+++ b/packages/wallet/src/types/GenerateOptions.ts
@@ -1,6 +1,8 @@
 import type { BytesLike } from '@ethersproject/bytes';
+import type { Provider } from '@fuel-ts/providers';
 
 export interface GenerateOptions {
   /** Additional entropy for the random bytes */
   entropy?: BytesLike;
+  provider?: string | Provider;
 }

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -99,6 +99,6 @@ export default class Wallet {
    */
   static generate(generateOptions?: GenerateOptions) {
     const privateKey = Signer.generatePrivateKey(generateOptions?.entropy);
-    return new Wallet(privateKey);
+    return new Wallet(privateKey, generateOptions?.provider);
   }
 }


### PR DESCRIPTION
## Summary

- Enable to pass provider config on `Wallet.generate(options)`.