### PR TITLE
Fix encoding of B256s with leading zero bytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-fix": "eslint . --ext .ts --fix",
     "prettier-format": "prettier --write packages",
     "run-services": "docker compose up",
-    "fix-ts-references": "npx @monorepo-utils/workspaces-to-typescript-project-references",
+    "fix-ts-references": "npx @monorepo-utils/workspaces-to-typescript-project-references && prettier --write packages/*/tsconfig.json",
     "docs": "typedoc"
   },
   "repository": {

--- a/packages/abi-coder/src/coder.test.ts
+++ b/packages/abi-coder/src/coder.test.ts
@@ -47,11 +47,16 @@ describe('AbiCoder', () => {
       ['0x0000000000000000000000000000000000000000000000000000000000000000']
     );
     expect(encoded).toEqual('0x0000000000000000000000000000000000000000000000000000000000000000');
-    encoded = abiCoder.encode(['b256'], ['0x0']);
-    expect(encoded).toEqual('0x0000000000000000000000000000000000000000000000000000000000000000');
+  });
 
-    decoded = abiCoder.decode(['b256'], encoded);
-    expect(decoded).toEqual(['0x0000000000000000000000000000000000000000000000000000000000000000']);
+  it('encodes and decodes b256 starting with zero', () => {
+    const encoded = abiCoder.encode(
+      ['b256'],
+      ['0x00579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b']
+    );
+    expect(encoded).toEqual('0x00579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b');
+    const decoded = abiCoder.decode(['b256'], encoded);
+    expect(decoded).toEqual(['0x00579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b']);
   });
 
   it('encodes and decodes byte', () => {
@@ -235,5 +240,7 @@ describe('AbiCoder', () => {
     }).toThrow('cannot encode object for signature with duplicate name');
 
     expect(() => abiCoder.encode(['b256'], ['0x'])).toThrow('Invalid b256');
+    expect(() => abiCoder.encode(['b256'], ['0x0'])).toThrow('Invalid b256');
+    expect(() => abiCoder.encode(['b256'], ['0x00'])).toThrow('Invalid b256');
   });
 });

--- a/packages/abi-coder/src/coders/b256.ts
+++ b/packages/abi-coder/src/coders/b256.ts
@@ -14,8 +14,7 @@ export default class B256Coder extends Coder {
   encode(value: string): Uint8Array {
     let encodedValue = new Uint8Array(32);
     try {
-      const numericValue = BN.from(value);
-      encodedValue = numericValue.isZero() ? encodedValue : arrayify(numericValue);
+      encodedValue = arrayify(value);
     } catch (error) {
       this.throwError(`Invalid ${this.type}`, value);
     }

--- a/packages/hdwallet/tsconfig.json
+++ b/packages/hdwallet/tsconfig.json
@@ -9,6 +9,9 @@
   "references": [
     {
       "path": "../mnemonic"
+    },
+    {
+      "path": "../signer"
     }
   ]
 }

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -9,13 +9,13 @@
   "include": ["src", "src/*.json"],
   "references": [
     {
+      "path": "../hasher"
+    },
+    {
       "path": "../providers"
     },
     {
       "path": "../signer"
-    },
-    {
-      "path": "../hasher"
     }
   ]
 }


### PR DESCRIPTION
Turns out the previous "B256 with all zero bytes" issue we fixed was actually a "B256 with leading zero bytes" issue.

With this PR, the bug is fixed and encoder only accepts exactly 32 bytes. So `0x0`, `0x00` and such are invalid now which should be safer.