### PR TITLE
fix: Throttle npm whoami

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -34,7 +34,7 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
-    "@semantic-release/npm",
+    "@semrel-extra/npm",
     [
       "@semantic-release/git",
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^8.0.2",
+        "@semrel-extra/npm": "^1.2.0",
         "@typechain/ethers-v5": "^6.0.5",
         "@types/jest": "^27.0.3",
         "@types/node": "^14",
@@ -8573,6 +8574,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@semrel-extra/npm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@semrel-extra/npm/-/npm-1.2.0.tgz",
+      "integrity": "sha512-l5hBMofOUuAfytK3ILEldRO5bdX4dJOfO8aaYyUqON+EcFlKMke7bPWGJjB/bqi1FGTEfESfAsn8zXsVp+G7Zg==",
+      "dev": true
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -32179,6 +32186,12 @@
           "peer": true
         }
       }
+    },
+    "@semrel-extra/npm": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@semrel-extra/npm/-/npm-1.2.0.tgz",
+      "integrity": "sha512-l5hBMofOUuAfytK3ILEldRO5bdX4dJOfO8aaYyUqON+EcFlKMke7bPWGJjB/bqi1FGTEfESfAsn8zXsVp+G7Zg==",
+      "dev": true
     },
     "@sindresorhus/is": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^8.0.2",
+    "@semrel-extra/npm": "^1.2.0",
     "@typechain/ethers-v5": "^6.0.5",
     "@types/jest": "^27.0.3",
     "@types/node": "^14",


### PR DESCRIPTION

99% sure the token is valid, but we're getting `EINVALIDNPMTOKEN`

This seems to be the recommending fix


> When releasing a monorepos you may get EINVALIDNPMTOKEN error. The more packages, the more chance of error, unfortunately.


https://github.com/dhoulb/multi-semantic-release#npm-invalid-npm-token