### PR TITLE
chore: reorg CI config

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  validate-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -2,8 +2,6 @@ name: "Test PR"
 
 on:
   pull_request:
-    branches:
-      - "**" # matches every branch
 
 jobs:
   cancel-previous-run:

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -1,11 +1,10 @@
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, edited]
+name: "Test PR"
 
-name: "Validate PR"
+on:
+  pull_request:
+    branches:
+      - "**" # matches every branch
+
 jobs:
   cancel-previous-run:
     name: Cancel previous actions
@@ -16,17 +15,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  validate-pr:
-    name: Validate PR title
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Pull request title check
-        uses: amannn/action-semantic-pull-request@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  validate:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -52,9 +41,12 @@ jobs:
           version: 7.0.0
           run_install: true
 
-      - name: Run ESLint and Build
+      - name: Build
         run: |
           BUILD_VERSION="0.0.0-${{ github.ref_name }}-$(git rev-parse --short $GITHUB_SHA)" pnpm build
+
+      - name: Lint
+        run: |
           pnpm lint
 
       - name: Setup Docker
@@ -64,10 +56,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run Test Coverage
+      - name: Test with coverage
         run: pnpm ci:test:coverage
 
-      - name: Coverage Report
+      - name: Report coverage
         uses: romeovs/lcov-reporter-action@v0.2.16
         if: ${{ github.event_name == 'pull_request' }}
         with:

--- a/.github/workflows/publish-npm-master.yaml
+++ b/.github/workflows/publish-npm-master.yaml
@@ -6,14 +6,16 @@
 # - can be installed with `pnpm add name@master` to get the latest version
 # - can be installed with `pnpm add name@0.0.0-master-GIT_HASH` to get a specific version
 # - will not be installed with `pnpm add name` (or `pnpm add name@latest`)
+name: "Publish to NPM Tag `master`"
+
 on:
   push:
     branches:
       - master
 
-name: "Publish to NPM Tag `master`"
 env:
   NPM_TAG: master
+
 jobs:
   publish:
     name: "Publish to NPM"
@@ -47,20 +49,9 @@ jobs:
           version: 7.0.0
           run_install: true
 
-      - name: Run ESLint and Build
+      - name: Build
         run: |
           BUILD_VERSION="0.0.0-${{ github.ref_name }}-$(git rev-parse --short $GITHUB_SHA)" pnpm build
-          pnpm lint
-
-      - name: Setup Docker
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Run Test Coverage
-        run: pnpm ci:test:coverage
 
       - name: Publish to NPM
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,10 @@
-name: "Test PR"
+name: "Test"
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   cancel-previous-run:


### PR DESCRIPTION
Currently we have a single action that both runs the tests and checks the PR title. They have to share their run triggers so tests rerun when the PR title changes for example. This PR splits those into two so that doesn't happen.

This PR also stops running tests when master is merged or before publishing. We don't need this since we can "require branches to be up to date before merging which ensures pull requests have been tested with the latest code".