### PR TITLE
chore: organize scripts

### DIFF
--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,4 +1,5 @@
 export * from './provider';
 export { default as Provider } from './provider';
 export * from './transaction-request';
+export * from './scripts';
 export * from './util';

--- a/packages/providers/src/provider.test.ts
+++ b/packages/providers/src/provider.test.ts
@@ -10,6 +10,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 import Provider from './provider';
+import { returnZeroScript } from './scripts';
 import contractABI from './test-contract/out/debug/test-contract-abi.json';
 import { getContractId } from './util';
 
@@ -136,8 +137,7 @@ describe('Provider', () => {
       gasPrice: BigNumber.from(0),
       gasLimit: BigNumber.from(1000000),
       bytePrice: BigNumber.from(0),
-      script: '0x24400000',
-      scriptData: '0x',
+      script: returnZeroScript.bytes,
       inputs: coins.map((coin) => ({
         type: InputType.Coin,
         ...coin,

--- a/packages/providers/src/script.ts
+++ b/packages/providers/src/script.ts
@@ -2,17 +2,27 @@
 import type { BytesLike } from '@ethersproject/bytes';
 import { arrayify } from '@ethersproject/bytes';
 
+import type { CallResult } from './provider';
+
 // TODO: Source these from other packages
 const VM_TX_MEMORY = 360;
 const TRANSACTION_SCRIPT_FIXED_SIZE = 112;
 const WORD_SIZE = 8;
 const CONTRACT_ID_LEN = 32;
 
-export class Script {
+export class Script<TScriptData = void, TScriptResult = void> {
   bytes: Uint8Array;
+  encodeScriptData: (data: TScriptData) => Uint8Array;
+  decodeScriptResult: (result: CallResult) => TScriptResult;
 
-  constructor(bytes: BytesLike) {
+  constructor(
+    bytes: BytesLike,
+    encodeScriptData: (data: TScriptData) => Uint8Array,
+    decodeScriptResult: (result: CallResult) => TScriptResult
+  ) {
     this.bytes = arrayify(bytes);
+    this.encodeScriptData = encodeScriptData;
+    this.decodeScriptResult = decodeScriptResult;
   }
 
   getScriptDataOffset() {

--- a/packages/providers/src/scripts.ts
+++ b/packages/providers/src/scripts.ts
@@ -1,0 +1,81 @@
+import type { BytesLike } from '@ethersproject/bytes';
+import { arrayify, concat } from '@ethersproject/bytes';
+import { NumberCoder } from '@fuel-ts/abi-coder';
+import { ReceiptType } from '@fuel-ts/transactions';
+
+import { Script } from './script';
+
+/**
+ * A script that calls contracts
+ *
+ * Accepts a contract ID and function data
+ * Returns function result
+ */
+export const contractCallScript = new Script<[contractId: BytesLike, data: BytesLike], Uint8Array>(
+  /*
+    Opcode::ADDI(0x10, REG_ZERO, script_data_offset)
+    Opcode::CALL(0x10, REG_ZERO, 0x10, REG_CGAS)
+    Opcode::RET(REG_RET)
+    Opcode::NOOP
+  */
+  '0x504001e82d40040a2434000047000000',
+  ([contractId, data]) => {
+    // Decode data in internal format
+    const dataArray = arrayify(data);
+    const functionSelector = dataArray.slice(0, 8);
+    const isStructArg = dataArray.slice(8, 16).some((b) => b === 0x01);
+    const arg = dataArray.slice(16);
+
+    // Encode data in script format
+    let scriptData;
+    if (isStructArg) {
+      scriptData = concat([
+        contractId,
+        functionSelector,
+        new NumberCoder('', 'u64').encode(contractCallScript.getArgOffset()),
+        arg,
+      ]);
+    } else {
+      scriptData = concat([contractId, functionSelector, arg]);
+    }
+
+    return scriptData;
+  },
+  (result) => {
+    if (result.receipts.length < 3) {
+      throw new Error('Expected at least 3 receipts');
+    }
+    const returnReceipt = result.receipts[result.receipts.length - 3];
+    switch (returnReceipt.type) {
+      case ReceiptType.Return: {
+        // The receipt doesn't have the expected encoding, so encode it manually
+        const returnValue = new NumberCoder('', 'u64').encode(returnReceipt.val);
+
+        return returnValue;
+      }
+      case ReceiptType.ReturnData: {
+        return arrayify(returnReceipt.data);
+      }
+      default: {
+        throw new Error('Invalid receipt type');
+      }
+    }
+  }
+);
+/**
+ * A script that just returns zero
+ *
+ * Accepts nothing
+ * Returns nothing
+ *
+ * Used for coin transfer transactions
+ */
+export const returnZeroScript = new Script(
+  /*
+    Opcode::RET(REG_ZERO)
+    Opcode::NOOP
+  */
+  '0x24000000',
+  () => new Uint8Array(0),
+  () => undefined
+);


### PR DESCRIPTION
This PR adds a file called `scripts.ts` that contains the two scripts we use: `contractCallScript` and `returnZeroScript`.

I know this conflicts with #170 but it should be a an easy one. If not we can merge #170 and I can rebase this.