### PR TITLE
fix: change build tasks in order to use pnpm link correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ const contract = MyContract__factory.connect(contractId, provider);
 git clone git@github.com:FuelLabs/fuels-ts.git
 cd fuels-ts
 pnpm install
+pnpm build
 ```
 
 ### Testing
@@ -136,6 +137,33 @@ This will run `services:run`, `tests` and then `services:clean`
 > Some times if you're running your tests locally using `services:run` in a separated terminal,
 > maybe you need to run `services:clean` after tests to clean docker containers and volumes. Because
 > this can break your tests sometimes!
+
+## Build and watch all packages
+
+If you want to work locally using realtime builds, open in one terminal tab build in watch mode
+on all packages from the root directory:
+
+```sh
+$ pnpm build:watch
+```
+
+This command you run `tsup --watch` on all packages using Turborepo
+
+### Local links using `pnpm link`
+
+If you want to use local links for development purposes, you can execute this command in the root
+of the directory:
+
+```sh
+$ pnpm -r exec pnpm link --global --dir ./
+```
+
+This will link all packages inside our monorepo in your global pnpm store, then iside the package
+you want to use the linked package, just run:
+
+```sh
+$ pnpm link --global <pkg-name>
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
+    "build:watch": "turbo run build --parallel -- --watch",
     "ci:test": "run-s services:run test services:clean",
     "ci:test-coverage": "run-s services:run test:coverage services:clean",
     "test": "jest",

--- a/packages/abi-coder/package.json
+++ b/packages/abi-coder/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/abi-coder/package.json
+++ b/packages/abi-coder/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -4,17 +4,14 @@
   "description": "Sha256 hash utility for Fuel",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "./src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/hdwallet/package.json
+++ b/packages/hdwallet/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/hdwallet/package.json
+++ b/packages/hdwallet/package.json
@@ -4,17 +4,14 @@
   "description": "The Hierarchal Desterministic (HD) Wallet",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "./src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/keystore/package.json
+++ b/packages/keystore/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/keystore/package.json
+++ b/packages/keystore/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "./index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/merkle-shared/package.json
+++ b/packages/merkle-shared/package.json
@@ -6,13 +6,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/merkle-shared/package.json
+++ b/packages/merkle-shared/package.json
@@ -3,17 +3,14 @@
   "version": "0.6.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/merkle/package.json
+++ b/packages/merkle/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/merkle/package.json
+++ b/packages/merkle/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/merklesum/package.json
+++ b/packages/merklesum/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/merklesum/package.json
+++ b/packages/merklesum/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/mnemonic/package.json
+++ b/packages/mnemonic/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/mnemonic/package.json
+++ b/packages/mnemonic/package.json
@@ -4,17 +4,14 @@
   "description": "Mnemonic implementation from BIP39",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "./src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "./src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -4,17 +4,14 @@
   "description": "Secp256k1 signer for the Fuel Network",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "./src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/sparsemerkle/package.json
+++ b/packages/sparsemerkle/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/sparsemerkle/package.json
+++ b/packages/sparsemerkle/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "./src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/typechain-target-fuels/package.json
+++ b/packages/typechain-target-fuels/package.json
@@ -5,13 +5,13 @@
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.mjs.js",
+  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "default": "./dist/index.mjs.js"
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/wallet-manager/package.json
+++ b/packages/wallet-manager/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/wallet-manager/package.json
+++ b/packages/wallet-manager/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "./src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -7,13 +7,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -4,17 +4,14 @@
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "./src/index.ts",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/wordlists/package.json
+++ b/packages/wordlists/package.json
@@ -6,13 +6,13 @@
   "main": "src/index.ts",
   "publishConfig": {
     "main": "dist/index.js",
-    "module": "dist/index.mjs.js",
+    "module": "dist/index.mjs",
     "types": "dist/index.d.ts",
     "typings": "dist/index.d.ts",
     "exports": {
       ".": {
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs.js"
+        "default": "./dist/index.mjs"
       }
     }
   },

--- a/packages/wordlists/package.json
+++ b/packages/wordlists/package.json
@@ -3,17 +3,14 @@
   "version": "0.6.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
-  "main": "src/index.ts",
-  "publishConfig": {
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "types": "dist/index.d.ts",
-    "typings": "dist/index.d.ts",
-    "exports": {
-      ".": {
-        "require": "./dist/index.js",
-        "default": "./dist/index.mjs"
-      }
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
+link-workspace-packages: deep
 packages:
   - "packages/*"


### PR DESCRIPTION
## Description 

This pull request intends to change our environment in order to be able to use `pnpm link` correctly.

After talking with @luizstacio we tried to keep the direct import in all `package.json` by using the `publishConfig`, but we notice that if you link some package to the global pnpm store, it'll keep the same `package.json` that uses the `main` field pointing to the Typescript file. This is bad if you trying to use the linked package with some bundler (vite, react-scripts, etc) because the bundler won't handle loaders to bundle outside the package directory, and by consuming `index.ts` file this is needed.

So, we change to instead of consuming direct inside our monorepo, we need to build/watch and have all `package.json` field pointing to the same publish config. It's an annoying trade-off, but by now is the only way to work.

I'll open an issue on PNPM repository in order to check if is possible to run this scenário.

## Main Changes

- Now for work inside our monorepo, we need to run in the root directory:

```sh
$ pnpm build:watch
```

This is specified in our README as well.
