### PR TITLE
fix: multi call with mutiple fowarding

### DIFF
--- a/packages/contract/src/contract.test.ts
+++ b/packages/contract/src/contract.test.ts
@@ -110,4 +110,33 @@ describe('Contract', () => {
       receipts: expect.arrayContaining([expect.any(Object)]),
     });
   });
+
+  it('MultiCall with multiple forwarding', async () => {
+    const contract = await setup();
+
+    const result = await contract.simulateMulticall(
+      [
+        contract.prepareCall.return_context_amount({
+          forward: [100, NativeAssetId],
+          gasLimit: 1000000,
+          gasPrice: 1,
+          bytePrice: 1,
+        }),
+        contract.prepareCall.return_context_amount({
+          forward: [200, '0x0101010101010101010101010101010101010101010101010101010101010101'],
+          gasLimit: 1000000,
+          gasPrice: 1,
+          bytePrice: 1,
+        }),
+      ],
+      {
+        gasPrice: 1,
+        bytePrice: 1,
+        gasLimit: 2000000,
+      }
+    );
+    expect(result).toEqual({
+      receipts: expect.arrayContaining([expect.any(Object)]),
+    });
+  });
 });

--- a/packages/contract/src/contract.ts
+++ b/packages/contract/src/contract.ts
@@ -10,10 +10,10 @@ import type {
   CoinQuantityLike,
   TransactionRequest,
   TransactionResult,
+  CoinQuantity,
 } from '@fuel-ts/providers';
 import { coinQuantityfy, ScriptTransactionRequest, Provider } from '@fuel-ts/providers';
 import { Wallet } from '@fuel-ts/wallet';
-import type { CoinQuantity } from 'fuels';
 
 import { contractCallScript } from './scripts';
 import type { ContractCall as MulticallCall } from './scripts';


### PR DESCRIPTION
When doing multiple forwardings the build transaction was trying to add twice the same asset resulting in an error of duplicate assets.