### PR TITLE
Add support to ABI types `struct` and `enum`

### DIFF
--- a/packages/abi-coder/src/abi-coder.ts
+++ b/packages/abi-coder/src/abi-coder.ts
@@ -17,6 +17,10 @@ import type { JsonFragmentType } from './fragments/fragment';
 
 const stringRegEx = /str\[([0-9]+)\]/;
 const arrayRegEx = /\[(\w+);\s*([0-9]+)\]/;
+/**
+ * Used to check if type is a custom struct or enum
+ */
+const structRegEx = /^(struct|enum)/;
 
 const logger = new Logger('0.0.1');
 
@@ -64,7 +68,8 @@ export default class AbiCoder {
       return new ArrayCoder(this.getCoder({ type, name: type }), parseInt(length, 10), name);
     }
 
-    if (param.type.includes('struct') && Array.isArray(param.components)) {
+    // If type starts with struct/enum we can use the TupleCoder to process it.
+    if (structRegEx.test(param.type) && Array.isArray(param.components)) {
       return new TupleCoder(
         param.components.map((component) => this.getCoder(component)),
         param.type

--- a/packages/typechain-target-fuels/src/codegen/structs.ts
+++ b/packages/typechain-target-fuels/src/codegen/structs.ts
@@ -1,7 +1,6 @@
 import type { TupleType } from '../parser/parseSvmTypes';
 
-import { STRUCT_POSTFIX } from './reserved-keywords';
-import { generateInputType } from './types';
+import { generateInputType, parseClassName } from './types';
 
 /**
  * Generates TS structs for ABI target
@@ -9,7 +8,7 @@ import { generateInputType } from './types';
 export default function generateStruct(struct: TupleType): string {
   if (struct.structName) {
     return `
-      export type ${struct.structName}${STRUCT_POSTFIX} = ${generateInputType(struct, {
+      export type ${parseClassName(struct)} = ${generateInputType(struct, {
       useStructs: false,
     })}
       `;

--- a/packages/typechain-target-fuels/src/codegen/types.test.ts
+++ b/packages/typechain-target-fuels/src/codegen/types.test.ts
@@ -49,6 +49,27 @@ describe('Type codegen', () => {
         ],
       })
     ).toEqual('{count: BigNumberish, address: string}');
+    expect(
+      generateInputType({
+        type: 'tuple',
+        components: [
+          {
+            name: 'custom',
+            type: {
+              type: 'tuple',
+              components: [
+                { name: 'foo', type: { type: 'b256', originalType: 'b256' } },
+                { name: 'bar', type: { type: 'b256', originalType: 'b256' } },
+              ],
+              originalType: 'enum MyCustom',
+              structName: 'MyCustom',
+            },
+          },
+        ],
+        originalType: 'enum Tuple',
+        structName: 'Return3',
+      })
+    ).toEqual('{custom: MyCustomEnum}');
   });
   it('generates outputs from svmTypes', () => {
     expect(generateOutputType({ type: 'bool', originalType: 'bool' })).toEqual('boolean');
@@ -106,5 +127,26 @@ describe('Type codegen', () => {
         ],
       })
     ).toEqual('{count: BigNumber, address: string}');
+    expect(
+      generateOutputType({
+        type: 'tuple',
+        components: [
+          {
+            name: 'custom',
+            type: {
+              type: 'tuple',
+              components: [
+                { name: 'foo', type: { type: 'b256', originalType: 'b256' } },
+                { name: 'bar', type: { type: 'b256', originalType: 'b256' } },
+              ],
+              originalType: 'enum MyCustom',
+              structName: 'MyCustom',
+            },
+          },
+        ],
+        originalType: 'enum Tuple',
+        structName: 'Return3',
+      })
+    ).toEqual('{custom: MyCustomEnum}');
   });
 });

--- a/packages/typechain-target-fuels/src/codegen/types.ts
+++ b/packages/typechain-target-fuels/src/codegen/types.ts
@@ -13,9 +13,10 @@ interface GenerateTypeOptions {
 
 /**
  * Parse a Type to a Valid Class name, when possible it
- * get the prefix struct name, adds it to the and of the name
- * and normalize it to achieve a name like `struct Custom` -> `CustomStruct`
- * if the type is a tuple but without struct/enum or other know prefix
+ * get the prefix struct name, adds it to the end of the name
+ * and normalize it. Ex.: `struct Custom` -> `CustomStruct`.
+ *
+ * If the type is a tuple but without struct/enum or other know prefix,
  * the class name will be postfixed with `Struct`.
  */
 export function parseClassName(type: TupleType) {

--- a/packages/typechain-target-fuels/src/codegen/types.ts
+++ b/packages/typechain-target-fuels/src/codegen/types.ts
@@ -14,7 +14,7 @@ interface GenerateTypeOptions {
 /**
  * Parse a Type to a Valid Class name, when possible it
  * get the prefix struct name, adds it to the end of the name
- * and normalize it. Ex.: `struct Custom` -> `CustomStruct`.
+ * and normalize it. Ex.: `struct Custom` -\> `CustomStruct`.
  *
  * If the type is a tuple but without struct/enum or other know prefix,
  * the class name will be postfixed with `Struct`.

--- a/packages/typechain-target-fuels/src/common.ts
+++ b/packages/typechain-target-fuels/src/common.ts
@@ -1,1 +1,2 @@
 export const FACTORY_POSTFIX = '__factory';
+export const STRUCT_DEFINITION_PREFIX = 'struct';

--- a/packages/typechain-target-fuels/src/common.ts
+++ b/packages/typechain-target-fuels/src/common.ts
@@ -1,2 +1,1 @@
 export const FACTORY_POSTFIX = '__factory';
-export const STRUCT_DEFINITION_PREFIX = 'struct';

--- a/packages/typechain-target-fuels/src/parser/abiParser.test.ts
+++ b/packages/typechain-target-fuels/src/parser/abiParser.test.ts
@@ -10,7 +10,7 @@ const ABI = [
         name: 'args',
         type: 'tuple',
         components: [
-          { name: 'reciever', type: 'b256' },
+          { name: 'receiver', type: 'b256' },
           { name: 'amount', type: 'u64' },
         ],
       },
@@ -29,7 +29,7 @@ const ABI = [
         type: 'tuple',
         components: [
           { name: 'sender', type: 'b256' },
-          { name: 'reciever', type: 'b256' },
+          { name: 'receiver', type: 'b256' },
           { name: 'amount', type: 'u64' },
         ],
       },
@@ -48,6 +48,44 @@ const ABI = [
     name: 'cancel',
     outputs: [],
     type: 'function',
+  },
+  {
+    type: 'function',
+    inputs: [
+      {
+        name: 'address_id',
+        type: 'struct Address',
+        components: [
+          {
+            name: 'value',
+            type: 'b256',
+          },
+        ],
+      },
+      {
+        name: 'asset_id',
+        type: 'struct ContractId',
+        components: [
+          {
+            name: 'value',
+            type: 'b256',
+          },
+        ],
+      },
+    ],
+    name: 'structure_method_return_structure',
+    outputs: [
+      {
+        name: '',
+        type: 'struct ContractId',
+        components: [
+          {
+            name: 'value',
+            type: 'b256',
+          },
+        ],
+      },
+    ],
   },
 ];
 
@@ -91,7 +129,7 @@ describe('ABI parser', () => {
                   type: 'tuple',
                   components: [
                     {
-                      name: 'reciever',
+                      name: 'receiver',
                       type: {
                         type: 'b256',
                         originalType: 'b256',
@@ -162,7 +200,7 @@ describe('ABI parser', () => {
                       },
                     },
                     {
-                      name: 'reciever',
+                      name: 'receiver',
                       type: {
                         type: 'b256',
                         originalType: 'b256',
@@ -231,6 +269,66 @@ describe('ABI parser', () => {
             ],
           },
         ],
+        structure_method_return_structure: [
+          {
+            name: 'structure_method_return_structure',
+            inputs: [
+              {
+                name: 'address_id',
+                type: {
+                  type: 'tuple',
+                  components: [
+                    {
+                      name: 'value',
+                      type: {
+                        type: 'b256',
+                        originalType: 'b256',
+                      },
+                    },
+                  ],
+                  originalType: 'struct Address',
+                  structName: 'Address',
+                },
+              },
+              {
+                name: 'asset_id',
+                type: {
+                  type: 'tuple',
+                  components: [
+                    {
+                      name: 'value',
+                      type: {
+                        type: 'b256',
+                        originalType: 'b256',
+                      },
+                    },
+                  ],
+                  originalType: 'struct ContractId',
+                  structName: 'ContractId',
+                },
+              },
+            ],
+            outputs: [
+              {
+                name: '',
+                type: {
+                  type: 'tuple',
+                  components: [
+                    {
+                      name: 'value',
+                      type: {
+                        type: 'b256',
+                        originalType: 'b256',
+                      },
+                    },
+                  ],
+                  originalType: 'struct ContractId',
+                  structName: 'ContractId',
+                },
+              },
+            ],
+          },
+        ],
       },
       structs: {
         Args: [
@@ -238,7 +336,7 @@ describe('ABI parser', () => {
             type: 'tuple',
             components: [
               {
-                name: 'reciever',
+                name: 'receiver',
                 type: {
                   type: 'b256',
                   originalType: 'b256',
@@ -255,6 +353,38 @@ describe('ABI parser', () => {
             ],
             originalType: 'tuple',
             structName: 'Args',
+          },
+        ],
+        Address: [
+          {
+            type: 'tuple',
+            components: [
+              {
+                name: 'value',
+                type: {
+                  type: 'b256',
+                  originalType: 'b256',
+                },
+              },
+            ],
+            originalType: 'struct Address',
+            structName: 'Address',
+          },
+        ],
+        ContractId: [
+          {
+            type: 'tuple',
+            components: [
+              {
+                name: 'value',
+                type: {
+                  type: 'b256',
+                  originalType: 'b256',
+                },
+              },
+            ],
+            originalType: 'struct ContractId',
+            structName: 'ContractId',
           },
         ],
       },

--- a/packages/typechain-target-fuels/src/parser/abiParser.test.ts
+++ b/packages/typechain-target-fuels/src/parser/abiParser.test.ts
@@ -87,6 +87,52 @@ const ABI = [
       },
     ],
   },
+  {
+    type: 'function',
+    inputs: [
+      {
+        name: 'params',
+        type: 'enum Params',
+        components: [
+          {
+            name: 'x',
+            type: 'u32',
+          },
+          {
+            name: 'y',
+            type: 'u32',
+          },
+        ],
+      },
+      {
+        name: 'asset_id',
+        type: 'struct ContractId',
+        components: [
+          {
+            name: 'value',
+            type: 'b256',
+          },
+        ],
+      },
+    ],
+    name: 'enum_method_return_enum',
+    outputs: [
+      {
+        name: '',
+        type: 'enum Params',
+        components: [
+          {
+            name: 'x',
+            type: 'u32',
+          },
+          {
+            name: 'y',
+            type: 'u32',
+          },
+        ],
+      },
+    ],
+  },
 ];
 
 describe('ABI parser', () => {
@@ -329,6 +375,84 @@ describe('ABI parser', () => {
             ],
           },
         ],
+        enum_method_return_enum: [
+          {
+            name: 'enum_method_return_enum',
+            inputs: [
+              {
+                name: 'params',
+                type: {
+                  type: 'tuple',
+                  components: [
+                    {
+                      name: 'x',
+                      type: {
+                        type: 'u32',
+                        bits: 32,
+                        originalType: 'u32',
+                      },
+                    },
+                    {
+                      name: 'y',
+                      type: {
+                        type: 'u32',
+                        bits: 32,
+                        originalType: 'u32',
+                      },
+                    },
+                  ],
+                  originalType: 'enum Params',
+                  structName: 'Params',
+                },
+              },
+              {
+                name: 'asset_id',
+                type: {
+                  type: 'tuple',
+                  components: [
+                    {
+                      name: 'value',
+                      type: {
+                        type: 'b256',
+                        originalType: 'b256',
+                      },
+                    },
+                  ],
+                  originalType: 'struct ContractId',
+                  structName: 'ContractId',
+                },
+              },
+            ],
+            outputs: [
+              {
+                name: '',
+                type: {
+                  type: 'tuple',
+                  components: [
+                    {
+                      name: 'x',
+                      type: {
+                        type: 'u32',
+                        bits: 32,
+                        originalType: 'u32',
+                      },
+                    },
+                    {
+                      name: 'y',
+                      type: {
+                        type: 'u32',
+                        bits: 32,
+                        originalType: 'u32',
+                      },
+                    },
+                  ],
+                  originalType: 'enum Params',
+                  structName: 'Params',
+                },
+              },
+            ],
+          },
+        ],
       },
       structs: {
         Args: [
@@ -385,6 +509,31 @@ describe('ABI parser', () => {
             ],
             originalType: 'struct ContractId',
             structName: 'ContractId',
+          },
+        ],
+        Params: [
+          {
+            type: 'tuple',
+            components: [
+              {
+                name: 'x',
+                type: {
+                  type: 'u32',
+                  bits: 32,
+                  originalType: 'u32',
+                },
+              },
+              {
+                name: 'y',
+                type: {
+                  type: 'u32',
+                  bits: 32,
+                  originalType: 'u32',
+                },
+              },
+            ],
+            originalType: 'enum Params',
+            structName: 'Params',
           },
         ],
       },

--- a/packages/typechain-target-fuels/src/parser/abiParser.ts
+++ b/packages/typechain-target-fuels/src/parser/abiParser.ts
@@ -13,6 +13,7 @@ export interface AbiParameter {
 export interface AbiOutputParameter {
   name: string;
   type: SvmOutputType;
+  components?: AbiOutputParameter[];
 }
 export declare type Named<T> = {
   name: string;
@@ -139,7 +140,8 @@ function parseOutputs(
   if (!outputs || outputs.length === 0) {
     return [{ name: '', type: { type: 'void' } }];
   }
-  return outputs.map((e) => parseRawAbiParameter(e, registerStruct));
+
+  return outputs.filter((i) => i.type !== '()').map((e) => parseRawAbiParameter(e, registerStruct));
 }
 /**
  * Parses the JSON abi

--- a/packages/typechain-target-fuels/src/parser/parseSvmTypes.test.ts
+++ b/packages/typechain-target-fuels/src/parser/parseSvmTypes.test.ts
@@ -21,5 +21,33 @@ describe('parseSvmTypes', () => {
       structName: 'Foobar',
       components: [{ name: 'sender', type: { type: 'u8', bits: 8, originalType: 'u8' } }],
     });
+    expect(
+      parseSvmType('struct MyParams', [
+        { name: 'foo', type: { type: 'u8', bits: 8, originalType: 'u8' } },
+        { name: 'bar', type: { type: 'u8', bits: 8, originalType: 'u8' } },
+      ])
+    ).toEqual({
+      type: 'tuple',
+      originalType: 'struct MyParams',
+      structName: 'MyParams',
+      components: [
+        { name: 'foo', type: { type: 'u8', bits: 8, originalType: 'u8' } },
+        { name: 'bar', type: { type: 'u8', bits: 8, originalType: 'u8' } },
+      ],
+    });
+    expect(
+      parseSvmType('enum MyParams', [
+        { name: 'foo', type: { type: 'u8', bits: 8, originalType: 'u8' } },
+        { name: 'bar', type: { type: 'u8', bits: 8, originalType: 'u8' } },
+      ])
+    ).toEqual({
+      type: 'tuple',
+      originalType: 'enum MyParams',
+      structName: 'MyParams',
+      components: [
+        { name: 'foo', type: { type: 'u8', bits: 8, originalType: 'u8' } },
+        { name: 'bar', type: { type: 'u8', bits: 8, originalType: 'u8' } },
+      ],
+    });
   });
 });

--- a/packages/typechain-target-fuels/src/parser/parseSvmTypes.ts
+++ b/packages/typechain-target-fuels/src/parser/parseSvmTypes.ts
@@ -1,5 +1,3 @@
-import { STRUCT_DEFINITION_PREFIX } from '../common';
-
 export declare type SvmType =
   | BoolType
   | U8intType
@@ -88,6 +86,10 @@ export declare type SvmSymbol = {
 
 const stringRegEx = /str\[([0-9]+)\]/;
 const arrayRegEx = /\[(\w+);\s*([0-9]+)\]/;
+/**
+ * Used to check if type is a custom struct
+ */
+const structRegEx = /^(struct|enum)/;
 
 /**
  * Converts valid file names to valid javascript symbols and does best effort to make them readable.
@@ -140,18 +142,17 @@ export function parseSvmType(rawType: string, components?: SvmSymbol[], name?: s
     };
   }
 
-  // Check if type starts with struct we can treat it safely as a tuple
-  // This makes the parser happy and the output works is created as
-  // expected
-  if (rawType.startsWith(STRUCT_DEFINITION_PREFIX)) {
-    if (!components) throw new Error('Tuple specified without components!');
+  // If type starts with struct/enum we can treat it as tuple.
+  // In this way, the parser can process all components from the struct.
+  if (structRegEx.test(rawType)) {
+    if (!components) throw new Error(`${rawType} specified without components!`);
     return {
       type: 'tuple',
       components,
       originalType: rawType,
       // Remove struct prefix enabling the code parser
       // To create a Class with the structName
-      structName: rawType.replace(STRUCT_DEFINITION_PREFIX, '').trim(),
+      structName: rawType.replace(structRegEx, '').trim(),
     };
   }
 

--- a/packages/typechain-target-fuels/src/parser/parseSvmTypes.ts
+++ b/packages/typechain-target-fuels/src/parser/parseSvmTypes.ts
@@ -1,3 +1,5 @@
+import { STRUCT_DEFINITION_PREFIX } from '../common';
+
 export declare type SvmType =
   | BoolType
   | U8intType
@@ -135,6 +137,21 @@ export function parseSvmType(rawType: string, components?: SvmSymbol[], name?: s
       itemType: parseSvmType(type, components),
       size: parseInt(length, 10),
       originalType: rawType,
+    };
+  }
+
+  // Check if type starts with struct we can treat it safely as a tuple
+  // This makes the parser happy and the output works is created as
+  // expected
+  if (rawType.startsWith(STRUCT_DEFINITION_PREFIX)) {
+    if (!components) throw new Error('Tuple specified without components!');
+    return {
+      type: 'tuple',
+      components,
+      originalType: rawType,
+      // Remove struct prefix enabling the code parser
+      // To create a Class with the structName
+      structName: rawType.replace(STRUCT_DEFINITION_PREFIX, '').trim(),
     };
   }
 


### PR DESCRIPTION
## Summary
- Add support to custom types like `struct` and `enum` on the `typechain`.
- Add support to struct and enum on `ABI Coder`

## Example

Contract ABI
```rust
    fn foo(address_id: Address, asset_id: ContractId) -> Address;
    fn bar(sum_params: MySumType) -> MySumType;
```

Without custom struct;
```ts
foo(
  address_id: any,
  asset_id: any,
  overrides?: Overrides & { from?: string | Promise<string> }
): Promise<any>;
bar(
  sum_params: any,
  overrides?: Overrides & { from?: string | Promise<string> }
): Promise<any>;
```

With custom struct;
```ts
export type ContractIdStruct = { value: string };

export type AddressStruct = { value: string };

export type MySumTypeStruct = { x: BigNumberish; y: BigNumberish };

foo(
  address_id: AddressStruct,
  asset_id: ContractIdStruct,
  overrides?: Overrides & { from?: string | Promise<string> }
): Promise<AddressStruct>;
bar(
  sum_params: MySumTypeEnum,
  overrides?: Overrides & { from?: string | Promise<string> }
): Promise<MySumTypeStruct>;
```

closes: #18 