### PR TITLE
chore: change docs link to point to docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Table of contents
 
-- [SDK documentation](./docs/packages)
+- [SDK documentation](https://fuellabs.github.io/fuels-ts/)
 - [Features](#features)
 - [Usage](#usage)
   - [Installation](#installation)


### PR DESCRIPTION
## Summary

- Change link from point to readme folder to docs pages.