### PR TITLE
feat: change `typechain` imports to fuels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25827,6 +25827,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
         "@fuel-ts/abi-coder": "0.3.0",
         "@fuel-ts/constants": "0.3.0",
         "@fuel-ts/contract": "0.3.0",
@@ -36263,6 +36264,7 @@
       "version": "file:packages/fuels",
       "requires": {
         "@ethersproject/bignumber": "^5.6.0",
+        "@ethersproject/bytes": "^5.6.0",
         "@fuel-ts/abi-coder": "0.3.0",
         "@fuel-ts/constants": "0.3.0",
         "@fuel-ts/contract": "0.3.0",

--- a/packages/example-contract/src/example-contract.test.ts
+++ b/packages/example-contract/src/example-contract.test.ts
@@ -21,5 +21,11 @@ describe('ExampleContract', () => {
 
     // Assert
     expect(result.toNumber()).toEqual(1337);
+
+    // Try co call from the factory
+    const contractInstance = ExampleContractAbi__factory.connect(contract.id, wallet);
+    const resultInstance = await contractInstance.functions.return_input(1337);
+
+    expect(resultInstance.toNumber()).toBe(1337);
   });
 });

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -11,6 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ethersproject/bignumber": "^5.6.0",
+    "@ethersproject/bytes": "^5.6.0",
     "@fuel-ts/abi-coder": "0.3.0",
     "@fuel-ts/constants": "0.3.0",
     "@fuel-ts/contract": "0.3.0",

--- a/packages/fuels/src/index.ts
+++ b/packages/fuels/src/index.ts
@@ -1,3 +1,4 @@
+export * from '@ethersproject/bytes';
 export * from '@ethersproject/bignumber';
 export * from '@fuel-ts/abi-coder';
 export * from '@fuel-ts/constants';

--- a/packages/typechain-target-fuels/example/types/Demo.d.ts
+++ b/packages/typechain-target-fuels/example/types/Demo.d.ts
@@ -2,11 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { Interface, FunctionFragment, DecodedValue } from "@fuel-ts/abi-coder";
-import { Contract, Overrides } from "@fuel-ts/contract";
-import { Provider } from "@fuel-ts/providers";
-import { BigNumberish } from "@ethersproject/bignumber";
-import { BytesLike } from "@ethersproject/bytes";
+import type {
+  Interface,
+  FunctionFragment,
+  DecodedValue,
+  Contract,
+  Overrides,
+  BigNumberish,
+  BytesLike,
+} from "fuels";
 
 export type PersonStruct = { name: string; address: string };
 

--- a/packages/typechain-target-fuels/example/types/Token.d.ts
+++ b/packages/typechain-target-fuels/example/types/Token.d.ts
@@ -2,11 +2,15 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { Interface, FunctionFragment, DecodedValue } from "@fuel-ts/abi-coder";
-import { Contract, Overrides } from "@fuel-ts/contract";
-import { Provider } from "@fuel-ts/providers";
-import { BigNumberish } from "@ethersproject/bignumber";
-import { BytesLike } from "@ethersproject/bytes";
+import type {
+  Interface,
+  FunctionFragment,
+  DecodedValue,
+  Contract,
+  Overrides,
+  BigNumberish,
+  BytesLike,
+} from "fuels";
 
 export type ArgsStruct = { reciever: string; amount: BigNumberish };
 

--- a/packages/typechain-target-fuels/example/types/factories/Demo__factory.ts
+++ b/packages/typechain-target-fuels/example/types/factories/Demo__factory.ts
@@ -2,10 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { Interface } from "@fuel-ts/abi-coder";
-import type { Provider } from "@fuel-ts/providers";
-import type { Wallet } from "@fuel-ts/wallet";
-import { Contract } from "@fuel-ts/contract";
+import type { Provider, Wallet } from "fuels";
+import { Interface, Contract } from "fuels";
 import type { Demo, DemoInterface } from "../Demo";
 const _abi = [
   {

--- a/packages/typechain-target-fuels/example/types/factories/Token__factory.ts
+++ b/packages/typechain-target-fuels/example/types/factories/Token__factory.ts
@@ -2,10 +2,8 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import { Interface } from "@fuel-ts/abi-coder";
-import type { Provider } from "@fuel-ts/providers";
-import type { Wallet } from "@fuel-ts/wallet";
-import { Contract } from "@fuel-ts/contract";
+import type { Provider, Wallet } from "fuels";
+import { Interface, Contract } from "fuels";
 import type { Token, TokenInterface } from "../Token";
 const _abi = [
   {

--- a/packages/typechain-target-fuels/src/codegen/index.ts
+++ b/packages/typechain-target-fuels/src/codegen/index.ts
@@ -18,11 +18,7 @@ import generateStruct from './structs';
  */
 export function codegenContractTypings(contract: Contract, codegenConfig: CodegenConfig): string {
   const template = `
-  import { Interface, FunctionFragment, DecodedValue } from '@fuel-ts/abi-coder';
-  import { Contract, Overrides } from '@fuel-ts/contract';
-  import { Provider } from '@fuel-ts/providers';
-  import { BigNumberish } from '@ethersproject/bignumber';
-  import { BytesLike } from '@ethersproject/bytes';
+  import type { Interface, FunctionFragment, DecodedValue, Contract, Overrides, BigNumberish, BytesLike } from 'fuels';
   
   ${Object.values(contract.structs)
     .map((v) => generateStruct(v[0]))
@@ -89,10 +85,8 @@ function codegenCommonContractFactory(
   abi: RawAbiDefinition[]
 ): { header: string; body: string } {
   const header = `
-  import { Interface } from "@fuel-ts/abi-coder";
-  import type { Provider } from "@fuel-ts/providers";
-  import type { Wallet } from "@fuel-ts/wallet";
-  import { Contract } from "@fuel-ts/contract";
+  import type { Provider, Wallet } from "fuels";
+  import { Interface, Contract } from "fuels";
   import type { ${contract.name}, ${contract.name}Interface } from "../${contract.name}";
   const _abi = ${JSON.stringify(abi, null, 2)};
   `.trim();


### PR DESCRIPTION
### Summary

- Change imports removing ether and specific ones like `@fuels-ts/contract`
- Add a test on `example-contract` to use the ContractFactory directly.
- Add `@ethersproject/bytes` on `fuels` in this way. It's possible to use `BytesLike` and others on projects without installing other packages.

Before the imports on generated files
```
import { Interface, FunctionFragment, DecodedValue } from "@fuel-ts/abi-coder";
import { Contract, Overrides } from "@fuel-ts/contract";
import { Provider } from "@fuel-ts/providers";
import { BigNumberish } from "@ethersproject/bignumber";
import { BytesLike } from "@ethersproject/bytes";
```

Now
```
import type {
  Interface,
  FunctionFragment,
  DecodedValue,
  Contract,
  Overrides,
  BigNumberish,
  BytesLike,
} from "fuels";
```

closes: #183 