### PR TITLE
feat: add hdwallet and mnemonic features to wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26164,16 +26164,16 @@
         "@ethersproject/bytes": "^5.5.0",
         "@fuel-ts/constants": "^0.4.0",
         "@fuel-ts/hasher": "^0.4.0",
+        "@fuel-ts/hdwallet": "^0.4.0",
         "@fuel-ts/interfaces": "^0.4.0",
+        "@fuel-ts/mnemonic": "^0.4.0",
         "@fuel-ts/providers": "^0.4.0",
-        "@fuel-ts/signer": "^0.4.0",
-        "lodash.clonedeep": "^4.5.0"
+        "@fuel-ts/signer": "^0.4.0"
       },
       "devDependencies": {
         "@ethersproject/bignumber": "^5.5.0",
         "@ethersproject/random": "5.5.1",
-        "@fuel-ts/testcases": "^0.4.0",
-        "@types/lodash.clonedeep": "^4.5.6"
+        "@fuel-ts/testcases": "^0.4.0"
       }
     },
     "packages/wordlists": {
@@ -27463,7 +27463,7 @@
         "@ethersproject/sha2": "^5.6.0",
         "@fuel-ts/abi-coder": "^0.4.0",
         "@fuel-ts/constants": "^0.4.0",
-        "@fuel-ts/interfaces": "*",
+        "@fuel-ts/interfaces": "^0.4.0",
         "@fuel-ts/merkle": "^0.4.0",
         "@fuel-ts/providers": "^0.4.0",
         "@fuel-ts/wallet": "^0.4.0"
@@ -27701,12 +27701,12 @@
         "@ethersproject/random": "5.5.1",
         "@fuel-ts/constants": "^0.4.0",
         "@fuel-ts/hasher": "^0.4.0",
+        "@fuel-ts/hdwallet": "^0.4.0",
         "@fuel-ts/interfaces": "^0.4.0",
+        "@fuel-ts/mnemonic": "^0.4.0",
         "@fuel-ts/providers": "^0.4.0",
         "@fuel-ts/signer": "^0.4.0",
-        "@fuel-ts/testcases": "^0.4.0",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "lodash.clonedeep": "^4.5.0"
+        "@fuel-ts/testcases": "^0.4.0"
       }
     },
     "@fuel-ts/wordlists": {

--- a/packages/signer/src/signer.test.ts
+++ b/packages/signer/src/signer.test.ts
@@ -37,4 +37,10 @@ describe('Signer', () => {
 
     expect(recoveredAddress).toEqual(signMessageTest.address);
   });
+
+  it('Extend publicKey from compact publicKey', async () => {
+    const signer = new Signer(signMessageTest.privateKey);
+
+    expect(signer.publicKey).toEqual(Signer.extendPublicKey(signer.compressedPublicKey));
+  });
 });

--- a/packages/signer/src/signer.ts
+++ b/packages/signer/src/signer.ts
@@ -128,6 +128,17 @@ class Signer {
   static generatePrivateKey(entropy?: BytesLike) {
     return entropy ? hash(concat([randomBytes(32), arrayify(entropy)])) : randomBytes(32);
   }
+
+  /**
+   * Extended publicKey from a compact publicKey
+   *
+   * @param publicKey - Compact publicKey
+   * @returns extended publicKey
+   */
+  static extendPublicKey(publicKey: BytesLike) {
+    const keyPair = getCurve().keyFromPublic(arrayify(publicKey));
+    return hexlify(keyPair.getPublic(false, 'array').slice(1));
+  }
 }
 
 export default Signer;

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -13,15 +13,15 @@
     "@ethersproject/bytes": "^5.5.0",
     "@fuel-ts/constants": "^0.4.0",
     "@fuel-ts/hasher": "^0.4.0",
+    "@fuel-ts/hdwallet": "^0.4.0",
     "@fuel-ts/interfaces": "^0.4.0",
+    "@fuel-ts/mnemonic": "^0.4.0",
     "@fuel-ts/providers": "^0.4.0",
-    "@fuel-ts/signer": "^0.4.0",
-    "lodash.clonedeep": "^4.5.0"
+    "@fuel-ts/signer": "^0.4.0"
   },
   "devDependencies": {
     "@ethersproject/bignumber": "^5.5.0",
     "@ethersproject/random": "5.5.1",
-    "@fuel-ts/testcases": "^0.4.0",
-    "@types/lodash.clonedeep": "^4.5.6"
+    "@fuel-ts/testcases": "^0.4.0"
   }
 }

--- a/packages/wallet/src/wallet-spec.ts
+++ b/packages/wallet/src/wallet-spec.ts
@@ -1,0 +1,19 @@
+export default {
+  mnemonic:
+    'fragile silver alley worth float lizard memory amazing fee race escape rotate evil mystery coyote',
+  seed: '0xfb4b1710a9ab55d8dc19b7633f3d50f6f16c73649c12ae5f00a1e443c72b8d16bf95ab9a2c7a53036b5ed8c8139fab460b86536b8cf0a4c805e272edc64252ae',
+  account_0: {
+    path: "m/44'/60'/0'/0/0",
+    publicKey:
+      '0xb2bd7143e653888307e4f6239933b180ec4ebb4dbee9d5b72bf290782b4b220e5e9ca9bb63933ff98f756b58a64d18a43f12afec223c4e591b9b5875d4c10b4e',
+    privateKey: '0x17a546a27a22e452a40ac1ea2196578560f909b147d0afae531e54975aa1f941',
+    xprv: 'xprvA4JdXy4HwwHXTd6EUtzKcVxXb5Rr49h9sjxJ2Wo5Qnz3Lj52XFhsVSi1pAycSoVSe2uAXwUqwki5NUU32qrNtTacfB3poQoEoNcbVeLp9qb',
+  },
+  account_1: {
+    path: "m/44'/60'/0'/0/0'",
+    publicKey:
+      '0x324b2edff3c2901992a9ba19fa2af90eb2fba71d7d8d52b614b1812848b350e3bf954ba74ad08b59fca2548ae1e27e6f59650f8a7e16d7ebece355aa30d3d790',
+    privateKey: '0x4490ed04cc8bc092b8a090960e0ad0ccd5229b0b3fabddd578e8214cce95a8b8',
+    xprv: 'xprvA4JdXy4SHbpVe9QMbej44oTLJHnWzDez3bcN7UXcL5euuPwHjkT93tHagBHgKvxXDkoRBMkuDgpdnW6Ks6UfeEtTeSvKFNq1i1XSgMXZwfa',
+  },
+};

--- a/packages/wallet/src/wallet.test.ts
+++ b/packages/wallet/src/wallet.test.ts
@@ -7,6 +7,7 @@ import signMessageTest from '@fuel-ts/testcases/src/signMessage.json';
 import signTransactionTest from '@fuel-ts/testcases/src/signTransaction.json';
 
 import Wallet from './wallet';
+import walletSpec from './wallet-spec';
 
 describe('Wallet', () => {
   it('Instantiate a new wallet', async () => {
@@ -112,5 +113,29 @@ describe('Wallet', () => {
     expect(wallet.privateKey).toBeTruthy();
     expect(wallet.publicKey).toBeTruthy();
     expect(wallet.address).toBe(recoveredAddress);
+  });
+
+  it('Create wallet from seed', async () => {
+    const wallet = Wallet.fromSeed(walletSpec.seed, walletSpec.account_1.path);
+
+    expect(wallet.publicKey).toBe(walletSpec.account_1.publicKey);
+  });
+
+  it('Create wallet from mnemonic', async () => {
+    const wallet = Wallet.fromMnemonic(walletSpec.mnemonic, walletSpec.account_1.path);
+
+    expect(wallet.publicKey).toBe(walletSpec.account_1.publicKey);
+  });
+
+  it('Create wallet from extendedKey', async () => {
+    const wallet = Wallet.fromExtendedKey(walletSpec.account_0.xprv);
+
+    expect(wallet.publicKey).toBe(walletSpec.account_0.publicKey);
+  });
+
+  it('Create wallet from seed with default path', async () => {
+    const wallet = Wallet.fromSeed(walletSpec.seed);
+
+    expect(wallet.publicKey).toBe(walletSpec.account_0.publicKey);
   });
 });

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -195,6 +195,7 @@ export default class Wallet extends AbstractWallet {
     transactionRequestLike: TransactionRequestLike
   ): Promise<TransactionResponse> {
     const transactionRequest = transactionRequestify(transactionRequestLike);
+
     return this.provider.sendTransaction(
       this.populateTransactionWitnessesSignature(transactionRequest)
     );
@@ -208,6 +209,7 @@ export default class Wallet extends AbstractWallet {
    */
   static generate(generateOptions?: GenerateOptions) {
     const privateKey = Signer.generatePrivateKey(generateOptions?.entropy);
+
     return new Wallet(privateKey, generateOptions?.provider);
   }
 
@@ -217,9 +219,8 @@ export default class Wallet extends AbstractWallet {
   static fromSeed(seed: string, path?: string): Wallet {
     const hdWallet = HDWallet.fromSeed(seed);
     const childWallet = hdWallet.derivePath(path || Wallet.defaultPath);
-    const wallet = new Wallet(<string>childWallet.privateKey);
 
-    return wallet;
+    return new Wallet(<string>childWallet.privateKey);
   }
 
   /**
@@ -229,9 +230,8 @@ export default class Wallet extends AbstractWallet {
     const seed = Mnemonic.mnemonicToSeed(mnemonic, passphrase);
     const hdWallet = HDWallet.fromSeed(seed);
     const childWallet = hdWallet.derivePath(path || Wallet.defaultPath);
-    const wallet = new Wallet(<string>childWallet.privateKey);
 
-    return wallet;
+    return new Wallet(<string>childWallet.privateKey);
   }
 
   /**
@@ -239,8 +239,7 @@ export default class Wallet extends AbstractWallet {
    */
   static fromExtendedKey(extendedKey: string): Wallet {
     const hdWallet = HDWallet.fromExtendedKey(extendedKey);
-    const wallet = new Wallet(<string>hdWallet.privateKey);
 
-    return wallet;
+    return new Wallet(<string>hdWallet.privateKey);
   }
 }

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -22,6 +22,12 @@
     },
     {
       "path": "../signer"
+    },
+    {
+      "path": "../mnemonic"
+    },
+    {
+      "path": "../hdwallet"
     }
   ]
 }


### PR DESCRIPTION
### Summary

- Add `fromSeed, fromMnemonic, fromExtendedKey` methods to Wallet. The designed solution didn't keep seed, mnemonic phrase, or other related info on the wallet instance, removing possible leaking of it on the wallet level. Because of that `derivePath and deriveIndex` methods can't be implemented on the wallet level. At this time the idea is to bring a new High Order Component something like `Wallet Manager`.
- Add `extendPublicKey` on `@fuels-ts/signer`, converting a compact publicKey to an extended publicKey.
- Add the `connect` method to `@fuels-ts/wallet`, connect to a different provider without the need to recreate the wallet.

closes: #146 