### PR TITLE
change author to authors in Forc.toml files

### DIFF
--- a/packages/contract/src/test-contract/Forc.toml
+++ b/packages/contract/src/test-contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Rodrigo Araujo"
+authors = ["Rodrigo Araujo"]
 license = "MIT"
 name = "test-contract"
 entry = "main.sw"

--- a/packages/contract/src/test-contract/lib-core/Forc.toml
+++ b/packages/contract/src/test-contract/lib-core/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Alexander Hansen"
+authors = ["Alexander Hansen"]
 license = "MIT"
 name = "core"
 entry = "lib.sw"

--- a/packages/contract/src/test-contract/lib-std/Forc.toml
+++ b/packages/contract/src/test-contract/lib-std/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Alex Hansen"
+authors = ["Alex Hansen"]
 license = "MIT"
 name = "lib-std"
 entry = "lib.sw"

--- a/packages/example-contract/Forc.toml
+++ b/packages/example-contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author = "Alex Hansen"
+authors = ["Alex Hansen"]
 license = "MIT"
 name = "Fuel example project"
 

--- a/packages/example-contract/lib-core/Forc.toml
+++ b/packages/example-contract/lib-core/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Alexander Hansen"
+authors = ["Alexander Hansen"]
 license = "MIT"
 name = "core"
 entry = "lib.sw"

--- a/packages/example-contract/lib-std/Forc.toml
+++ b/packages/example-contract/lib-std/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Alex Hansen"
+authors = ["Alex Hansen"]
 license = "MIT"
 name = "lib-std"
 entry = "lib.sw"

--- a/packages/providers/src/test-contract/Forc.toml
+++ b/packages/providers/src/test-contract/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Rodrigo Araujo"
+authors = ["Rodrigo Araujo"]
 license = "MIT"
 name = "test-contract"
 entry = "main.sw"

--- a/packages/providers/src/test-contract/lib-core/Forc.toml
+++ b/packages/providers/src/test-contract/lib-core/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Alexander Hansen"
+authors = ["Alexander Hansen"]
 license = "MIT"
 name = "core"
 entry = "lib.sw"

--- a/packages/providers/src/test-contract/lib-std/Forc.toml
+++ b/packages/providers/src/test-contract/lib-std/Forc.toml
@@ -1,5 +1,5 @@
 [project]
-author  = "Alex Hansen"
+authors = ["Alex Hansen"]
 license = "MIT"
 name = "lib-std"
 entry = "lib.sw"


### PR DESCRIPTION
Updating 'Forc.toml' files to use `authors` instead of `author`. This enables compatibility with the change being made in this PR https://github.com/FuelLabs/sway/pull/822