### PR TITLE
feat: support abi fuel types

### DIFF
--- a/packages/abi-coder/src/abi-coder.ts
+++ b/packages/abi-coder/src/abi-coder.ts
@@ -21,6 +21,7 @@ const arrayRegEx = /\[(\w+);\s*([0-9]+)\]/;
  * Used to check if type is a custom struct or enum
  */
 const structRegEx = /^(struct|enum)/;
+const tuppleRegEx = /^\((.*)\)$/;
 
 const logger = new Logger('0.0.1');
 
@@ -77,8 +78,9 @@ export default class AbiCoder {
       );
     }
 
-    if (param.type[0] === '(' && param.type[param.type.length - 1] === ')') {
-      const tupleContent = param.type.slice(1, param.type.length - 1);
+    const tupleMatch = param.type.match(tuppleRegEx);
+    if (tupleMatch !== null) {
+      const tupleContent = tupleMatch[1];
 
       return new TupleCoder(
         tupleContent.split(',').map((t) => this.getCoder({ type: t.trim() })),

--- a/packages/abi-coder/src/abi-coder.ts
+++ b/packages/abi-coder/src/abi-coder.ts
@@ -46,6 +46,7 @@ export default class AbiCoder {
         return new B256Coder('address', name);
       case 'b256':
         return new B256Coder('address', name);
+      // NOTE: this is ethers tuple - should be replaced and refactored
       case 'tuple':
         return new TupleCoder(
           (param.components || []).map((component) => this.getCoder(component)),
@@ -72,6 +73,15 @@ export default class AbiCoder {
     if (structRegEx.test(param.type) && Array.isArray(param.components)) {
       return new TupleCoder(
         param.components.map((component) => this.getCoder(component)),
+        param.type
+      );
+    }
+
+    if (param.type[0] === '(' && param.type[param.type.length - 1] === ')') {
+      const tupleContent = param.type.slice(1, param.type.length - 1);
+
+      return new TupleCoder(
+        tupleContent.split(',').map((t) => this.getCoder({ type: t.trim() })),
         param.type
       );
     }

--- a/packages/abi-coder/src/coder.test.ts
+++ b/packages/abi-coder/src/coder.test.ts
@@ -671,6 +671,114 @@ describe('AbiCoder', () => {
 
     expect(Array.from(decoded)).toEqual([BN.from(65535)]);
   });
+
+  it('encodes and decodes tuples', () => {
+    let encoded = abiCoder.encode(
+      [
+        {
+          name: 'input',
+          type: '(u64, u64)',
+          components: null,
+        },
+      ],
+      [[42, 2]]
+    );
+    expect(encoded).toEqual('0x000000000000002a0000000000000002');
+
+    let decoded = abiCoder.decode(
+      [
+        {
+          name: 'input',
+          type: '(u64, u64)',
+          components: null,
+        },
+      ],
+      encoded
+    ) as DecodedValue[];
+
+    expect(Array.from(decoded)).toEqual([[BN.from(42), BN.from(2)]]);
+
+    encoded = abiCoder.encode(
+      [
+        {
+          name: 'input',
+          type: '(u64,u64)',
+          components: null,
+        },
+      ],
+      [[42, 2]]
+    );
+    expect(encoded).toEqual('0x000000000000002a0000000000000002');
+
+    decoded = abiCoder.decode(
+      [
+        {
+          name: 'input',
+          type: '(u64,u64)',
+          components: null,
+        },
+      ],
+      encoded
+    ) as DecodedValue[];
+
+    expect(Array.from(decoded)).toEqual([[BN.from(42), BN.from(2)]]);
+  });
+
+  it('it throws errors if tuple type and input/output length do not match', () => {
+    expect(() =>
+      abiCoder.encode(
+        [
+          {
+            name: 'input',
+            type: '(u64, u64)',
+            components: null,
+          },
+        ],
+        [[42, 2, 4]]
+      )
+    ).toThrow('Types/values length mismatch');
+
+    expect(() =>
+      abiCoder.encode(
+        [
+          {
+            name: 'input',
+            type: '(u64, u64)',
+            components: null,
+          },
+        ],
+        [[]]
+      )
+    ).toThrow('Types/values length mismatch');
+
+    expect(() =>
+      abiCoder.decode(
+        [
+          {
+            name: 'input',
+            type: '(u64)',
+            components: null,
+          },
+        ],
+        '0x000000000000002a0000000000000002'
+      )
+    ).toThrow('Types/values length mismatch');
+
+    // TODO: Update to throw type/value error
+    expect(() =>
+      abiCoder.decode(
+        [
+          {
+            name: 'input',
+            type: '(u64, u64, u64)',
+            components: null,
+          },
+        ],
+        '0x000000000000002a0000000000000002'
+      )
+    ).toThrowError();
+  });
+
   it('throws an error if empty ABI has values', () => {
     expect(() =>
       abiCoder.encode(

--- a/packages/abi-coder/src/coders/tuple.ts
+++ b/packages/abi-coder/src/coders/tuple.ts
@@ -46,7 +46,7 @@ export default class TupleCoder extends Coder {
     }
 
     if (this.coders.length !== arrayValues.length) {
-      this.throwError('types/value length mismatch', { value });
+      this.throwError('Types/values length mismatch', { value });
     }
 
     return concat(this.coders.map((coder, i) => coder.encode(arrayValues[i])));


### PR DESCRIPTION
Encoding/Decoding  tuples from the ABI

e.g.

```
       {
          name: 'input',
          type: '(u64, u64)',
          components: null,
        },
```
