### PR TITLE
fix: enable prettier errors via eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,9 +11,9 @@ module.exports = {
     'airbnb-base',
     'airbnb-typescript/base',
     'plugin:@typescript-eslint/recommended',
-    'prettier',
     'plugin:eslint-comments/recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
   ],
   settings: {
     jsdoc: {

--- a/packages/contract/src/util.ts
+++ b/packages/contract/src/util.ts
@@ -1,7 +1,6 @@
 import type { BytesLike } from '@ethersproject/bytes';
 import { hexlify, arrayify, concat } from '@ethersproject/bytes';
 import { sha256 } from '@ethersproject/sha2';
-import { ZeroBytes32 } from '@fuel-ts/constants';
 import { calcRoot } from '@fuel-ts/merkle';
 
 const getContractRoot = (bytecode: Uint8Array): string => {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -5,5 +5,6 @@
     "types": ["@types/node"],
     "noEmit": true,
     "allowJs": true
-  }
+  },
+  "include": [".eslintrc.js"]
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -6,5 +6,11 @@
     "noEmit": true,
     "allowJs": true
   },
-  "include": [".eslintrc.js"]
+  "include": [
+    "packages/**/*",
+    "scripts/**/*",
+    ".eslintrc.js",
+    "jest.env.ts",
+    "jest.config.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- This PR adds a configuration necessary to enable prettier errors via eslint.
- Enable `eslint-plugin-prettier` (runs prettier as an ESLint rule).
- Keep `eslint-config-prettier` enabled (that only turns rules off).
- Fix `extends` array order, because it should always be the last on `extends` array (so it gets the chance to override other configs).
- Add `.eslintrc.js` to include files by `tsconfig.eslint.json` ([see reference](https://github.com/typescript-eslint/typescript-eslint/blob/b229ee4ace1417d2d4f7d6cafa039f073e845c3a/tsconfig.eslint.json#L10) from the official repo)
- Remove an unused import (from `packages/contract/src/util.ts`).

## Before (using only the `eslint-config-prettier`) ⚠️ 
![before](https://user-images.githubusercontent.com/7074983/174464443-4b135c03-de4a-4017-8d13-5b0e2c76122f.png)

## Now ✅
![now](https://user-images.githubusercontent.com/7074983/174464445-6dad8c4d-e165-41df-9219-d40e5a78d5d6.png)

## Reference
- [eslint-config-prettier - Installation](https://github.com/prettier/eslint-config-prettier#installation)
- [eslint-plugin-prettier - Recommended Configuration](https://github.com/prettier/eslint-plugin-prettier#recommended-configuration)
- [tsconfig.eslint.json](https://github.com/typescript-eslint/typescript-eslint/blob/b229ee4ace1417d2d4f7d6cafa039f073e845c3a/tsconfig.eslint.json#L10)