### PR TITLE
Fix npm publish script where order matters

### DIFF
--- a/.github/workflows/publish-npm-master.yaml
+++ b/.github/workflows/publish-npm-master.yaml
@@ -48,8 +48,8 @@ jobs:
 
       - name: Run ESLint and Build
         run: |
-          pnpm lint
           BUILD_VERSION="0.0.0-${{ github.ref_name }}-$(git rev-parse --short $GITHUB_SHA)" pnpm build
+          pnpm lint
 
       - uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Reordered scripts as linting seems to rely on building

Part of fixing #237 

Caused by #263 