### PR TITLE
fix: change postinstall to prepare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25573,7 +25573,6 @@
     "packages/providers": {
       "name": "@fuel-ts/providers",
       "version": "0.3.0",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/bignumber": "^5.4.2",

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "postinstall": "npm run build-operations",
+    "prepare": "npm run build-operations",
     "update-schema": "get-graphql-schema http://localhost:4000/graphql > fuel-core-schema.graphql && prettier --write fuel-core-schema.graphql",
     "build-operations": "graphql-codegen",
     "build-test-contract": "forc build -p src/test-contract -o src/test-contract/out.bin --print-finalized-asm"


### PR DESCRIPTION
## Summary

- When installing the packages from npm, it runs `post/pre install` scripts. It's preferable to use ' prepare' for scripts that should run only on development env.