### PR TITLE
feat: add `callStatic` methods to Contract

### DIFF
--- a/packages/contract/src/storage-test-contract.test.ts
+++ b/packages/contract/src/storage-test-contract.test.ts
@@ -28,7 +28,7 @@ describe('StorageTestContract', () => {
     const incrementResult = await contract.functions.increment_counter(37);
     expect(incrementResult.toNumber()).toEqual(1337);
 
-    const count = await contract.functions.counter();
+    const count = await contract.callStatic.counter();
     expect(count.toNumber()).toEqual(1337);
   });
 });


### PR DESCRIPTION
This PR:
- Renames the internal `buildCall`, which was intended to just do dry runs but was actually submitting transactions, to `buildSubmit`. (`buildSubmit` is used for building `contract.functions.xyz` methods.)
- Introduces `buildCall` that actually does dry runs and uses that to build `contract.callStatic.xyz` methods.

So basically:
```ts
// Submits a tx
await contract.functions.initialize_counter(1337);

// Does not submit a tx
const count = await contract.callStatic.counter();
```