### PR TITLE
feat: add types on contract factory generated code

### DIFF
--- a/packages/abi-coder/src/abi-coder.ts
+++ b/packages/abi-coder/src/abi-coder.ts
@@ -1,6 +1,4 @@
 // See: https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI
-import type { JsonFragment } from '@ethersproject/abi';
-import { ParamType } from '@ethersproject/abi';
 import type { BytesLike } from '@ethersproject/bytes';
 import { arrayify, hexConcat } from '@ethersproject/bytes';
 import { Logger } from '@ethersproject/logger';

--- a/packages/abi-coder/src/abi-coder.ts
+++ b/packages/abi-coder/src/abi-coder.ts
@@ -28,20 +28,22 @@ export default class AbiCoder {
   }
 
   getCoder(param: JsonFragmentType): Coder {
+    const name = param.name || '';
+
     switch (param.type) {
       case 'u8':
       case 'u16':
       case 'u32':
       case 'u64':
-        return new NumberCoder(param.type, param.name);
+        return new NumberCoder(param.type, name);
       case 'bool':
-        return new BooleanCoder(param.name);
+        return new BooleanCoder(name);
       case 'byte':
-        return new ByteCoder(param.name);
+        return new ByteCoder(name);
       case 'address':
-        return new B256Coder('address', param.name);
+        return new B256Coder('address', name);
       case 'b256':
-        return new B256Coder('address', param.name);
+        return new B256Coder('address', name);
       case 'tuple':
         return new TupleCoder(
           (param.components || []).map((component) => this.getCoder(component)),
@@ -54,14 +56,14 @@ export default class AbiCoder {
     if (stringMatch !== null) {
       const length = stringMatch[1];
 
-      return new StringCoder(param.name, parseInt(length, 10));
+      return new StringCoder(name, parseInt(length, 10));
     }
 
     const arrayMatch = param.type.match(arrayRegEx);
     if (arrayMatch !== null) {
       const type = arrayMatch[1];
       const length = arrayMatch[2];
-      return new ArrayCoder(this.getCoder({ type, name: type }), parseInt(length, 10), param.name);
+      return new ArrayCoder(this.getCoder({ type, name: type }), parseInt(length, 10), name);
     }
 
     if (param.type.includes('struct') && Array.isArray(param.components)) {

--- a/packages/abi-coder/src/fragments/fragment.ts
+++ b/packages/abi-coder/src/fragments/fragment.ts
@@ -1,7 +1,7 @@
 import type { ParamType } from '@ethersproject/abi';
 
 export interface JsonFragmentType {
-  readonly name: string;
+  readonly name?: string;
   readonly type: string;
   // TODO: Remove `null` when forc doesn't output nulls (https://github.com/FuelLabs/sway/issues/926)
   readonly components?: ReadonlyArray<JsonFragmentType> | null;

--- a/packages/typechain-target-fuels/example/demo.json
+++ b/packages/typechain-target-fuels/example/demo.json
@@ -3,11 +3,11 @@
     "inputs": [
       {
         "name": "name",
-        "type": "str[12][2]"
+        "type": "[str[12]; 2]"
       },
       {
         "name": "addresses",
-        "type": "address[2]"
+        "type": "[address; 2]"
       },
       {
         "name": "foo",

--- a/packages/typechain-target-fuels/example/token.json
+++ b/packages/typechain-target-fuels/example/token.json
@@ -67,7 +67,7 @@
     "type": "function"
   },
   {
-    "name": "return_tuple",
+    "name": "return_struct",
     "type": "function",
     "inputs": [
       { "name": "arg0", "type": "u64" }

--- a/packages/typechain-target-fuels/example/token.json
+++ b/packages/typechain-target-fuels/example/token.json
@@ -8,13 +8,19 @@
         "name": "args",
         "type": "tuple",
         "components": [
-          { "name": "reciever", "type": "b256" },
+          { "name": "receiver", "type": "b256" },
           { "name": "amount", "type": "u64" }
         ]
       }
     ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "u64",
+        "components": null
+      }
+    ],
     "name": "mint",
-    "outputs": [],
     "type": "function"
   },
   {
@@ -27,13 +33,62 @@
         "type": "tuple",
         "components": [
           { "name": "sender", "type": "b256" },
-          { "name": "reciever", "type": "b256" },
+          { "name": "receiver", "type": "b256" },
           { "name": "amount", "type": "u64" }
         ]
       }
     ],
     "name": "send",
-    "outputs": [],
     "type": "function"
+  },
+  {
+    "name": "get_balance",
+    "type": "function",
+    "outputs": [
+      {
+        "name": "",
+        "type": "u64",
+        "components": null
+      }
+    ]
+  },
+  {
+    "inputs": [
+      { "name": "gas", "type": "u64" }
+    ],
+    "name": "return_array",
+    "outputs": [
+      {
+        "name": "",
+        "type": "[b256; 2]",
+        "components": null
+      }
+    ],
+    "type": "function"
+  },
+  {
+    "name": "return_tuple",
+    "type": "function",
+    "inputs": [
+      { "name": "arg0", "type": "u64" }
+    ],
+    "outputs": [
+      {
+        "type": "tuple",
+        "name": "Ret0",
+        "components": [
+          { "name": "sender", "type": "b256" },
+          { "name": "receiver", "type": "b256" },
+          {
+            "type": "tuple",
+            "name": "Ret1",
+            "components": [
+              { "name": "foo", "type": "b256" },
+              { "name": "bar", "type": "b256" }
+            ]
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/packages/typechain-target-fuels/example/types/Demo.d.ts
+++ b/packages/typechain-target-fuels/example/types/Demo.d.ts
@@ -10,19 +10,20 @@ import type {
   Overrides,
   BigNumberish,
   BytesLike,
+  BigNumber,
 } from "fuels";
 
 export type PersonStruct = { name: string; address: string };
 
 interface DemoInterface extends Interface {
   functions: {
-    "name(str[12][2],address[2],bool)": FunctionFragment;
+    "name([str[12]; 2],[address; 2],bool)": FunctionFragment;
     "tuple_function((str[20],address))": FunctionFragment;
   };
 
   encodeFunctionData(
     functionFragment: "name",
-    values: [[string, string], [string, string], boolean]
+    values: [string, [string, string], boolean]
   ): string;
   encodeFunctionData(
     functionFragment: "tuple_function",
@@ -40,51 +41,51 @@ export class Demo extends Contract {
   interface: DemoInterface;
   functions: {
     name(
-      name: [string, string],
+      name: string,
       addresses: [string, string],
       foo: boolean,
       overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<any>;
+    ): Promise<void>;
 
-    "name(str[12][2],address[2],bool)"(
-      name: [string, string],
+    "name([str[12]; 2],[address; 2],bool)"(
+      name: string,
       addresses: [string, string],
       foo: boolean,
       overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<any>;
+    ): Promise<void>;
 
     tuple_function(
       person: PersonStruct,
       overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<any>;
+    ): Promise<void>;
 
     "tuple_function((str[20],address))"(
       person: PersonStruct,
       overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<any>;
+    ): Promise<void>;
   };
 
   name(
-    name: [string, string],
+    name: string,
     addresses: [string, string],
     foo: boolean,
     overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<any>;
+  ): Promise<void>;
 
-  "name(str[12][2],address[2],bool)"(
-    name: [string, string],
+  "name([str[12]; 2],[address; 2],bool)"(
+    name: string,
     addresses: [string, string],
     foo: boolean,
     overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<any>;
+  ): Promise<void>;
 
   tuple_function(
     person: PersonStruct,
     overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<any>;
+  ): Promise<void>;
 
   "tuple_function((str[20],address))"(
     person: PersonStruct,
     overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<any>;
+  ): Promise<void>;
 }

--- a/packages/typechain-target-fuels/example/types/Token.d.ts
+++ b/packages/typechain-target-fuels/example/types/Token.d.ts
@@ -25,7 +25,7 @@ interface TokenInterface extends Interface {
     "send(u64,u64,b256,(b256,b256,u64))": FunctionFragment;
     "get_balance()": FunctionFragment;
     "return_array(u64)": FunctionFragment;
-    "return_tuple(u64)": FunctionFragment;
+    "return_struct(u64)": FunctionFragment;
   };
 
   encodeFunctionData(
@@ -45,7 +45,7 @@ interface TokenInterface extends Interface {
     values: [BigNumberish]
   ): string;
   encodeFunctionData(
-    functionFragment: "return_tuple",
+    functionFragment: "return_struct",
     values: [BigNumberish]
   ): string;
 
@@ -60,7 +60,7 @@ interface TokenInterface extends Interface {
     data: BytesLike
   ): DecodedValue;
   decodeFunctionData(
-    functionFragment: "return_tuple",
+    functionFragment: "return_struct",
     data: BytesLike
   ): DecodedValue;
 }
@@ -118,12 +118,12 @@ export class Token extends Contract {
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<[string, string]>;
 
-    return_tuple(
+    return_struct(
       arg0: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<Ret0Struct>;
 
-    "return_tuple(u64)"(
+    "return_struct(u64)"(
       arg0: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<Ret0Struct>;
@@ -179,12 +179,12 @@ export class Token extends Contract {
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<[string, string]>;
 
-  return_tuple(
+  return_struct(
     arg0: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<Ret0Struct>;
 
-  "return_tuple(u64)"(
+  "return_struct(u64)"(
     arg0: BigNumberish,
     overrides?: Overrides & { from?: string | Promise<string> }
   ): Promise<Ret0Struct>;

--- a/packages/typechain-target-fuels/example/types/Token.d.ts
+++ b/packages/typechain-target-fuels/example/types/Token.d.ts
@@ -10,14 +10,22 @@ import type {
   Overrides,
   BigNumberish,
   BytesLike,
+  BigNumber,
 } from "fuels";
 
-export type ArgsStruct = { reciever: string; amount: BigNumberish };
+export type ArgsStruct = { receiver: string; amount: BigNumberish };
+
+export type Ret1Struct = { foo: string; bar: string };
+
+export type Ret0Struct = { sender: string; receiver: string; Ret1: Ret1Struct };
 
 interface TokenInterface extends Interface {
   functions: {
     "mint(u64,u64,b256,(b256,u64))": FunctionFragment;
     "send(u64,u64,b256,(b256,b256,u64))": FunctionFragment;
+    "get_balance()": FunctionFragment;
+    "return_array(u64)": FunctionFragment;
+    "return_tuple(u64)": FunctionFragment;
   };
 
   encodeFunctionData(
@@ -28,9 +36,33 @@ interface TokenInterface extends Interface {
     functionFragment: "send",
     values: [BigNumberish, BigNumberish, string, ArgsStruct]
   ): string;
+  encodeFunctionData(
+    functionFragment: "get_balance",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "return_array",
+    values: [BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "return_tuple",
+    values: [BigNumberish]
+  ): string;
 
   decodeFunctionData(functionFragment: "mint", data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: "send", data: BytesLike): DecodedValue;
+  decodeFunctionData(
+    functionFragment: "get_balance",
+    data: BytesLike
+  ): DecodedValue;
+  decodeFunctionData(
+    functionFragment: "return_array",
+    data: BytesLike
+  ): DecodedValue;
+  decodeFunctionData(
+    functionFragment: "return_tuple",
+    data: BytesLike
+  ): DecodedValue;
 }
 
 export class Token extends Contract {
@@ -42,7 +74,7 @@ export class Token extends Contract {
       asset_id: string,
       args: ArgsStruct,
       overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<any>;
+    ): Promise<BigNumber>;
 
     "mint(u64,u64,b256,(b256,u64))"(
       gas: BigNumberish,
@@ -50,7 +82,7 @@ export class Token extends Contract {
       asset_id: string,
       args: ArgsStruct,
       overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<any>;
+    ): Promise<BigNumber>;
 
     send(
       gas: BigNumberish,
@@ -58,7 +90,7 @@ export class Token extends Contract {
       asset_id: string,
       args: ArgsStruct,
       overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<any>;
+    ): Promise<void>;
 
     "send(u64,u64,b256,(b256,b256,u64))"(
       gas: BigNumberish,
@@ -66,7 +98,35 @@ export class Token extends Contract {
       asset_id: string,
       args: ArgsStruct,
       overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<any>;
+    ): Promise<void>;
+
+    get_balance(
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
+    "get_balance()"(
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<BigNumber>;
+
+    return_array(
+      gas: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<[string, string]>;
+
+    "return_array(u64)"(
+      gas: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<[string, string]>;
+
+    return_tuple(
+      arg0: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<Ret0Struct>;
+
+    "return_tuple(u64)"(
+      arg0: BigNumberish,
+      overrides?: Overrides & { from?: string | Promise<string> }
+    ): Promise<Ret0Struct>;
   };
 
   mint(
@@ -75,7 +135,7 @@ export class Token extends Contract {
     asset_id: string,
     args: ArgsStruct,
     overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<any>;
+  ): Promise<BigNumber>;
 
   "mint(u64,u64,b256,(b256,u64))"(
     gas: BigNumberish,
@@ -83,7 +143,7 @@ export class Token extends Contract {
     asset_id: string,
     args: ArgsStruct,
     overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<any>;
+  ): Promise<BigNumber>;
 
   send(
     gas: BigNumberish,
@@ -91,7 +151,7 @@ export class Token extends Contract {
     asset_id: string,
     args: ArgsStruct,
     overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<any>;
+  ): Promise<void>;
 
   "send(u64,u64,b256,(b256,b256,u64))"(
     gas: BigNumberish,
@@ -99,5 +159,33 @@ export class Token extends Contract {
     asset_id: string,
     args: ArgsStruct,
     overrides?: Overrides & { from?: string | Promise<string> }
-  ): Promise<any>;
+  ): Promise<void>;
+
+  get_balance(
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<BigNumber>;
+
+  "get_balance()"(
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<BigNumber>;
+
+  return_array(
+    gas: BigNumberish,
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<[string, string]>;
+
+  "return_array(u64)"(
+    gas: BigNumberish,
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<[string, string]>;
+
+  return_tuple(
+    arg0: BigNumberish,
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<Ret0Struct>;
+
+  "return_tuple(u64)"(
+    arg0: BigNumberish,
+    overrides?: Overrides & { from?: string | Promise<string> }
+  ): Promise<Ret0Struct>;
 }

--- a/packages/typechain-target-fuels/example/types/factories/Demo__factory.ts
+++ b/packages/typechain-target-fuels/example/types/factories/Demo__factory.ts
@@ -10,11 +10,11 @@ const _abi = [
     inputs: [
       {
         name: "name",
-        type: "str[12][2]",
+        type: "[str[12]; 2]",
       },
       {
         name: "addresses",
-        type: "address[2]",
+        type: "[address; 2]",
       },
       {
         name: "foo",

--- a/packages/typechain-target-fuels/example/types/factories/Token__factory.ts
+++ b/packages/typechain-target-fuels/example/types/factories/Token__factory.ts
@@ -25,7 +25,7 @@ const _abi = [
         type: "tuple",
         components: [
           {
-            name: "reciever",
+            name: "receiver",
             type: "b256",
           },
           {
@@ -35,8 +35,14 @@ const _abi = [
         ],
       },
     ],
+    outputs: [
+      {
+        name: "",
+        type: "u64",
+        components: null,
+      },
+    ],
     name: "mint",
-    outputs: [],
     type: "function",
   },
   {
@@ -62,7 +68,7 @@ const _abi = [
             type: "b256",
           },
           {
-            name: "reciever",
+            name: "receiver",
             type: "b256",
           },
           {
@@ -73,8 +79,75 @@ const _abi = [
       },
     ],
     name: "send",
-    outputs: [],
     type: "function",
+  },
+  {
+    name: "get_balance",
+    type: "function",
+    outputs: [
+      {
+        name: "",
+        type: "u64",
+        components: null,
+      },
+    ],
+  },
+  {
+    inputs: [
+      {
+        name: "gas",
+        type: "u64",
+      },
+    ],
+    name: "return_array",
+    outputs: [
+      {
+        name: "",
+        type: "[b256; 2]",
+        components: null,
+      },
+    ],
+    type: "function",
+  },
+  {
+    name: "return_tuple",
+    type: "function",
+    inputs: [
+      {
+        name: "arg0",
+        type: "u64",
+      },
+    ],
+    outputs: [
+      {
+        type: "tuple",
+        name: "Ret0",
+        components: [
+          {
+            name: "sender",
+            type: "b256",
+          },
+          {
+            name: "receiver",
+            type: "b256",
+          },
+          {
+            type: "tuple",
+            name: "Ret1",
+            components: [
+              {
+                name: "foo",
+                type: "b256",
+              },
+              {
+                name: "bar",
+                type: "b256",
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
 ];
 

--- a/packages/typechain-target-fuels/example/types/factories/Token__factory.ts
+++ b/packages/typechain-target-fuels/example/types/factories/Token__factory.ts
@@ -110,7 +110,7 @@ const _abi = [
     type: "function",
   },
   {
-    name: "return_tuple",
+    name: "return_struct",
     type: "function",
     inputs: [
       {

--- a/packages/typechain-target-fuels/src/codegen/functions.ts
+++ b/packages/typechain-target-fuels/src/codegen/functions.ts
@@ -5,7 +5,7 @@ import { createPositionalIdentifier } from 'typechain';
 import type { AbiParameter, FunctionDeclaration, FunctionDocumentation } from '../parser/abiParser';
 import { getSignatureForFn } from '../utils';
 
-import { generateInputType, generateInputTypes } from './types';
+import { generateInputType, generateInputTypes, generateOutputTypes } from './types';
 
 interface GenerateFunctionOptions {
   returnResultObject?: boolean;
@@ -50,7 +50,12 @@ function generateFunction(
   ${generateFunctionDocumentation(fn.documentation)}
   ${overloadedName ?? fn.name}(${generateInputTypes(fn.inputs, {
     useStructs: true,
-  })}${`overrides?: ${'Overrides & { from?: string | Promise<string> }'}`}): ${`Promise<any>`};
+  })}${`overrides?: ${'Overrides & { from?: string | Promise<string> }'}`}): ${`Promise<${generateOutputTypes(
+    fn.outputs,
+    {
+      useStructs: true,
+    }
+  )}>`};
 `;
 }
 

--- a/packages/typechain-target-fuels/src/codegen/index.ts
+++ b/packages/typechain-target-fuels/src/codegen/index.ts
@@ -18,7 +18,7 @@ import generateStruct from './structs';
  */
 export function codegenContractTypings(contract: Contract, codegenConfig: CodegenConfig): string {
   const template = `
-  import type { Interface, FunctionFragment, DecodedValue, Contract, Overrides, BigNumberish, BytesLike } from 'fuels';
+  import type { Interface, FunctionFragment, DecodedValue, Contract, Overrides, BigNumberish, BytesLike, BigNumber } from 'fuels';
   
   ${Object.values(contract.structs)
     .map((v) => generateStruct(v[0]))

--- a/packages/typechain-target-fuels/src/codegen/types.test.ts
+++ b/packages/typechain-target-fuels/src/codegen/types.test.ts
@@ -1,4 +1,4 @@
-import { generateInputType, generateOutputType } from './types';
+import { generateInputType, generateOutputType, generateOutputTypes } from './types';
 
 describe('Type codegen', () => {
   it('generates inputs from svmTypes', () => {
@@ -37,7 +37,18 @@ describe('Type codegen', () => {
           { type: { type: 'address', originalType: 'address' }, name: 'address' },
         ],
       })
-    ).toEqual('{count: BigNumberish,address: string}');
+    ).toEqual('{count: BigNumberish, address: string}');
+    expect(
+      generateInputType({
+        type: 'tuple',
+        originalType: 'barfoo',
+        structName: 'barfoo',
+        components: [
+          { type: { type: 'u8', bits: 8, originalType: 'u8' }, name: 'count' },
+          { type: { type: 'address', originalType: 'address' }, name: 'address' },
+        ],
+      })
+    ).toEqual('{count: BigNumberish, address: string}');
   });
   it('generates outputs from svmTypes', () => {
     expect(generateOutputType({ type: 'bool', originalType: 'bool' })).toEqual('boolean');
@@ -62,15 +73,38 @@ describe('Type codegen', () => {
       })
     ).toEqual('[number, number, number]');
     expect(
-      generateInputType({
+      generateOutputType({
+        type: 'tuple',
+        components: [
+          { name: 'sender', type: { type: 'b256', originalType: 'b256' } },
+          { name: 'receiver', type: { type: 'b256', originalType: 'b256' } },
+          {
+            name: 'Return2',
+            type: {
+              type: 'tuple',
+              components: [
+                { name: 'foo', type: { type: 'b256', originalType: 'b256' } },
+                { name: 'bar', type: { type: 'b256', originalType: 'b256' } },
+              ],
+              originalType: 'tuple',
+              structName: 'Return2',
+            },
+          },
+        ],
+        originalType: 'tuple',
+        structName: 'Return',
+      })
+    ).toEqual('{sender: string, receiver: string, Return2: Return2Struct}');
+    expect(
+      generateOutputType({
         type: 'tuple',
         originalType: 'barfoo',
         structName: 'barfoo',
         components: [
-          { type: { type: 'u8', bits: 8, originalType: 'u8' }, name: 'count' },
+          { type: { type: 'u32', bits: 32, originalType: 'u32' }, name: 'count' },
           { type: { type: 'address', originalType: 'address' }, name: 'address' },
         ],
       })
-    ).toEqual('{count: BigNumberish,address: string}');
+    ).toEqual('{count: BigNumber, address: string}');
   });
 });

--- a/packages/typechain-target-fuels/src/codegen/types.test.ts
+++ b/packages/typechain-target-fuels/src/codegen/types.test.ts
@@ -1,4 +1,4 @@
-import { generateInputType, generateOutputType, generateOutputTypes } from './types';
+import { generateInputType, generateOutputType } from './types';
 
 describe('Type codegen', () => {
   it('generates inputs from svmTypes', () => {

--- a/packages/typechain-target-fuels/src/parser/abiParser.ts
+++ b/packages/typechain-target-fuels/src/parser/abiParser.ts
@@ -79,9 +79,7 @@ function parseFunctionDeclaration(
 ): FunctionDeclaration {
   return {
     name: abiPiece.name,
-    inputs: abiPiece.inputs
-      .filter((i) => i.type !== '()')
-      .map((e) => parseRawAbiParameter(e, registerStruct)),
+    inputs: parseInputs(registerStruct, abiPiece.inputs),
     outputs: parseOutputs(registerStruct, abiPiece.outputs),
     documentation: getFunctionDocumentation(abiPiece, documentation),
   };
@@ -120,6 +118,17 @@ function parseRawAbiParameterType(
   return parsed;
 }
 
+/**
+ * Parses the ABI function inputs
+ */
+function parseInputs(
+  registerStruct: (struct: TupleType) => void,
+  inputs?: Array<RawAbiParameter>
+): AbiParameter[] {
+  return (inputs || [])
+    .filter((i) => i.type !== '()')
+    .map((e) => parseRawAbiParameter(e, registerStruct));
+}
 /**
  * Parses the ABI function outputs
  */
@@ -191,7 +200,7 @@ export function getFunctionDocumentation(
   abiPiece: RawAbiDefinition,
   documentation?: DocumentationResult
 ): FunctionDocumentation | undefined {
-  const docKey = `${abiPiece.name}(${abiPiece.inputs.map(({ type }) => type).join(',')})`;
+  const docKey = `${abiPiece.name}(${(abiPiece.inputs || []).map(({ type }) => type).join(',')})`;
   return documentation && documentation.methods && documentation.methods[docKey];
 }
 


### PR DESCRIPTION
### Summary

- Add support to typed return on contract methods from generated code.


#### Examples:

Before:
```
return_struct(
    arg0: BigNumberish,
    overrides?: Overrides & { from?: string | Promise<string> }
): Promise<any>;
```

With generated types:
```
type Ret0Struct = { sender: string; receiver: string; Ret1: Ret1Struct };

return_struct(
    arg0: BigNumberish,
    overrides?: Overrides & { from?: string | Promise<string> }
): Promise<Ret0Struct>;
```

closes: #179 