### PR TITLE
feat: update fuel-core to v0.9.2

### DIFF
--- a/packages/contract/src/call-test-contract/call-test-contract.test.ts
+++ b/packages/contract/src/call-test-contract/call-test-contract.test.ts
@@ -36,8 +36,7 @@ const setup = async (abi: JsonAbi | Interface = abiJSON) => {
   // Create wallet
   const wallet = await createWallet();
   const factory = new ContractFactory(contractBytecode, abi, wallet);
-  const contract = deployContract(factory);
-
+  const contract = await deployContract(factory);
   return contract;
 };
 

--- a/packages/contract/src/contract-factory.test.ts
+++ b/packages/contract/src/contract-factory.test.ts
@@ -109,7 +109,10 @@ describe('Contract Factory', () => {
     );
   });
 
-  it('Creates a contract with initial storage', async () => {
+  // TODO: https://github.com/FuelLabs/fuels-ts/issues/334
+  // Fix storage initialization in the SDK looks like Merkle Three is not working
+  // as expected
+  it.skip('Creates a contract with initial storage', async () => {
     const factory = await createContractFactory();
     const u64 = '0x1000000000000001';
     const b256 = '0x626f0c36909faecc316056fca8be684ab0cd06afc63247dc008bdf9e433f927a';

--- a/packages/contract/src/contract-factory.ts
+++ b/packages/contract/src/contract-factory.ts
@@ -2,13 +2,14 @@ import type { BytesLike } from '@ethersproject/bytes';
 import { Logger } from '@ethersproject/logger';
 import { Interface } from '@fuel-ts/abi-coder';
 import type { JsonAbi } from '@fuel-ts/abi-coder';
+import { ZeroBytes32 } from '@fuel-ts/constants';
 import { randomBytes } from '@fuel-ts/keystore';
 import type { CreateTransactionRequestLike } from '@fuel-ts/providers';
 import { Provider, CreateTransactionRequest } from '@fuel-ts/providers';
 import { Wallet } from '@fuel-ts/wallet';
 
 import Contract from './contract';
-import { getContractId, getContractStorageRoot } from './util';
+import { getContractId } from './util';
 
 const logger = new Logger(process.env.BUILD_VERSION || '~');
 
@@ -63,7 +64,12 @@ export default class ContractFactory {
       ...deployContractOptions,
     };
 
-    const stateRoot = options.stateRoot || getContractStorageRoot(options.storageSlots);
+    // If storage slot is zero it should return zero and
+    // as contract stateRoot is different form the receiptsState Root
+    // https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#transactioncreate
+    // const stateRoot = options.stateRoot || getContractStorageRoot(options.storageSlots);
+    // TODO: https://github.com/FuelLabs/fuels-ts/issues/334
+    const stateRoot = ZeroBytes32;
     const contractId = getContractId(this.bytecode, options.salt, stateRoot);
     const request = new CreateTransactionRequest({
       gasPrice: 0,

--- a/packages/contract/src/util.ts
+++ b/packages/contract/src/util.ts
@@ -1,6 +1,7 @@
 import type { BytesLike } from '@ethersproject/bytes';
 import { hexlify, arrayify, concat } from '@ethersproject/bytes';
 import { sha256 } from '@ethersproject/sha2';
+import { ZeroBytes32 } from '@fuel-ts/constants';
 import { calcRoot } from '@fuel-ts/merkle';
 
 const getContractRoot = (bytecode: Uint8Array): string => {

--- a/packages/providers/fuel-core-schema.graphql
+++ b/packages/providers/fuel-core-schema.graphql
@@ -1,8 +1,3 @@
-"""
-Directs the executor to query only when the field exists.
-"""
-directive @ifdef on FIELD
-
 scalar Address
 
 scalar AssetId
@@ -22,7 +17,7 @@ type BalanceConnection {
   """
   A list of edges.
   """
-  edges: [BalanceEdge]
+  edges: [BalanceEdge!]!
 }
 
 """
@@ -30,14 +25,14 @@ An edge in a connection.
 """
 type BalanceEdge {
   """
-  The item at the end of the edge
-  """
-  node: Balance!
-
-  """
   A cursor for use in pagination
   """
   cursor: String!
+
+  """
+  "The item at the end of the edge
+  """
+  node: Balance!
 }
 
 input BalanceFilterInput {
@@ -64,7 +59,7 @@ type BlockConnection {
   """
   A list of edges.
   """
-  edges: [BlockEdge]
+  edges: [BlockEdge!]!
 }
 
 """
@@ -72,17 +67,22 @@ An edge in a connection.
 """
 type BlockEdge {
   """
-  The item at the end of the edge
-  """
-  node: Block!
-
-  """
   A cursor for use in pagination
   """
   cursor: String!
+
+  """
+  "The item at the end of the edge
+  """
+  node: Block!
 }
 
 scalar BlockId
+
+input Breakpoint {
+  contract: ContractId!
+  pc: U64!
+}
 
 scalar Bytes32
 
@@ -91,6 +91,7 @@ type ChainInfo {
   latestBlock: Block!
   baseChainHeight: U64!
   peerCount: Int!
+  consensusParameters: ConsensusParameters!
 }
 
 type ChangeOutput {
@@ -118,7 +119,7 @@ type CoinConnection {
   """
   A list of edges.
   """
-  edges: [CoinEdge]
+  edges: [CoinEdge!]!
 }
 
 """
@@ -126,14 +127,14 @@ An edge in a connection.
 """
 type CoinEdge {
   """
-  The item at the end of the edge
-  """
-  node: Coin!
-
-  """
   A cursor for use in pagination
   """
   cursor: String!
+
+  """
+  "The item at the end of the edge
+  """
+  node: Coin!
 }
 
 input CoinFilterInput {
@@ -159,9 +160,65 @@ enum CoinStatus {
   SPENT
 }
 
+type ConsensusParameters {
+  contractMaxSize: U64!
+  maxInputs: U64!
+  maxOutputs: U64!
+  maxWitnesses: U64!
+  maxGasPerTx: U64!
+  maxScriptLength: U64!
+  maxScriptDataLength: U64!
+  maxStaticContracts: U64!
+  maxStorageSlots: U64!
+  maxPredicateLength: U64!
+  maxPredicateDataLength: U64!
+  gasPriceFactor: U64!
+}
+
 type Contract {
   id: ContractId!
   bytecode: HexString!
+  salt: Salt!
+}
+
+type ContractBalance {
+  contract: ContractId!
+  amount: U64!
+  assetId: AssetId!
+}
+
+type ContractBalanceConnection {
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+
+  """
+  A list of edges.
+  """
+  edges: [ContractBalanceEdge!]!
+}
+
+"""
+An edge in a connection.
+"""
+type ContractBalanceEdge {
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+
+  """
+  "The item at the end of the edge
+  """
+  node: ContractBalance!
+}
+
+input ContractBalanceFilterInput {
+  """
+  Filter assets based on the `contractId` field
+  """
+  contract: ContractId!
 }
 
 type ContractCreated {
@@ -218,6 +275,10 @@ type Mutation {
   endSession(id: ID!): Boolean!
   reset(id: ID!): Boolean!
   execute(id: ID!, op: String!): Boolean!
+  setSingleStepping(id: ID!, enable: Boolean!): Boolean!
+  setBreakpoint(id: ID!, breakpoint: Breakpoint!): Boolean!
+  startTx(id: ID!, txJson: String!): RunResult!
+  continueTx(id: ID!): RunResult!
 
   """
   Execute a dry-run of the transaction using a fork of current state, no changes are committed.
@@ -230,6 +291,17 @@ type Mutation {
   submit(tx: HexString!): Transaction!
 }
 
+type NodeInfo {
+  utxoValidation: Boolean!
+  predicates: Boolean!
+  vmBacktrace: Boolean!
+  minGasPrice: U64!
+  minBytePrice: U64!
+  maxTx: U64!
+  maxDepth: U64!
+  nodeVersion: String!
+}
+
 union Output =
     CoinOutput
   | ContractOutput
@@ -237,6 +309,15 @@ union Output =
   | ChangeOutput
   | VariableOutput
   | ContractCreated
+
+"""
+A separate `Breakpoint` type to be used as an output, as a single
+type cannot act as both input and output type in async-graphql
+"""
+type OutputBreakpoint {
+  contract: ContractId!
+  pc: U64!
+}
 
 """
 Information about pagination in a connection
@@ -302,7 +383,6 @@ type Query {
   ): Block
   blocks(first: Int, after: String, last: Int, before: String): BlockConnection!
   chain: ChainInfo!
-  version: String!
   transaction(
     """
     The ID of the transaction
@@ -340,6 +420,13 @@ type Query {
     last: Int
     before: String
   ): CoinConnection!
+
+  """
+  For each `spend_query`, get some spendable coins (of asset specified by the query) owned by
+  `owner` that add up at least the query amount. The returned coins (UTXOs) are actual coins
+  that can be spent. The number of coins (UXTOs) is optimized to prevent dust accumulation.
+  Max number of UTXOS and excluded UTXOS can also be specified.
+  """
   coinsToSpend(
     """
     The Address of the utxo owner
@@ -357,7 +444,7 @@ type Query {
     maxInputs: Int
 
     """
-    The max number of utxos that can be used
+    The utxos that cannot be used
     """
     excludedIds: [UtxoId!]
   ): [Coin!]!
@@ -367,6 +454,15 @@ type Query {
     """
     id: ContractId!
   ): Contract
+  contractBalance(contract: ContractId!, asset: AssetId!): ContractBalance!
+  contractBalances(
+    filter: ContractBalanceFilterInput!
+    first: Int
+    after: String
+    last: Int
+    before: String
+  ): ContractBalanceConnection!
+  nodeInfo: NodeInfo!
 }
 
 type Receipt {
@@ -415,6 +511,23 @@ enum ReturnType {
   REVERT
 }
 
+type RunResult {
+  state: RunState!
+  breakpoint: OutputBreakpoint
+}
+
+enum RunState {
+  """
+  All breakpoints have been processed, and the program has terminated
+  """
+  COMPLETED
+
+  """
+  Stopped on a breakpoint
+  """
+  BREAKPOINT
+}
+
 scalar Salt
 
 input SpendQueryElementInput {
@@ -424,7 +537,7 @@ input SpendQueryElementInput {
   assetId: AssetId!
 
   """
-  Address of the owner
+  Target amount for the query
   """
   amount: U64!
 }
@@ -477,7 +590,7 @@ type TransactionConnection {
   """
   A list of edges.
   """
-  edges: [TransactionEdge]
+  edges: [TransactionEdge!]!
 }
 
 """
@@ -485,14 +598,14 @@ An edge in a connection.
 """
 type TransactionEdge {
   """
-  The item at the end of the edge
-  """
-  node: Transaction!
-
-  """
   A cursor for use in pagination
   """
   cursor: String!
+
+  """
+  "The item at the end of the edge
+  """
+  node: Transaction!
 }
 
 scalar TransactionId

--- a/packages/providers/src/operations.graphql
+++ b/packages/providers/src/operations.graphql
@@ -65,7 +65,9 @@ fragment balanceFragment on Balance {
 
 # Queries and Mutations
 query getVersion {
-  version
+  nodeInfo {
+    nodeVersion
+  }
 }
 
 query getChain {

--- a/packages/providers/src/provider.test.ts
+++ b/packages/providers/src/provider.test.ts
@@ -12,7 +12,7 @@ describe('Provider', () => {
 
     const version = await provider.getVersion();
 
-    expect(version).toEqual('0.7.1');
+    expect(version).toEqual('0.9.2');
   });
 
   it('can call()', async () => {

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -101,8 +101,10 @@ export default class Provider {
    * Returns the version of the connected Fuel node
    */
   async getVersion(): Promise<string> {
-    const { version } = await this.operations.getVersion();
-    return version;
+    const {
+      nodeInfo: { nodeVersion },
+    } = await this.operations.getVersion();
+    return nodeVersion;
   }
 
   /**

--- a/packages/wallet/src/transfer.test.ts
+++ b/packages/wallet/src/transfer.test.ts
@@ -26,21 +26,21 @@ describe('Wallet', () => {
 
     /* Error out because gas is to low */
     await expect(async () => {
-      await sender.transfer(receiver.address, 1, NativeAssetId, {
+      const result = await sender.transfer(receiver.address, 1, NativeAssetId, {
         gasLimit: 1,
         gasPrice: 1,
         bytePrice: 1,
-        maturity: 1,
       });
-    }).rejects.toThrowError('InsufficientFeeAmount');
+      await result.wait();
+    }).rejects.toThrowError('Transaction failed: OutOfGas');
 
     await sender.transfer(receiver.address, 1, NativeAssetId, {
       gasLimit: 10000,
     });
     const senderBalances = await sender.getBalances();
-    expect(senderBalances).toEqual([{ assetId: NativeAssetId, amount: 99n }]);
+    expect(senderBalances).toEqual([{ assetId: NativeAssetId, amount: 96n }]);
     const receiverBalances = await receiver.getBalances();
-    expect(receiverBalances).toEqual([{ assetId: NativeAssetId, amount: 1n }]);
+    expect(receiverBalances).toEqual([{ assetId: NativeAssetId, amount: 2n }]);
   });
 
   it('can transfer multiple types of coins to multiple destinations', async () => {

--- a/services/fuel-core/Dockerfile
+++ b/services/fuel-core/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/fuellabs/fuel-core:v0.8.0
+FROM ghcr.io/fuellabs/fuel-core:v0.9.2
 
 ARG IP=0.0.0.0
 ARG PORT=4000

--- a/services/fuel-core/chainConfig.json
+++ b/services/fuel-core/chainConfig.json
@@ -38,6 +38,7 @@
     "max_static_contracts": 255,
     "max_storage_slots": 255,
     "max_predicate_length": 1048576,
-    "max_predicate_data_length": 1048576
+    "max_predicate_data_length": 1048576,
+    "gas_price_factor": 1000000
   }
 }


### PR DESCRIPTION
On this PR I'm removing the ability to initialize storage slots on contract deploy [#239](https://github.com/FuelLabs/fuels-ts/pull/239).

It would be tracked by #334. The current solution stopped working due to a difference when calculating `stateRoot` between [fuel-merkle](https://github.com/FuelLabs/fuel-merkle) and [@fuel-ts/merkle](./packages/merkle).

closes: #339 