### PR TITLE
feat: replace `amount`/`assetId` overrides with `forward`

### DIFF
--- a/packages/contract/src/call-test-contract/call-test-contract.test.ts
+++ b/packages/contract/src/call-test-contract/call-test-contract.test.ts
@@ -163,8 +163,7 @@ describe('TestContractTwo', () => {
       },
     ]);
     const result = await contract.functions.return_context_amount({
-      amount: 1_000_000,
-      asset_id: NativeAssetId,
+      forward: [1_000_000, NativeAssetId],
     });
     expect(BigNumber.from(result).toNumber()).toBe(1_000_000);
   });
@@ -184,8 +183,7 @@ describe('TestContractTwo', () => {
 
     const assetId = '0x0101010101010101010101010101010101010101010101010101010101010101';
     const result = await contract.functions.return_context_asset({
-      amount: 0,
-      assetId,
+      forward: [0, assetId],
     });
     expect(result).toBe(assetId);
   });
@@ -209,8 +207,7 @@ describe('TestContractTwo', () => {
     const spyTransformRequest = jest.spyOn(methods, 'transformRequest');
 
     await contract.functions.return_context_asset({
-      amount: 0,
-      assetId,
+      forward: [0, assetId],
       transformRequest: methods.transformRequest,
     });
 


### PR DESCRIPTION
This PR replaces the current way of forwarding coins to a contract call from the `amount`/`assetId` override combo to a single `forward` property.

Another change is that when you call a contract using `forward`, the SDK will automatically get coins from the wallet so:
- You don't have to call `getCoinsToSpend` and manually insert coins.
- Both this new functionality and the current txn funding mechanism uses a single `getCoinsToSpend` call so https://github.com/FuelLabs/fuels-ts/issues/229 is fixed as a side effect.

```ts
// Before
await contract.functions.<method>({
        assetId: '0x0000....0000',
        amount: 1_000_000,
        transformRequest: async (request) => {
          // Remove all previous inputs with the same coin
          request.inputs = request.inputs.filter(i => {
            return !(i.type === InputType.Coin && i.assetId === coinFrom.assetId);
          });
          const coins = await wallet.getCoinsToSpend([[1_500_000, '0x0000....0000']]);
          request.addCoins(coins);
          // Now request has no duplicated inputs
          return request;
        },
});

// After
await contract.functions.<method>({
        forward: [1_000_000, '0x0000....0000'],
});
```