### PR TITLE
fix: set json fragment name optional

### DIFF
--- a/packages/abi-coder/src/abi-coder.ts
+++ b/packages/abi-coder/src/abi-coder.ts
@@ -28,20 +28,22 @@ export default class AbiCoder {
   }
 
   getCoder(param: JsonFragmentType): Coder {
+    const name = param.name || '';
+
     switch (param.type) {
       case 'u8':
       case 'u16':
       case 'u32':
       case 'u64':
-        return new NumberCoder(param.type, param.name);
+        return new NumberCoder(param.type, name);
       case 'bool':
-        return new BooleanCoder(param.name);
+        return new BooleanCoder(name);
       case 'byte':
-        return new ByteCoder(param.name);
+        return new ByteCoder(name);
       case 'address':
-        return new B256Coder('address', param.name);
+        return new B256Coder('address', name);
       case 'b256':
-        return new B256Coder('address', param.name);
+        return new B256Coder('address', name);
       case 'tuple':
         return new TupleCoder(
           (param.components || []).map((component) => this.getCoder(component)),
@@ -54,14 +56,14 @@ export default class AbiCoder {
     if (stringMatch !== null) {
       const length = stringMatch[1];
 
-      return new StringCoder(param.name, parseInt(length, 10));
+      return new StringCoder(name, parseInt(length, 10));
     }
 
     const arrayMatch = param.type.match(arrayRegEx);
     if (arrayMatch !== null) {
       const type = arrayMatch[1];
       const length = arrayMatch[2];
-      return new ArrayCoder(this.getCoder({ type, name: type }), parseInt(length, 10), param.name);
+      return new ArrayCoder(this.getCoder({ type, name: type }), parseInt(length, 10), name);
     }
 
     if (param.type.includes('struct') && Array.isArray(param.components)) {

--- a/packages/abi-coder/src/fragments/fragment.ts
+++ b/packages/abi-coder/src/fragments/fragment.ts
@@ -1,7 +1,7 @@
 import type { ParamType } from '@ethersproject/abi';
 
 export interface JsonFragmentType {
-  readonly name: string;
+  readonly name?: string;
   readonly type: string;
   // TODO: Remove `null` when forc doesn't output nulls (https://github.com/FuelLabs/sway/issues/926)
   readonly components?: ReadonlyArray<JsonFragmentType> | null;


### PR DESCRIPTION
### Summary

- When declaring a JSONFrament `input/outputs` name is not required.

#### Example

This works;
```ts
    const contract = await setup([
      {
        type: 'function',
        name: 'return_context_asset',
        outputs: [
          {
            name: 'arg0',
            type: 'b256',
          },
        ],
      },
    ]);
```

This should work also;
```ts
    const contract = await setup([
      {
        type: 'function',
        name: 'return_context_asset',
        outputs: [
          {
            type: 'b256',
          },
        ],
      },
    ]);
```

