### PR TITLE
chore: delete master releases after publish stable

### DIFF
--- a/scripts/release-stable.ts
+++ b/scripts/release-stable.ts
@@ -3,7 +3,7 @@
 import prompts from 'prompts';
 import sh from 'shelljs';
 
-import { changeAllPkgJSON } from './utils/changePackages';
+import { changeAllPkgJSON, deleteMasterReleases } from './utils/changePackages';
 import { generateChangelogs } from './utils/generateChangelogs';
 import { getVersion } from './utils/getVersion';
 
@@ -27,5 +27,6 @@ import { getVersion } from './utils/getVersion';
     sh.exec(`git tag -a ${res.version} -m "bump to ${res.version}"`);
     sh.exec('git push origin master --tags');
     sh.exec(`pnpm publish -r --tag=latest --no-git-checks --force`);
+    await deleteMasterReleases();
   }
 })();

--- a/scripts/utils/changePackages.ts
+++ b/scripts/utils/changePackages.ts
@@ -29,3 +29,20 @@ export async function changeAllPkgJSON(version: string) {
   spinner.succeed();
   changePkgJsonVersion('./', version);
 }
+
+export async function deleteMasterReleases() {
+  const pkgsDir = resolveDir('./packages');
+  const dirs = await fs.readdir(pkgsDir);
+
+  for (const dir of dirs) {
+    try {
+      const filepath = path.join(dir, 'package.json');
+      const pkgJsonPath = resolveDir(filepath);
+      const pkgJson = fs.readJsonSync(pkgJsonPath);
+      sh.exec(`npm dist-tag rm ${pkgJson.name} master`);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+  }
+}


### PR DESCRIPTION
This pull request will add a function to clean `master` releases programmatically after publishing `stable` version