### PR TITLE
feat!: upgrade to fuel-core 0.6.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   fuel-core:
     build: ./services/fuel-core
-    # image: ghcr.io/fuellabs/fuel-core:v0.3.2
+    # image: ghcr.io/fuellabs/fuel-core:v0.6.3
     ports:
       - "4000:4000"
     volumes:

--- a/packages/providers/src/provider.test.ts
+++ b/packages/providers/src/provider.test.ts
@@ -13,7 +13,7 @@ describe('Provider', () => {
 
     const version = await provider.getVersion();
 
-    expect(version).toEqual('0.5.0');
+    expect(version).toEqual('0.6.3');
   });
 
   it('can call()', async () => {

--- a/packages/wallet/src/transfer.test.ts
+++ b/packages/wallet/src/transfer.test.ts
@@ -8,11 +8,13 @@ describe('Wallet', () => {
   it('can transfer a single type of coin to a single destination', async () => {
     const provider = new Provider('http://127.0.0.1:4000/graphql');
 
-    const sender = await generateTestWallet(provider, [[1, NativeAssetId]]);
+    const sender = await generateTestWallet(provider, [[100, NativeAssetId]]);
     const receiver = await generateTestWallet(provider);
 
     await sender.transfer(receiver.address, 1, NativeAssetId);
 
+    const senderBalances = await sender.getBalances();
+    expect(senderBalances).toEqual([{ assetId: NativeAssetId, amount: BigNumber.from(99) }]);
     const receiverBalances = await receiver.getBalances();
     expect(receiverBalances).toEqual([{ assetId: NativeAssetId, amount: BigNumber.from(1) }]);
   });

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -175,12 +175,14 @@ export default class Wallet extends AbstractWallet {
     /** Asset ID of coins */
     assetId: BytesLike = NativeAssetId
   ): Promise<TransactionResponse> {
-    const coins = await this.getCoinsToSpend([{ assetId, amount }]);
-
     const request = new ScriptTransactionRequest({ gasLimit: 1000000 });
-    request.addCoins(coins);
     request.addCoinOutput(destination, amount, assetId);
-    await this.fund(request);
+    const feeAmount = request.calculateFee();
+    const coins = await this.getCoinsToSpend([
+      [amount, assetId],
+      [feeAmount, NativeAssetId],
+    ]);
+    request.addCoins(coins);
 
     return this.sendTransaction(request);
   }

--- a/services/fuel-core/Dockerfile
+++ b/services/fuel-core/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/fuellabs/fuel-core:v0.5.0
+FROM ghcr.io/fuellabs/fuel-core:v0.6.3
 
 ARG IP=0.0.0.0
 ARG PORT=4000


### PR DESCRIPTION
A smooth upgrade besides the "duplicate UTXO" error I got on a transfer test. Reducing `coinsToSpend` calls to one solved the issue.