### PR TITLE
fix: EnumCoder not padding its value

### DIFF
--- a/packages/abi-coder/src/coders/__snapshots__/coders.test.ts.snap
+++ b/packages/abi-coder/src/coders/__snapshots__/coders.test.ts.snap
@@ -20,6 +20,8 @@ exports[`ByteCoder as a byte can encode 0 then decode 0 1`] = `"0x00000000000000
 
 exports[`ByteCoder as a byte can encode 255 then decode 255 1`] = `"0x00000000000000ff"`;
 
+exports[`EnumCoder as a [enum TestEnum; 4] can encode [[Object], [Object], [Object], [Object]] then decode [[Object], [Object], [Object], [Object]] 1`] = `"0x000000000000000000000000000000000000000000000539000000000000000100000000000005390000000000000539000000000000000000000000000000000000000000000539000000000000000100000000000005390000000000000539"`;
+
 exports[`EnumCoder as a enum TestEnum can encode {"a": true} then decode {"a": true} 1`] = `"0x00000000000000000000000000000001"`;
 
 exports[`EnumCoder as a enum TestEnum can encode {"b": 1337} then decode {"b": 1337n} 1`] = `"0x00000000000000010000000000000539"`;

--- a/packages/abi-coder/src/coders/abstract-coder.ts
+++ b/packages/abi-coder/src/coders/abstract-coder.ts
@@ -29,18 +29,14 @@ export type TypesOfCoder<TCoder> = TCoder extends Coder<infer TInput, infer TDec
   : never;
 
 export default abstract class Coder<TInput = unknown, TDecoded = unknown> {
-  // The coder name:
-  //   - address, uint256, tuple, array, etc.
   readonly name: string;
-
-  // The fully expanded type, including composite types:
-  //   - address, u16, tuple(address,bytes)
   readonly type: string;
+  readonly encodedLength: number;
 
-  constructor(name: string, type: string) {
-    // @TODO: defineReadOnly these
+  constructor(name: string, type: string, encodedLength: number) {
     this.name = name;
     this.type = type;
+    this.encodedLength = encodedLength;
   }
 
   throwError(message: string, value: unknown): never {

--- a/packages/abi-coder/src/coders/array.ts
+++ b/packages/abi-coder/src/coders/array.ts
@@ -14,7 +14,7 @@ export default class ArrayCoder<TCoder extends Coder> extends Coder<
   length: number;
 
   constructor(coder: TCoder, length: number) {
-    super('array', `[${coder.type}; ${length}]`);
+    super('array', `[${coder.type}; ${length}]`, length * coder.encodedLength);
     this.coder = coder;
     this.length = length;
   }

--- a/packages/abi-coder/src/coders/b256.ts
+++ b/packages/abi-coder/src/coders/b256.ts
@@ -5,7 +5,7 @@ import Coder from './abstract-coder';
 
 export default class B256Coder extends Coder<string, string> {
   constructor() {
-    super('b256', 'b256');
+    super('b256', 'b256', 32);
   }
 
   encode(value: string): Uint8Array {

--- a/packages/abi-coder/src/coders/boolean.ts
+++ b/packages/abi-coder/src/coders/boolean.ts
@@ -5,7 +5,7 @@ import Coder from './abstract-coder';
 
 export default class BooleanCoder extends Coder<boolean, boolean> {
   constructor() {
-    super('boolean', 'boolean');
+    super('boolean', 'boolean', 8);
   }
 
   encode(value: boolean): Uint8Array {

--- a/packages/abi-coder/src/coders/byte.ts
+++ b/packages/abi-coder/src/coders/byte.ts
@@ -5,7 +5,7 @@ import Coder from './abstract-coder';
 
 export default class ByteCoder extends Coder<number, number> {
   constructor() {
-    super('byte', 'byte');
+    super('byte', 'byte', 8);
   }
 
   encode(value: number): Uint8Array {

--- a/packages/abi-coder/src/coders/coders.test.ts
+++ b/packages/abi-coder/src/coders/coders.test.ts
@@ -121,6 +121,17 @@ const testCases = [
         { b: 1337 },
         { b: 1337n },
       ],
+      [
+        new ArrayCoder(
+          new EnumCoder('TestEnum', {
+            a: new NumberCoder('u64'),
+            b: new TupleCoder([new NumberCoder('u64'), new NumberCoder('u64')]),
+          }),
+          4
+        ),
+        [{ a: 1337 }, { b: [1337, 1337] }, { a: 1337 }, { b: [1337, 1337] }],
+        [{ a: 1337n }, { b: [1337n, 1337n] }, { a: 1337n }, { b: [1337n, 1337n] }],
+      ],
     ],
     [
       // Under
@@ -259,7 +270,8 @@ describe.each(testCases)('%s', (coderName, goodCases, badCases) => {
   )('as a %s can encode %p then decode %p', (abiType, input, output, coder) => {
     const encoded = coder.encode(input);
     expect(hexlify(encoded)).toMatchSnapshot();
-    const [decoded] = coder.decode(encoded, 0);
+    const [decoded, length] = coder.decode(encoded, 0);
+    expect(length).toEqual(encoded.length);
     expect(decoded).toEqual(output);
   });
   it.each(

--- a/packages/abi-coder/src/coders/number.ts
+++ b/packages/abi-coder/src/coders/number.ts
@@ -17,7 +17,7 @@ export default class NumberCoder<TBaseType extends NumberCoderType = NumberCoder
   baseType: TBaseType;
 
   constructor(baseType: TBaseType) {
-    super('number', baseType);
+    super('number', baseType, 8);
     this.baseType = baseType;
     switch (baseType) {
       case 'u8':

--- a/packages/abi-coder/src/coders/string.ts
+++ b/packages/abi-coder/src/coders/string.ts
@@ -5,25 +5,27 @@ import Coder from './abstract-coder';
 
 export default class StringCoder<TLength extends number = number> extends Coder<string, string> {
   length: TLength;
+  #paddingLength: number;
 
   constructor(length: TLength) {
-    super('string', `str[${length}]`);
+    let paddingLength = (8 - length) % 8;
+    paddingLength = paddingLength < 0 ? paddingLength + 8 : paddingLength;
+    super('string', `str[${length}]`, length + paddingLength);
     this.length = length;
+    this.#paddingLength = paddingLength;
   }
 
   encode(value: string): Uint8Array {
-    let pad = (8 - this.length) % 8;
-    pad = pad < 0 ? pad + 8 : pad;
-    const str = toUtf8Bytes(value.slice(0, this.length));
-    return concat([str, new Uint8Array(pad)]);
+    const encoded = toUtf8Bytes(value.slice(0, this.length));
+    const padding = new Uint8Array(this.#paddingLength);
+    return concat([encoded, padding]);
   }
 
   decode(data: Uint8Array, offset: number): [string, number] {
-    let pad = (8 - this.length) % 8;
-    pad = pad < 0 ? pad + 8 : pad;
-
     const bytes = data.slice(offset, offset + this.length);
     const value = toUtf8String(bytes);
-    return [value, offset + this.length + pad];
+
+    const padding = this.#paddingLength;
+    return [value, offset + this.length + padding];
   }
 }

--- a/packages/abi-coder/src/coders/struct.ts
+++ b/packages/abi-coder/src/coders/struct.ts
@@ -19,7 +19,11 @@ export default class StructCoder<TCoders extends Record<string, Coder>> extends 
   coders: TCoders;
 
   constructor(name: string, coders: TCoders) {
-    super('struct', `struct ${name}`);
+    const encodedLength = Object.values(coders).reduce(
+      (acc, coder) => acc + coder.encodedLength,
+      0
+    );
+    super('struct', `struct ${name}`, encodedLength);
     this.name = name;
     this.coders = coders;
   }

--- a/packages/abi-coder/src/coders/tuple.ts
+++ b/packages/abi-coder/src/coders/tuple.ts
@@ -17,7 +17,8 @@ export default class TupleCoder<TCoders extends Coder[]> extends Coder<
   coders: TCoders;
 
   constructor(coders: TCoders) {
-    super('tuple', `(${coders.map((coder) => coder.type).join(', ')})`);
+    const encodedLength = coders.reduce((acc, coder) => acc + coder.encodedLength, 0);
+    super('tuple', `(${coders.map((coder) => coder.type).join(', ')})`, encodedLength);
     this.coders = coders;
   }
 

--- a/packages/transactions/src/coders/byte-array.ts
+++ b/packages/transactions/src/coders/byte-array.ts
@@ -2,8 +2,6 @@ import type { BytesLike } from '@ethersproject/bytes';
 import { arrayify, concat, hexlify } from '@ethersproject/bytes';
 import { Coder } from '@fuel-ts/abi-coder';
 
-const padToBytes = 8;
-
 export class ByteArrayCoder extends Coder<BytesLike, string> {
   length: number;
   #paddingLength: number;

--- a/packages/transactions/src/coders/byte-array.ts
+++ b/packages/transactions/src/coders/byte-array.ts
@@ -6,17 +6,22 @@ const padToBytes = 8;
 
 export class ByteArrayCoder extends Coder<BytesLike, string> {
   length: number;
+  #paddingLength: number;
 
   constructor(length: number) {
+    const paddingLength = (8 - (length % 8)) % 8;
+    const encodedLength = length + paddingLength;
     super(
       'ByteArray',
       // While this might sound like a [u8; N] coder it's actually not.
       // A [u8; N] coder would pad every u8 to 8 bytes which would
       // make every u8 have the same size as a u64.
       // We are packing four u8s into u64s here, avoiding this padding.
-      `[u64; ${length + padToBytes - (length % padToBytes)}]`
+      `[u64; ${encodedLength / 4}]`,
+      encodedLength
     );
     this.length = length;
+    this.#paddingLength = paddingLength;
   }
 
   encode(value: BytesLike): Uint8Array {
@@ -25,9 +30,8 @@ export class ByteArrayCoder extends Coder<BytesLike, string> {
     const data = arrayify(value);
     parts.push(data);
     // Write padding
-    const pad = padToBytes - (this.length % padToBytes);
-    if (pad % padToBytes) {
-      parts.push(new Uint8Array(pad).fill(0));
+    if (this.#paddingLength) {
+      parts.push(new Uint8Array(this.#paddingLength));
     }
 
     return concat(parts);
@@ -40,9 +44,8 @@ export class ByteArrayCoder extends Coder<BytesLike, string> {
     [decoded, o] = [hexlify(data.slice(o, o + this.length)), o + this.length];
     const value = decoded;
     // Read padding
-    const pad = padToBytes - (this.length % padToBytes);
-    if (pad % padToBytes) {
-      [decoded, o] = [null, o + pad];
+    if (this.#paddingLength) {
+      [decoded, o] = [null, o + this.#paddingLength];
     }
 
     return [value, o];

--- a/packages/transactions/src/coders/input.ts
+++ b/packages/transactions/src/coders/input.ts
@@ -38,7 +38,7 @@ export type InputCoin = {
 
 export class InputCoinCoder extends Coder<InputCoin, InputCoin> {
   constructor() {
-    super('InputCoin', 'struct InputCoin');
+    super('InputCoin', 'struct InputCoin', 0);
   }
 
   encode(value: InputCoin): Uint8Array {

--- a/packages/transactions/src/coders/input.ts
+++ b/packages/transactions/src/coders/input.ts
@@ -120,7 +120,7 @@ export type InputContract = {
 
 export class InputContractCoder extends Coder<InputContract, InputContract> {
   constructor() {
-    super('InputContract', 'struct InputContract');
+    super('InputContract', 'struct InputContract', 0);
   }
 
   encode(value: InputContract): Uint8Array {
@@ -164,7 +164,7 @@ export type Input = InputCoin | InputContract;
 
 export class InputCoder extends Coder<Input, Input> {
   constructor() {
-    super('Input', 'struct Input');
+    super('Input', 'struct Input', 0);
   }
 
   encode(value: Input): Uint8Array {

--- a/packages/transactions/src/coders/output.ts
+++ b/packages/transactions/src/coders/output.ts
@@ -71,7 +71,7 @@ export type OutputContract = {
 
 export class OutputContractCoder extends Coder<OutputContract, OutputContract> {
   constructor() {
-    super('OutputContract', 'struct OutputContract');
+    super('OutputContract', 'struct OutputContract', 0);
   }
 
   encode(value: OutputContract): Uint8Array {
@@ -119,7 +119,7 @@ export type OutputWithdrawal = {
 
 export class OutputWithdrawalCoder extends Coder<OutputWithdrawal, OutputWithdrawal> {
   constructor() {
-    super('OutputWithdrawal', 'struct OutputWithdrawal');
+    super('OutputWithdrawal', 'struct OutputWithdrawal', 0);
   }
 
   encode(value: OutputWithdrawal): Uint8Array {
@@ -167,7 +167,7 @@ export type OutputChange = {
 
 export class OutputChangeCoder extends Coder<OutputChange, OutputChange> {
   constructor() {
-    super('OutputChange', 'struct OutputChange');
+    super('OutputChange', 'struct OutputChange', 0);
   }
 
   encode(value: OutputChange): Uint8Array {
@@ -215,7 +215,7 @@ export type OutputVariable = {
 
 export class OutputVariableCoder extends Coder<OutputVariable, OutputVariable> {
   constructor() {
-    super('OutputVariable', 'struct OutputVariable');
+    super('OutputVariable', 'struct OutputVariable', 0);
   }
 
   encode(value: OutputVariable): Uint8Array {
@@ -264,7 +264,7 @@ export class OutputContractCreatedCoder extends Coder<
   OutputContractCreated
 > {
   constructor() {
-    super('OutputContractCreated', 'struct OutputContractCreated');
+    super('OutputContractCreated', 'struct OutputContractCreated', 0);
   }
 
   encode(value: OutputContractCreated): Uint8Array {
@@ -306,7 +306,7 @@ export type Output =
 
 export class OutputCoder extends Coder<Output, Output> {
   constructor() {
-    super('Output', ' struct Output');
+    super('Output', ' struct Output', 0);
   }
 
   encode(value: Output): Uint8Array {

--- a/packages/transactions/src/coders/output.ts
+++ b/packages/transactions/src/coders/output.ts
@@ -23,7 +23,7 @@ export type OutputCoin = {
 
 export class OutputCoinCoder extends Coder<OutputCoin, OutputCoin> {
   constructor() {
-    super('OutputCoin', 'struct OutputCoin');
+    super('OutputCoin', 'struct OutputCoin', 0);
   }
 
   encode(value: OutputCoin): Uint8Array {

--- a/packages/transactions/src/coders/receipt.ts
+++ b/packages/transactions/src/coders/receipt.ts
@@ -114,7 +114,7 @@ export type ReceiptReturn = {
 
 export class ReceiptReturnCoder extends Coder<ReceiptReturn, ReceiptReturn> {
   constructor() {
-    super('ReceiptReturn', 'struct ReceiptReturn');
+    super('ReceiptReturn', 'struct ReceiptReturn', 0);
   }
 
   encode(value: ReceiptReturn): Uint8Array {
@@ -172,7 +172,7 @@ export type ReceiptReturnData = {
 
 export class ReceiptReturnDataCoder extends Coder<ReceiptReturnData, ReceiptReturnData> {
   constructor() {
-    super('ReceiptReturnData', 'struct ReceiptReturnData');
+    super('ReceiptReturnData', 'struct ReceiptReturnData', 0);
   }
 
   encode(value: ReceiptReturnData): Uint8Array {
@@ -234,7 +234,7 @@ export type ReceiptPanic = {
 
 export class ReceiptPanicCoder extends Coder<ReceiptPanic, ReceiptPanic> {
   constructor() {
-    super('ReceiptPanic', 'struct ReceiptPanic');
+    super('ReceiptPanic', 'struct ReceiptPanic', 0);
   }
 
   encode(value: ReceiptPanic): Uint8Array {
@@ -288,7 +288,7 @@ export type ReceiptRevert = {
 
 export class ReceiptRevertCoder extends Coder<ReceiptRevert, ReceiptRevert> {
   constructor() {
-    super('ReceiptRevert', 'struct ReceiptRevert');
+    super('ReceiptRevert', 'struct ReceiptRevert', 0);
   }
 
   encode(value: ReceiptRevert): Uint8Array {
@@ -348,7 +348,7 @@ export type ReceiptLog = {
 
 export class ReceiptLogCoder extends Coder<ReceiptLog, ReceiptLog> {
   constructor() {
-    super('ReceiptLog', 'struct ReceiptLog');
+    super('ReceiptLog', 'struct ReceiptLog', 0);
   }
 
   encode(value: ReceiptLog): Uint8Array {
@@ -422,7 +422,7 @@ export type ReceiptLogData = {
 
 export class ReceiptLogDataCoder extends Coder<ReceiptLogData, ReceiptLogData> {
   constructor() {
-    super('ReceiptLogData', 'struct ReceiptLogData');
+    super('ReceiptLogData', 'struct ReceiptLogData', 0);
   }
 
   encode(value: ReceiptLogData): Uint8Array {
@@ -496,7 +496,7 @@ export type ReceiptTransfer = {
 
 export class ReceiptTransferCoder extends Coder<ReceiptTransfer, ReceiptTransfer> {
   constructor() {
-    super('ReceiptTransfer', 'struct ReceiptTransfer');
+    super('ReceiptTransfer', 'struct ReceiptTransfer', 0);
   }
 
   encode(value: ReceiptTransfer): Uint8Array {
@@ -562,7 +562,7 @@ export type ReceiptTransferOut = {
 
 export class ReceiptTransferOutCoder extends Coder<ReceiptTransferOut, ReceiptTransferOut> {
   constructor() {
-    super('ReceiptTransferOut', 'struct ReceiptTransferOut');
+    super('ReceiptTransferOut', 'struct ReceiptTransferOut', 0);
   }
 
   encode(value: ReceiptTransferOut): Uint8Array {
@@ -620,7 +620,7 @@ export type ReceiptScriptResult = {
 
 export class ReceiptScriptResultCoder extends Coder<ReceiptScriptResult, ReceiptScriptResult> {
   constructor() {
-    super('ReceiptScriptResult', 'struct ReceiptScriptResult');
+    super('ReceiptScriptResult', 'struct ReceiptScriptResult', 0);
   }
 
   encode(value: ReceiptScriptResult): Uint8Array {
@@ -666,7 +666,7 @@ export type Receipt =
 
 export class ReceiptCoder extends Coder<Receipt, Receipt> {
   constructor() {
-    super('Receipt', 'struct Receipt');
+    super('Receipt', 'struct Receipt', 0);
   }
 
   encode(value: Receipt): Uint8Array {

--- a/packages/transactions/src/coders/receipt.ts
+++ b/packages/transactions/src/coders/receipt.ts
@@ -40,7 +40,7 @@ export type ReceiptCall = {
 
 export class ReceiptCallCoder extends Coder<ReceiptCall, ReceiptCall> {
   constructor() {
-    super('ReceiptCall', 'struct ReceiptCall');
+    super('ReceiptCall', 'struct ReceiptCall', 0);
   }
 
   encode(value: ReceiptCall): Uint8Array {

--- a/packages/transactions/src/coders/transaction.ts
+++ b/packages/transactions/src/coders/transaction.ts
@@ -54,7 +54,7 @@ export type TransactionScript = {
 
 export class TransactionScriptCoder extends Coder<TransactionScript, TransactionScript> {
   constructor() {
-    super('TransactionScript', 'struct TransactionScript');
+    super('TransactionScript', 'struct TransactionScript', 0);
   }
 
   encode(value: TransactionScript): Uint8Array {

--- a/packages/transactions/src/coders/transaction.ts
+++ b/packages/transactions/src/coders/transaction.ts
@@ -184,7 +184,7 @@ export type TransactionCreate = {
 
 export class TransactionCreateCoder extends Coder<TransactionCreate, TransactionCreate> {
   constructor() {
-    super('TransactionCreate', 'struct TransactionCreate');
+    super('TransactionCreate', 'struct TransactionCreate', 0);
   }
 
   encode(value: TransactionCreate): Uint8Array {
@@ -294,7 +294,7 @@ export type Transaction = TransactionScript | TransactionCreate;
 
 export class TransactionCoder extends Coder<Transaction, Transaction> {
   constructor() {
-    super('Transaction', 'struct Transaction');
+    super('Transaction', 'struct Transaction', 0);
   }
 
   encode(value: Transaction): Uint8Array {

--- a/packages/transactions/src/coders/witness.ts
+++ b/packages/transactions/src/coders/witness.ts
@@ -15,7 +15,8 @@ export class WitnessCoder extends Coder<Witness, Witness> {
     super(
       'Witness',
       // Types of dynamic length are not supported in the ABI
-      'unknown'
+      'unknown',
+      0
     );
   }
 


### PR DESCRIPTION
EnumCoder needed to left-pad its value to the max length among all possible values, but that wasn't the case.

The actual changes are in [enum.ts](https://github.com/FuelLabs/fuels-ts/pull/336/files#diff-5cc0231e0e475c5030836a1e71284195e87dafe4e2d6875a707c27d61f276647) and the rest is for length calculation.