### PR TITLE
chore: use `concurrency` to cancel previous CI runs

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-title:
     name: Validate PR title

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,16 +6,11 @@ on:
     branches:
       - master
 
-jobs:
-  cancel-previous-run:
-    name: Cancel previous actions
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: n1hility/cancel-previous-runs@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
+jobs:
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
From this SO page, it seems like the way we cancel previous runs is outdated and GitHub's native `concurrency` setting is the current practice: https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre

The current GH action we use haven't been touched for two years and the alternatives looked similar.