### PR TITLE
fix: remove empty params from types

### DIFF
--- a/packages/typechain-target-fuels/src/parser/abiParser.test.ts
+++ b/packages/typechain-target-fuels/src/parser/abiParser.test.ts
@@ -38,6 +38,17 @@ const ABI = [
     outputs: [],
     type: 'function',
   },
+  {
+    inputs: [
+      { name: 'gas', type: 'u64' },
+      { name: 'coins', type: 'u64' },
+      { name: 'asset_id', type: 'b256' },
+      { name: 'params', type: '()' },
+    ],
+    name: 'cancel',
+    outputs: [],
+    type: 'function',
+  },
 ];
 
 describe('ABI parser', () => {
@@ -168,6 +179,45 @@ describe('ABI parser', () => {
                   ],
                   originalType: 'tuple',
                   structName: 'Args',
+                },
+              },
+            ],
+            outputs: [
+              {
+                name: '',
+                type: {
+                  type: 'void',
+                },
+              },
+            ],
+          },
+        ],
+        cancel: [
+          {
+            name: 'cancel',
+            documentation: undefined,
+            inputs: [
+              {
+                name: 'gas',
+                type: {
+                  type: 'u64',
+                  bits: 64,
+                  originalType: 'u64',
+                },
+              },
+              {
+                name: 'coins',
+                type: {
+                  type: 'u64',
+                  bits: 64,
+                  originalType: 'u64',
+                },
+              },
+              {
+                name: 'asset_id',
+                type: {
+                  type: 'b256',
+                  originalType: 'b256',
                 },
               },
             ],

--- a/packages/typechain-target-fuels/src/parser/abiParser.ts
+++ b/packages/typechain-target-fuels/src/parser/abiParser.ts
@@ -79,7 +79,9 @@ function parseFunctionDeclaration(
 ): FunctionDeclaration {
   return {
     name: abiPiece.name,
-    inputs: abiPiece.inputs.map((e) => parseRawAbiParameter(e, registerStruct)),
+    inputs: abiPiece.inputs
+      .filter((i) => i.type !== '()')
+      .map((e) => parseRawAbiParameter(e, registerStruct)),
     outputs: parseOutputs(registerStruct, abiPiece.outputs),
     documentation: getFunctionDocumentation(abiPiece, documentation),
   };


### PR DESCRIPTION
### Summary

- When the contract has the declaration with empty param `()`. It creates a type declaration without the last param, which is not required.

Declaration;
```
fn deposit(gas_: u64, amount_: u64, asset_id_: b256, params: ()) {
```
Result;
```ts
encodeFunctionData(
  functionFragment: "deposit",
  values: [BigNumberish, BigNumberish, string]
): string;
```