### PR TITLE
Improve Script Error Reporting

### DIFF
--- a/packages/contract/src/contract.ts
+++ b/packages/contract/src/contract.ts
@@ -105,7 +105,7 @@ const buildCall = (contract: Contract, func: FunctionFragment): ContractFunction
 
     const request = await buildTransaction(contract, func, args);
     const result = await contract.provider.call(request);
-    const encodedResult = contractCallScript.decodeScriptResult(result);
+    const encodedResult = contractCallScript.decodeCallResult(result);
     const returnValue = contract.interface.decodeFunctionResult(func, encodedResult)[0];
 
     return returnValue;
@@ -121,8 +121,8 @@ const buildSubmit = (contract: Contract, func: FunctionFragment): ContractFuncti
       fundTransaction: true,
     });
     const response = await contract.wallet.sendTransaction(request);
-    const result = await response.wait();
-    const encodedResult = contractCallScript.decodeScriptResult(result);
+    const result = await response.waitForResult();
+    const encodedResult = contractCallScript.decodeCallResult(result);
     const returnValue = contract.interface.decodeFunctionResult(func, encodedResult)?.[0];
 
     return returnValue;

--- a/packages/contract/src/scripts.ts
+++ b/packages/contract/src/scripts.ts
@@ -78,22 +78,24 @@ export const contractCallScript = new Script<
     );
   },
   (result) => {
-    if (result.receipts.length < 3) {
-      throw new Error('Expected at least 3 receipts');
+    if (result.code !== 0n) {
+      throw new Error(`Script returned non-zero result: ${result.code}`);
     }
-    const returnReceipt = result.receipts[result.receipts.length - 3];
-    switch (returnReceipt.type) {
+    const contractReturnReceipt = result.receipts.pop();
+    if (!contractReturnReceipt) {
+      throw new Error(`Expected contractReturnReceipt`);
+    }
+    switch (contractReturnReceipt.type) {
       case ReceiptType.Return: {
         // The receipt doesn't have the expected encoding, so encode it manually
-        const returnValue = new NumberCoder('', 'u64').encode(returnReceipt.val);
-
+        const returnValue = new NumberCoder('', 'u64').encode(contractReturnReceipt.val);
         return returnValue;
       }
       case ReceiptType.ReturnData: {
-        return arrayify(returnReceipt.data);
+        return arrayify(contractReturnReceipt.data);
       }
       default: {
-        throw new Error('Invalid receipt type');
+        throw new Error(`Invalid contractReturnReceipt type: ${contractReturnReceipt.type}`);
       }
     }
   }

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -8,6 +8,7 @@ export * from './coin';
 export * from './provider';
 export { default as Provider } from './provider';
 export * from './transaction-request';
+export * from './transaction-response';
 export * from './script';
 export * from './scripts';
 export * from './util';

--- a/packages/providers/src/script.ts
+++ b/packages/providers/src/script.ts
@@ -1,8 +1,17 @@
+/* eslint-disable max-classes-per-file */
 // TODO: Move this file out of this package
 import type { BytesLike } from '@ethersproject/bytes';
 import { arrayify } from '@ethersproject/bytes';
+import type {
+  ReceiptReturn,
+  ReceiptReturnData,
+  ReceiptRevert,
+  ReceiptScriptResult,
+} from '@fuel-ts/transactions';
+import { ReceiptType } from '@fuel-ts/transactions';
 
 import type { CallResult } from './provider';
+import type { TransactionResultReceipt } from './transaction-response';
 
 // TODO: Source these from other packages
 const VM_TX_MEMORY = 10240;
@@ -12,19 +21,85 @@ const CONTRACT_ID_LEN = 32;
 const ASSET_ID_LEN = 32;
 const AMOUNT_LEN = 8;
 
-export class Script<TScriptData = void, TScriptResult = void> {
+const bigintReplacer = (key: unknown, value: unknown) =>
+  typeof value === 'bigint' ? value.toString() : value;
+
+class ScriptResultDecoderError extends Error {
+  constructor(result: CallResult, message: string) {
+    const revertReceipts = result.receipts.filter(
+      (r) => r.type === ReceiptType.Revert
+    ) as ReceiptRevert[];
+    const revertsText = revertReceipts.length
+      ? `Reverts:\n${revertReceipts
+          .map(({ type, id, ...r }) => `${id}: ${JSON.stringify(r, bigintReplacer)}`)
+          .join('\n')}`
+      : null;
+    const receiptsText = `Receipts:\n${JSON.stringify(
+      result.receipts.map(({ type, ...r }) => ({ type: ReceiptType[type], ...r })),
+      bigintReplacer,
+      2
+    )}`;
+    super(`${message}\n\n${revertsText ? `${revertsText}\n\n` : ''}${receiptsText}`);
+  }
+}
+
+export type ScriptResult = {
+  code: bigint;
+  gasUsed: bigint;
+  receipts: TransactionResultReceipt[];
+  scriptResultReceipt: ReceiptScriptResult;
+  returnReceipt: ReceiptReturn | ReceiptReturnData | ReceiptRevert;
+  callResult: CallResult;
+};
+
+function callResultToScriptResult(callResult: CallResult): ScriptResult {
+  const receipts = [...callResult.receipts];
+
+  // Every script call ends with two specific receipts
+  // Here we check them so `this.scriptResultDecoder` doesn't have to
+  const scriptResultReceipt = receipts.pop();
+  if (!scriptResultReceipt) {
+    throw new Error(`Expected scriptResultReceipt`);
+  }
+  if (scriptResultReceipt.type !== ReceiptType.ScriptResult) {
+    throw new Error(`Invalid scriptResultReceipt type: ${scriptResultReceipt.type}`);
+  }
+  const returnReceipt = receipts.pop();
+  if (!returnReceipt) {
+    throw new Error(`Expected returnReceipt`);
+  }
+  if (
+    returnReceipt.type !== ReceiptType.Return &&
+    returnReceipt.type !== ReceiptType.ReturnData &&
+    returnReceipt.type !== ReceiptType.Revert
+  ) {
+    throw new Error(`Invalid returnReceipt type: ${returnReceipt.type}`);
+  }
+
+  const scriptResult = {
+    code: scriptResultReceipt.result,
+    gasUsed: scriptResultReceipt.gasUsed,
+    receipts,
+    scriptResultReceipt,
+    returnReceipt,
+    callResult,
+  };
+
+  return scriptResult;
+}
+export class Script<TData = void, TResult = void> {
   bytes: Uint8Array;
-  encodeScriptData: (data: TScriptData) => Uint8Array;
-  decodeScriptResult: (result: CallResult) => TScriptResult;
+  scriptDataEncoder: (data: TData) => Uint8Array;
+  scriptResultDecoder: (scriptResult: ScriptResult) => TResult;
 
   constructor(
     bytes: BytesLike,
-    encodeScriptData: (data: TScriptData) => Uint8Array,
-    decodeScriptResult: (result: CallResult) => TScriptResult
+    scriptDataEncoder: (data: TData) => Uint8Array,
+    scriptResultDecoder: (scriptResult: ScriptResult) => TResult
   ) {
     this.bytes = arrayify(bytes);
-    this.encodeScriptData = encodeScriptData;
-    this.decodeScriptResult = decodeScriptResult;
+    this.scriptDataEncoder = scriptDataEncoder;
+    this.scriptResultDecoder = scriptResultDecoder;
   }
 
   getScriptDataOffset() {
@@ -39,5 +114,25 @@ export class Script<TScriptData = void, TScriptResult = void> {
    */
   getArgOffset() {
     return this.getScriptDataOffset() + CONTRACT_ID_LEN + 2 * WORD_SIZE;
+  }
+
+  /**
+   * Encodes the data for a script call
+   */
+  encodeScriptData(data: TData): Uint8Array {
+    return this.scriptDataEncoder(data);
+  }
+
+  /**
+   * Decodes the result of a script call
+   */
+  decodeCallResult(callResult: CallResult): TResult {
+    try {
+      const scriptResult = callResultToScriptResult(callResult);
+      const decoded = this.scriptResultDecoder(scriptResult);
+      return decoded;
+    } catch (error) {
+      throw new ScriptResultDecoderError(callResult, (error as Error).message);
+    }
   }
 }

--- a/packages/providers/src/transaction-response/index.ts
+++ b/packages/providers/src/transaction-response/index.ts
@@ -1,0 +1,1 @@
+export * from './transaction-response';

--- a/packages/providers/src/transaction-response/transaction-response.ts
+++ b/packages/providers/src/transaction-response/transaction-response.ts
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { arrayify } from '@ethersproject/bytes';
+import type {
+  ReceiptCall,
+  ReceiptLog,
+  ReceiptLogData,
+  ReceiptPanic,
+  ReceiptReturn,
+  ReceiptReturnData,
+  ReceiptRevert,
+  ReceiptTransfer,
+  ReceiptTransferOut,
+  ReceiptScriptResult,
+} from '@fuel-ts/transactions';
+import { ReceiptType, ReceiptCoder } from '@fuel-ts/transactions';
+
+import type {
+  GqlGetTransactionWithReceiptsQuery,
+  GqlReceiptFragmentFragment,
+} from '../__generated__/operations';
+import type Provider from '../provider';
+import type { TransactionRequest } from '../transaction-request';
+
+export type TransactionResultReceipt =
+  | ReceiptCall
+  | ReceiptReturn
+  | (ReceiptReturnData & { data: string })
+  | ReceiptPanic
+  | ReceiptRevert
+  | ReceiptLog
+  | (ReceiptLogData & { data: string })
+  | ReceiptTransfer
+  | ReceiptTransferOut
+  | ReceiptScriptResult;
+
+export type TransactionResult<TStatus extends 'success' | 'failure'> = {
+  status: TStatus extends 'success'
+    ? { type: 'success'; programState: any }
+    : { type: 'failure'; reason: any };
+  /** Receipts produced during the execution of the transaction */
+  receipts: TransactionResultReceipt[];
+  blockId: any;
+  time: any;
+};
+
+const processGqlReceipt = (gqlReceipt: GqlReceiptFragmentFragment): TransactionResultReceipt => {
+  const receipt = new ReceiptCoder('receipt').decode(arrayify(gqlReceipt.rawPayload), 0)[0];
+
+  switch (receipt.type) {
+    case ReceiptType.ReturnData: {
+      return {
+        ...receipt,
+        data: gqlReceipt.data!,
+      };
+    }
+    case ReceiptType.LogData: {
+      return {
+        ...receipt,
+        data: gqlReceipt.data!,
+      };
+    }
+    default:
+      return receipt;
+  }
+};
+
+export class TransactionResponse {
+  /** Transaction ID */
+  id: string;
+  /** Transaction request */
+  request: TransactionRequest;
+  provider: Provider;
+
+  constructor(id: string, request: TransactionRequest, provider: Provider) {
+    this.id = id;
+    this.request = request;
+    this.provider = provider;
+  }
+
+  async #fetch(): Promise<NonNullable<GqlGetTransactionWithReceiptsQuery['transaction']>> {
+    const { transaction } = await this.provider.operations.getTransactionWithReceipts({
+      transactionId: this.id,
+    });
+    if (!transaction) {
+      throw new Error('No Transaction was received from the client.');
+    }
+    return transaction;
+  }
+
+  /** Waits for transaction to succeed or fail and returns the result */
+  async waitForResult(): Promise<TransactionResult<any>> {
+    const transaction = await this.#fetch();
+
+    switch (transaction.status?.type) {
+      case 'SubmittedStatus': {
+        // TODO: Implement polling or GQL subscription
+        throw new Error('Not yet implemented');
+      }
+      case 'FailureStatus': {
+        return {
+          status: { type: 'failure', reason: transaction.status.reason },
+          receipts: transaction.receipts!.map(processGqlReceipt),
+          blockId: transaction.status.block.id,
+          time: transaction.status.time,
+        };
+      }
+      case 'SuccessStatus': {
+        return {
+          status: { type: 'success', programState: transaction.status.programState },
+          receipts: transaction.receipts!.map(processGqlReceipt),
+          blockId: transaction.status.block.id,
+          time: transaction.status.time,
+        };
+      }
+      default: {
+        throw new Error('Invalid Transaction status');
+      }
+    }
+  }
+
+  /** Waits for transaction to succeed and returns the result */
+  async wait(): Promise<TransactionResult<'success'>> {
+    const result = await this.waitForResult();
+
+    if (result.status.type === 'failure') {
+      throw new Error(`Transaction failed: ${result.status.reason}`);
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
[feat: improve TransactionResponse](https://github.com/FuelLabs/fuels-ts/pull/271/commits/782c4f3105a33935c47f24547f67aea3f26bb168)

- Extracts `TransactionResponse` from `provider.ts` into its own file.
- Adds `TransactionResponse.waitForResult()` which doesn't throw on failure so you can do your own error handling.

[feat: improve Script error handling](https://github.com/FuelLabs/fuels-ts/pull/271/commits/fb0f3c6b1ce89cbb98ad262641085875d84b7d88)

- Uses the new `waitForResult` to do better error reporting

Before:
![image](https://user-images.githubusercontent.com/412180/168318768-c1692593-9511-4cd4-ba5c-41487e928e36.png)
After:
![image](https://user-images.githubusercontent.com/412180/168318881-cfd64a36-1a03-4247-bab4-dfdb80af94ce.png)