### PR TITLE
feat: add extra transaction request overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9034,6 +9034,15 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/lodash.mergewith": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz",
+      "integrity": "sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -16590,6 +16599,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -25688,7 +25702,11 @@
         "@fuel-ts/constants": "0.3.0",
         "@fuel-ts/merkle": "0.3.0",
         "@fuel-ts/providers": "0.3.0",
-        "@fuel-ts/wallet": "0.3.0"
+        "@fuel-ts/wallet": "0.3.0",
+        "lodash.mergewith": "^4.6.2"
+      },
+      "devDependencies": {
+        "@types/lodash.mergewith": "^4.6.6"
       }
     },
     "packages/contract/node_modules/@ethersproject/bytes": {
@@ -27396,7 +27414,9 @@
         "@fuel-ts/constants": "0.3.0",
         "@fuel-ts/merkle": "0.3.0",
         "@fuel-ts/providers": "0.3.0",
-        "@fuel-ts/wallet": "0.3.0"
+        "@fuel-ts/wallet": "0.3.0",
+        "@types/lodash.mergewith": "^4.6.6",
+        "lodash.mergewith": "^4.6.2"
       },
       "dependencies": {
         "@ethersproject/bytes": {
@@ -33101,6 +33121,15 @@
       "version": "4.5.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
       "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.mergewith": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz",
+      "integrity": "sha512-RY/8IaVENjG19rxTZu9Nukqh0W2UrYgmBj5sdns4hWRZaV8PqR7wIKHFKzvOTjo4zVRV7sVI+yFhAJql12Kfqg==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -39080,6 +39109,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.once": {
       "version": "4.1.1",

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -22,6 +22,10 @@
     "@fuel-ts/constants": "0.3.0",
     "@fuel-ts/merkle": "0.3.0",
     "@fuel-ts/providers": "0.3.0",
-    "@fuel-ts/wallet": "0.3.0"
+    "@fuel-ts/wallet": "0.3.0",
+    "lodash.mergewith": "^4.6.2"
+  },
+  "devDependencies": {
+    "@types/lodash.mergewith": "^4.6.6"
   }
 }

--- a/packages/contract/src/contract.test.ts
+++ b/packages/contract/src/contract.test.ts
@@ -3,7 +3,8 @@ import { Provider } from '@fuel-ts/providers';
 import { Wallet } from '@fuel-ts/wallet';
 import { seedWallet } from '@fuel-ts/wallet/dist/test-utils';
 
-import Contract from './contract';
+import Contract, { createTransactionRequest } from './contract';
+import requestSpecs from './request.specs';
 
 const jsonFragment = {
   type: 'function',
@@ -80,4 +81,16 @@ describe('Contract', () => {
 
     expect(contract.provider).toEqual(provider);
   });
+
+  it.each(requestSpecs)(
+    `Test create transaction request with overrides`,
+    async ({ contractId, scriptData, overrides, transactionSpec }) => {
+      const result = createTransactionRequest({
+        contractId,
+        overrides,
+        data: scriptData,
+      });
+      expect(result).toEqual(transactionSpec);
+    }
+  );
 });

--- a/packages/contract/src/request.specs.ts
+++ b/packages/contract/src/request.specs.ts
@@ -1,0 +1,231 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { arrayify } from '@ethersproject/bytes';
+
+interface TransactionRequestSpec {
+  contractId: string;
+  scriptData: any;
+  overrides: any;
+  transactionSpec: any;
+}
+
+export default [
+  [
+    {
+      contractId: '0x012b77e3fdaa1c70197818a5168a45e6ab337a02dda3c99967321047da9327c0',
+      scriptData: arrayify('0x0000000013ddc66f'),
+      overrides: {},
+      transactionSpec: {
+        type: 0,
+        gasPrice: 0,
+        gasLimit: 1000000,
+        bytePrice: 0,
+        script: arrayify('0x504001e82d40040a2434000047000000'),
+        scriptData: arrayify(
+          '0x012b77e3fdaa1c70197818a5168a45e6ab337a02dda3c99967321047da9327c00000000013ddc66f'
+        ),
+        inputs: [
+          {
+            type: 1,
+            contractId: '0x012b77e3fdaa1c70197818a5168a45e6ab337a02dda3c99967321047da9327c0',
+          },
+        ],
+        outputs: [
+          {
+            type: 1,
+            inputIndex: 0,
+          },
+        ],
+      },
+    },
+  ],
+  [
+    {
+      contractId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      scriptData: arrayify(
+        '0x0000000067ac6a050000000000000001666f6f00000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+      ),
+      overrides: {
+        inputs: [
+          {
+            type: 0,
+            id: '0xefe2937354e847dd25e6d31aece8a195379a01e8ab365bdd492628d41d8c506300',
+            status: 'UNSPENT',
+            assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            amount: {
+              type: 'BigNumber',
+              hex: '0x01',
+            },
+            owner: '0x09ea14b677b62562c9da07b8d0ac285968f19ca222d8e8e3283360aad35cc02c',
+            maturity: {
+              type: 'BigNumber',
+              hex: '0x00',
+            },
+            blockCreated: {
+              type: 'BigNumber',
+              hex: '0x2993',
+            },
+            witnessIndex: 0,
+          },
+        ],
+        outputs: [
+          {
+            type: 3,
+            assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            to: '0x09ea14b677b62562c9da07b8d0ac285968f19ca222d8e8e3283360aad35cc02c',
+          },
+        ],
+      },
+      transactionSpec: {
+        type: 0,
+        gasPrice: 0,
+        gasLimit: 1000000,
+        bytePrice: 0,
+        script: arrayify('0x504001e82d40040a2434000047000000'),
+        scriptData: arrayify(
+          '0x00000000000000000000000000000000000000000000000000000000000000000000000067ac6a050000000000000218666f6f00000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+        ),
+        inputs: [
+          {
+            type: 1,
+            contractId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          },
+          {
+            type: 0,
+            id: '0xefe2937354e847dd25e6d31aece8a195379a01e8ab365bdd492628d41d8c506300',
+            status: 'UNSPENT',
+            assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            amount: {
+              type: 'BigNumber',
+              hex: '0x01',
+            },
+            owner: '0x09ea14b677b62562c9da07b8d0ac285968f19ca222d8e8e3283360aad35cc02c',
+            maturity: {
+              type: 'BigNumber',
+              hex: '0x00',
+            },
+            blockCreated: {
+              type: 'BigNumber',
+              hex: '0x2993',
+            },
+            witnessIndex: 0,
+          },
+        ],
+        outputs: [
+          {
+            type: 1,
+            inputIndex: 0,
+          },
+          {
+            type: 3,
+            assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            to: '0x09ea14b677b62562c9da07b8d0ac285968f19ca222d8e8e3283360aad35cc02c',
+          },
+        ],
+      },
+    },
+  ],
+  [
+    {
+      contractId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      scriptData: arrayify(
+        '0x0000000067ac6a050000000000000001666f6f00000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+      ),
+      overrides: [
+        {
+          gasPrice: 1000,
+          inputs: [
+            {
+              type: 0,
+              id: '0xefe2937354e847dd25e6d31aece8a195379a01e8ab365bdd492628d41d8c506300',
+              status: 'UNSPENT',
+              assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              amount: {
+                type: 'BigNumber',
+                hex: '0x01',
+              },
+              owner: '0x09ea14b677b62562c9da07b8d0ac285968f19ca222d8e8e3283360aad35cc02c',
+              maturity: {
+                type: 'BigNumber',
+                hex: '0x00',
+              },
+              blockCreated: {
+                type: 'BigNumber',
+                hex: '0x2993',
+              },
+              witnessIndex: 0,
+            },
+          ],
+          outputs: [
+            {
+              type: 3,
+              assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              to: '0x09ea14b677b62562c9da07b8d0ac285968f19ca222d8e8e3283360aad35cc02c',
+            },
+          ],
+        },
+        {
+          gasPrice: 2000,
+          outputs: [
+            {
+              type: 3,
+              assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+              to: '0x09ea14b677b62562c9da07b8d0ac285968f19ca222d8e8e3283360aad35cc02c',
+            },
+          ],
+        },
+      ],
+      transactionSpec: {
+        type: 0,
+        gasPrice: 2000,
+        gasLimit: 1000000,
+        bytePrice: 0,
+        script: arrayify('0x504001e82d40040a2434000047000000'),
+        scriptData: arrayify(
+          '0x00000000000000000000000000000000000000000000000000000000000000000000000067ac6a050000000000000218666f6f00000000d5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+        ),
+        inputs: [
+          {
+            type: 1,
+            contractId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+          },
+          {
+            type: 0,
+            id: '0xefe2937354e847dd25e6d31aece8a195379a01e8ab365bdd492628d41d8c506300',
+            status: 'UNSPENT',
+            assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            amount: {
+              type: 'BigNumber',
+              hex: '0x01',
+            },
+            owner: '0x09ea14b677b62562c9da07b8d0ac285968f19ca222d8e8e3283360aad35cc02c',
+            maturity: {
+              type: 'BigNumber',
+              hex: '0x00',
+            },
+            blockCreated: {
+              type: 'BigNumber',
+              hex: '0x2993',
+            },
+            witnessIndex: 0,
+          },
+        ],
+        outputs: [
+          {
+            type: 1,
+            inputIndex: 0,
+          },
+          {
+            type: 3,
+            assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            to: '0x09ea14b677b62562c9da07b8d0ac285968f19ca222d8e8e3283360aad35cc02c',
+          },
+          {
+            type: 3,
+            assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+            to: '0x09ea14b677b62562c9da07b8d0ac285968f19ca222d8e8e3283360aad35cc02c',
+          },
+        ],
+      },
+    },
+  ],
+] as Array<Array<TransactionRequestSpec>>;


### PR DESCRIPTION
### Summary

When calling a method from the contract, sometimes we need to send coins and maybe add some other things like `gasPrice`, `bytePrice`, etc. 

Because of this, I think we shouldn't limit what can be overridden but instead enable to override the `transactionRequest` payload completely.

The suggested implementation will merge the additional `transactionRequest` into the default, overriding the default configs with the new ones, **except for `inputs` and `outputs`** which will be concatenated with the default `inputs and outputs`

Notes: Another change suggest is to change the `Overrides` param to `CallOptions{ transaction }` this would allow adding more options in the future without breaking the Interface if we enable to pass the entire `TranasctionRequest`.

### Discussion;

- Should we allow the entire transaction override?
- Should we concatenate the inputs and outputs?
   - If we do so, should we have another config to override instead of concatenating? like a `transactionRequestOverride` or something like a `transactionRequest` hook from [axios](https://axios-http.com/docs/req_config)? Enabling to override something right before submitting the call.

closes: #175 