### PR TITLE
feat!: make prepareCall return ContractCall

### DIFF
--- a/packages/contract/src/contract-factory.test.ts
+++ b/packages/contract/src/contract-factory.test.ts
@@ -70,7 +70,6 @@ describe('Contract Factory', () => {
     );
 
     const dryRunResult = await contact.dryRunResult.increment_counter(1);
-    expect(dryRunResult.blockId).toBeFalsy();
     expect(dryRunResult).toEqual(
       expect.objectContaining({
         receipts: expect.arrayContaining([
@@ -88,25 +87,13 @@ describe('Contract Factory', () => {
 
     const contact = await factory.deployContract();
 
-    const prepared = await contact.prepareCall.increment_counter(1);
-    expect(prepared).toEqual(
-      expect.objectContaining({
-        bytePrice: 0n,
-        gasLimit: 1000000n,
-        inputs: expect.arrayContaining([
-          expect.objectContaining({ type: 1 }),
-          expect.objectContaining({ status: 'UNSPENT', type: 0, witnessIndex: 0 }),
-        ]),
-        outputs: expect.arrayContaining([
-          expect.objectContaining({ inputIndex: 0, type: 1 }),
-          expect.objectContaining({ type: 3 }),
-        ]),
-        gasPrice: 0n,
-        maturity: 0n,
-        type: 0,
-        witnesses: ['0x'],
-      })
-    );
+    const prepared = contact.prepareCall.increment_counter(1);
+    expect(prepared).toEqual({
+      contract: expect.objectContaining({ id: contact.id }),
+      func: expect.objectContaining({ name: 'increment_counter' }),
+      args: [1],
+      options: {},
+    });
   });
 
   // TODO: https://github.com/FuelLabs/fuels-ts/issues/334

--- a/packages/typechain-target-fuels/example/types/Demo.d.ts
+++ b/packages/typechain-target-fuels/example/types/Demo.d.ts
@@ -7,6 +7,8 @@ import type {
   FunctionFragment,
   DecodedValue,
   Contract,
+  ContractCall,
+  ContractCallOptions,
   Overrides,
   BigNumberish,
   BytesLike,
@@ -20,37 +22,7 @@ export type PersonInput = { name: string; address: string };
 export type Person = { name: string; address: string };
 
 interface DemoInterface extends Interface {
-  submit: {
-    name: FunctionFragment;
-    tuple_function: FunctionFragment;
-    void_return_function: FunctionFragment;
-  };
-  submitResult: {
-    name: FunctionFragment;
-    tuple_function: FunctionFragment;
-    void_return_function: FunctionFragment;
-  };
-  dryRun: {
-    name: FunctionFragment;
-    tuple_function: FunctionFragment;
-    void_return_function: FunctionFragment;
-  };
-  dryRunResult: {
-    name: FunctionFragment;
-    tuple_function: FunctionFragment;
-    void_return_function: FunctionFragment;
-  };
-  simulate: {
-    name: FunctionFragment;
-    tuple_function: FunctionFragment;
-    void_return_function: FunctionFragment;
-  };
-  simulateResult: {
-    name: FunctionFragment;
-    tuple_function: FunctionFragment;
-    void_return_function: FunctionFragment;
-  };
-  prepareCall: {
+  functions: {
     name: FunctionFragment;
     tuple_function: FunctionFragment;
     void_return_function: FunctionFragment;
@@ -82,6 +54,21 @@ interface DemoInterface extends Interface {
 
 export class Demo extends Contract {
   interface: DemoInterface;
+  prepareCall: {
+    name(
+      name: string,
+      addresses: [string, string],
+      foo: boolean,
+      options?: ContractCallOptions
+    ): ContractCall;
+
+    tuple_function(
+      person: PersonInput,
+      options?: ContractCallOptions
+    ): ContractCall;
+
+    void_return_function(options?: ContractCallOptions): ContractCall;
+  };
   submit: {
     name(
       name: string,
@@ -149,23 +136,6 @@ export class Demo extends Contract {
     void_return_function(
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<CallResult>;
-  };
-  prepareCall: {
-    name(
-      name: string,
-      addresses: [string, string],
-      foo: boolean,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<ScriptTransactionRequest>;
-
-    tuple_function(
-      person: PersonInput,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<ScriptTransactionRequest>;
-
-    void_return_function(
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<ScriptTransactionRequest>;
   };
   simulate: {
     name(

--- a/packages/typechain-target-fuels/example/types/Token.d.ts
+++ b/packages/typechain-target-fuels/example/types/Token.d.ts
@@ -7,6 +7,8 @@ import type {
   FunctionFragment,
   DecodedValue,
   Contract,
+  ContractCall,
+  ContractCallOptions,
   Overrides,
   BigNumberish,
   BytesLike,
@@ -28,49 +30,7 @@ export type Ret0Input = { sender: string; receiver: string; Ret1: Ret1Input };
 export type Ret0 = { sender: string; receiver: string; Ret1: Ret1 };
 
 interface TokenInterface extends Interface {
-  submit: {
-    mint: FunctionFragment;
-    send: FunctionFragment;
-    get_balance: FunctionFragment;
-    return_array: FunctionFragment;
-    return_struct: FunctionFragment;
-  };
-  submitResult: {
-    mint: FunctionFragment;
-    send: FunctionFragment;
-    get_balance: FunctionFragment;
-    return_array: FunctionFragment;
-    return_struct: FunctionFragment;
-  };
-  dryRun: {
-    mint: FunctionFragment;
-    send: FunctionFragment;
-    get_balance: FunctionFragment;
-    return_array: FunctionFragment;
-    return_struct: FunctionFragment;
-  };
-  dryRunResult: {
-    mint: FunctionFragment;
-    send: FunctionFragment;
-    get_balance: FunctionFragment;
-    return_array: FunctionFragment;
-    return_struct: FunctionFragment;
-  };
-  simulate: {
-    mint: FunctionFragment;
-    send: FunctionFragment;
-    get_balance: FunctionFragment;
-    return_array: FunctionFragment;
-    return_struct: FunctionFragment;
-  };
-  simulateResult: {
-    mint: FunctionFragment;
-    send: FunctionFragment;
-    get_balance: FunctionFragment;
-    return_array: FunctionFragment;
-    return_struct: FunctionFragment;
-  };
-  prepareCall: {
+  functions: {
     mint: FunctionFragment;
     send: FunctionFragment;
     get_balance: FunctionFragment;
@@ -117,6 +77,35 @@ interface TokenInterface extends Interface {
 
 export class Token extends Contract {
   interface: TokenInterface;
+  prepareCall: {
+    mint(
+      gas: BigNumberish,
+      coins: BigNumberish,
+      asset_id: string,
+      args: ArgsInput,
+      options?: ContractCallOptions
+    ): ContractCall;
+
+    send(
+      gas: BigNumberish,
+      coins: BigNumberish,
+      asset_id: string,
+      args: ArgsInput,
+      options?: ContractCallOptions
+    ): ContractCall;
+
+    get_balance(options?: ContractCallOptions): ContractCall;
+
+    return_array(
+      gas: BigNumberish,
+      options?: ContractCallOptions
+    ): ContractCall;
+
+    return_struct(
+      arg0: BigNumberish,
+      options?: ContractCallOptions
+    ): ContractCall;
+  };
   submit: {
     mint(
       gas: BigNumberish,
@@ -240,37 +229,6 @@ export class Token extends Contract {
       arg0: BigNumberish,
       overrides?: Overrides & { from?: string | Promise<string> }
     ): Promise<CallResult>;
-  };
-  prepareCall: {
-    mint(
-      gas: BigNumberish,
-      coins: BigNumberish,
-      asset_id: string,
-      args: ArgsInput,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<ScriptTransactionRequest>;
-
-    send(
-      gas: BigNumberish,
-      coins: BigNumberish,
-      asset_id: string,
-      args: ArgsInput,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<ScriptTransactionRequest>;
-
-    get_balance(
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<ScriptTransactionRequest>;
-
-    return_array(
-      gas: BigNumberish,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<ScriptTransactionRequest>;
-
-    return_struct(
-      arg0: BigNumberish,
-      overrides?: Overrides & { from?: string | Promise<string> }
-    ): Promise<ScriptTransactionRequest>;
   };
   simulate: {
     mint(

--- a/packages/typechain-target-fuels/src/codegen/functions.ts
+++ b/packages/typechain-target-fuels/src/codegen/functions.ts
@@ -12,6 +12,7 @@ interface GenerateFunctionOptions {
   isStaticCall?: boolean;
   overrideOutput?: string;
   codegenConfig: CodegenConfig;
+  isPrepareCall?: boolean;
 }
 
 /**
@@ -46,17 +47,23 @@ function generateFunction(
   fn: FunctionDeclaration,
   overloadedName?: string
 ): string {
+  let prependedArg;
+  let returnType;
+  if (options.isPrepareCall) {
+    prependedArg = 'options?: ContractCallOptions';
+    returnType = 'ContractCall';
+  } else {
+    prependedArg = `overrides?: ${'Overrides & { from?: string | Promise<string> }'}`;
+    returnType = `Promise<${generateOutputTypes(fn.outputs, {
+      returnResultObject: options.returnResultObject,
+      useStructs: true,
+    })}>`;
+  }
   return `
   ${generateFunctionDocumentation(fn.documentation)}
   ${overloadedName ?? fn.name}(${generateInputTypes(fn.inputs, {
     useStructs: true,
-  })}${`overrides?: ${'Overrides & { from?: string | Promise<string> }'}`}): ${`Promise<${generateOutputTypes(
-    fn.outputs,
-    {
-      returnResultObject: options.returnResultObject,
-      useStructs: true,
-    }
-  )}>`};
+  })}${prependedArg}): ${returnType};
 `;
 }
 

--- a/packages/typechain-target-fuels/src/codegen/index.ts
+++ b/packages/typechain-target-fuels/src/codegen/index.ts
@@ -36,43 +36,7 @@ export function codegenContractTypings(contract: Contract, codegenConfig: Codege
     .join('\n')}
 
   interface ${contract.name}Interface extends Interface {
-    submit: {
-      ${Object.values(contract.functions)
-        .map((v) => v[0])
-        .map(generateInterfaceFunctionDescription)
-        .join('\n')}
-    };
-    submitResult: {
-      ${Object.values(contract.functions)
-        .map((v) => v[0])
-        .map(generateInterfaceFunctionDescription)
-        .join('\n')}
-    };
-    dryRun: {
-      ${Object.values(contract.functions)
-        .map((v) => v[0])
-        .map(generateInterfaceFunctionDescription)
-        .join('\n')}
-    };
-    dryRunResult: {
-      ${Object.values(contract.functions)
-        .map((v) => v[0])
-        .map(generateInterfaceFunctionDescription)
-        .join('\n')}
-    };
-   simulate: {
-      ${Object.values(contract.functions)
-        .map((v) => v[0])
-        .map(generateInterfaceFunctionDescription)
-        .join('\n')}
-    };
-    simulateResult: {
-      ${Object.values(contract.functions)
-        .map((v) => v[0])
-        .map(generateInterfaceFunctionDescription)
-        .join('\n')}
-    };
-    prepareCall: {
+    functions: {
       ${Object.values(contract.functions)
         .map((v) => v[0])
         .map(generateInterfaceFunctionDescription)

--- a/packages/typechain-target-fuels/src/codegen/index.ts
+++ b/packages/typechain-target-fuels/src/codegen/index.ts
@@ -23,6 +23,8 @@ export function codegenContractTypings(contract: Contract, codegenConfig: Codege
     FunctionFragment,
     DecodedValue,
     Contract,
+    ContractCall,
+    ContractCallOptions,
     Overrides,
     BigNumberish,
     BytesLike,
@@ -56,6 +58,16 @@ export function codegenContractTypings(contract: Contract, codegenConfig: Codege
 
   export class ${contract.name} extends Contract {
     interface: ${contract.name}Interface;
+    prepareCall: {
+      ${Object.values(contract.functions)
+        .map(
+          codegenFunctions.bind(null, {
+            isPrepareCall: true,
+            codegenConfig,
+          })
+        )
+        .join('\n')}
+    };
     submit: {
       ${Object.values(contract.functions)
         .map(codegenFunctions.bind(null, { returnResultObject: undefined, codegenConfig }))
@@ -79,16 +91,6 @@ export function codegenContractTypings(contract: Contract, codegenConfig: Codege
     dryRunResult: {
       ${Object.values(contract.functions)
         .map(codegenFunctions.bind(null, { returnResultObject: 'CallResult', codegenConfig }))
-        .join('\n')}
-    };
-    prepareCall: {
-      ${Object.values(contract.functions)
-        .map(
-          codegenFunctions.bind(null, {
-            returnResultObject: 'ScriptTransactionRequest',
-            codegenConfig,
-          })
-        )
         .join('\n')}
     };
     simulate: {


### PR DESCRIPTION
This PR makes some necessary changes for https://github.com/FuelLabs/fuels-ts/pull/288. While it was possible to write cleaner code, I thought it would be wiser to not commit to any abstractions until at least #288 and #315 land so we have a clearer path.

The idea here is to formalize the concept of a contract call in a struct called `ContractCall`, and with #288 be able to execute multiples of these in a single tx.

---

[fix: remove types for unused props](https://github.com/FuelLabs/fuels-ts/pull/348/commits/6317ff96d2e853a63343bdf9c432e0b0c97d6b07)

We actually don't put these props on Interfaces.

[feat!: make prepareCall return ContractCall](https://github.com/FuelLabs/fuels-ts/pull/348/commits/b5b5d5d1c03c755c1e3f53ef46c3a183211cd329)

Now `prepareCall` returns a new struct named `ContractCall`. There are also other refactors around this.