### PR TITLE
feat: adds transformRequest method on contract call

### DIFF
--- a/packages/contract/src/call-test-contract/call-test-contract.test.ts
+++ b/packages/contract/src/call-test-contract/call-test-contract.test.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import type { Interface, JsonFragment } from '@fuel-ts/abi-coder';
 import { NativeAssetId } from '@fuel-ts/constants';
+import type { ScriptTransactionRequest } from '@fuel-ts/providers';
 import { Provider } from '@fuel-ts/providers';
 import { Wallet } from '@fuel-ts/wallet';
 import { seedWallet } from '@fuel-ts/wallet/dist/test-utils';
@@ -187,5 +188,32 @@ describe('TestContractTwo', () => {
       assetId,
     });
     expect(result).toBe(assetId);
+  });
+
+  it('Test if transformRequest is called before sendTransaction', async () => {
+    const contract = await setup([
+      {
+        type: 'function',
+        name: 'return_context_asset',
+        outputs: [
+          {
+            type: 'b256',
+          },
+        ],
+      },
+    ]);
+    const assetId = '0x0101010101010101010101010101010101010101010101010101010101010101';
+    const methods = {
+      transformRequest: async (request: ScriptTransactionRequest) => request,
+    };
+    const spyTransformRequest = jest.spyOn(methods, 'transformRequest');
+
+    await contract.functions.return_context_asset({
+      amount: 0,
+      assetId,
+      transformRequest: methods.transformRequest,
+    });
+
+    expect(spyTransformRequest).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Summary

When calling a contract sometimes we need to change the request, add inputs/outputs, or other things. To make easier to access it before submitting/calling a contract we add a `tranformRequest`. This follow API implementations commons on other request libs like Axios.

### Example
```ts
await contract.functions.return_context_asset({
      amount: 0,
      assetId: '0x000...000',
      transformRequest: (request: ScriptTransactionRequest) => {
          request.inputs = [];
          request.outputs = [];
          return request;
      },
});
```