### PR TITLE
feat: make predicates functions accept request tx params

### DIFF
--- a/packages/contract/src/__test__/contract.test.ts
+++ b/packages/contract/src/__test__/contract.test.ts
@@ -80,7 +80,7 @@ describe('Contract', () => {
     expect(contract.provider).toEqual(provider);
   });
 
-  it.only('should fail to execute call if gasLimit is too low', async () => {
+  it('should fail to execute call if gasLimit is too low', async () => {
     const contract = await setup();
 
     let failed;

--- a/packages/contract/src/__test__/contract.test.ts
+++ b/packages/contract/src/__test__/contract.test.ts
@@ -80,6 +80,24 @@ describe('Contract', () => {
     expect(contract.provider).toEqual(provider);
   });
 
+  it.only('should fail to execute call if gasLimit is too low', async () => {
+    const contract = await setup();
+
+    let failed;
+    try {
+      await contract.functions
+        .foo(1336)
+        .txParams({
+          gasLimit: 1,
+        })
+        .call();
+    } catch (e) {
+      failed = true;
+    }
+
+    expect(failed).toEqual(true);
+  });
+
   it('submits multiple calls', async () => {
     const contract = await setup();
 
@@ -87,6 +105,24 @@ describe('Contract', () => {
       .multiCall([contract.functions.foo(1336), contract.functions.foo(1336)])
       .call();
     expect(results).toEqual([1337n, 1337n]);
+  });
+
+  it('should fail to execute multiple calls if gasLimit is too low', async () => {
+    const contract = await setup();
+
+    let failed;
+    try {
+      await contract
+        .multiCall([contract.functions.foo(1336), contract.functions.foo(1336)])
+        .txParams({
+          gasLimit: 1,
+        })
+        .call();
+    } catch (e) {
+      failed = true;
+    }
+
+    expect(failed).toEqual(true);
   });
 
   it('dryRuns multiple calls', async () => {

--- a/packages/predicate/src/predicate.test.ts
+++ b/packages/predicate/src/predicate.test.ts
@@ -258,7 +258,8 @@ describe('Predicate', () => {
   });
 
   // TODO: Enable this test once predicates start to consume gas
-  // https://github.com/FuelLabs/fuel-specs/issues/119
+  // FUELS-TS - https://github.com/FuelLabs/fuels-ts/issues/385
+  // SPEC - https://github.com/FuelLabs/fuel-specs/issues/119
   it.skip('should fail if inform gasLimit too low', async () => {
     const receiverAddress = hexlify(randomBytes(32));
     const wallet = await setup();

--- a/packages/predicate/src/predicate.test.ts
+++ b/packages/predicate/src/predicate.test.ts
@@ -256,4 +256,36 @@ describe('Predicate', () => {
       ]);
     }).rejects.toThrow('Invalid Predicate');
   });
+
+  // TODO: Enable this test once predicates start to consume gas
+  // https://github.com/FuelLabs/fuel-specs/issues/119
+  it.skip('should fail if inform gasLimit too low', async () => {
+    const receiverAddress = hexlify(randomBytes(32));
+    const wallet = await setup();
+    const amountToPredicate = 10n;
+    const predicate = new Predicate(testPredicateStruct, StructAbiInputs);
+
+    const initialPredicateBalance = await setupPredicate(wallet, amountToPredicate, predicate);
+
+    const validation: Validation = {
+      has_account: true,
+      total_complete: 100n,
+    };
+
+    let failed;
+    try {
+      await predicate.submitSpendPredicate(
+        wallet,
+        initialPredicateBalance,
+        receiverAddress,
+        [validation],
+        undefined,
+        { gasLimit: 1 }
+      );
+    } catch (e) {
+      failed = true;
+    }
+
+    expect(failed).toEqual(true);
+  });
 });

--- a/packages/predicate/src/predicate.ts
+++ b/packages/predicate/src/predicate.ts
@@ -14,7 +14,7 @@ import type {
 import { ScriptTransactionRequest } from '@fuel-ts/providers';
 import type { Wallet } from '@fuel-ts/wallet';
 
-type BuildPrecidateOptions = {
+type BuildPredicateOptions = {
   fundTransaction?: boolean;
 } & Pick<TransactionRequestLike, 'gasLimit' | 'gasPrice' | 'bytePrice' | 'maturity'>;
 
@@ -37,7 +37,7 @@ export class Predicate {
     wallet: Wallet,
     amountToPredicate: BigNumberish,
     assetId: BytesLike = NativeAssetId,
-    predicateOptions?: BuildPrecidateOptions
+    predicateOptions?: BuildPredicateOptions
   ): Promise<ScriptTransactionRequest> {
     const options = {
       fundTransaction: true,
@@ -52,7 +52,7 @@ export class Predicate {
     request.addCoinOutput(this.address, amountToPredicate, assetId);
 
     const requiredCoinQuantities: CoinQuantityLike[] = [];
-    if (options?.fundTransaction) {
+    if (options.fundTransaction) {
       const amount = request.calculateFee();
       requiredCoinQuantities.push([amount]);
     }
@@ -69,7 +69,7 @@ export class Predicate {
     wallet: Wallet,
     amountToPredicate: BigNumberish,
     assetId: BytesLike = NativeAssetId,
-    options?: BuildPrecidateOptions
+    options?: BuildPredicateOptions
   ): Promise<TransactionResult<'success'>> {
     const request = await this.buildPredicateTransaction(
       wallet,
@@ -88,7 +88,7 @@ export class Predicate {
     receiverAddress: BytesLike,
     predicateData?: InputValue[],
     assetId: BytesLike = NativeAssetId,
-    predicateOptions?: BuildPrecidateOptions
+    predicateOptions?: BuildPredicateOptions
   ): Promise<ScriptTransactionRequest> {
     const predicateCoins: Coin[] = await wallet.provider.getCoinsToSpend(this.address, [
       [amountToSpend, assetId],
@@ -142,7 +142,7 @@ export class Predicate {
     receiverAddress: BytesLike,
     predicateData?: InputValue[],
     assetId: BytesLike = NativeAssetId,
-    options?: BuildPrecidateOptions
+    options?: BuildPredicateOptions
   ): Promise<TransactionResult<'success'>> {
     const request = await this.buildSpendPredicate(
       wallet,

--- a/packages/predicate/src/predicate.ts
+++ b/packages/predicate/src/predicate.ts
@@ -5,9 +5,18 @@ import { AbiCoder } from '@fuel-ts/abi-coder';
 import { NativeAssetId } from '@fuel-ts/constants';
 import { ContractUtils } from '@fuel-ts/contract';
 import type { BigNumberish } from '@fuel-ts/math';
-import type { CoinQuantityLike, TransactionResult, Coin } from '@fuel-ts/providers';
+import type {
+  CoinQuantityLike,
+  TransactionRequestLike,
+  TransactionResult,
+  Coin,
+} from '@fuel-ts/providers';
 import { ScriptTransactionRequest } from '@fuel-ts/providers';
 import type { Wallet } from '@fuel-ts/wallet';
+
+type BuildPrecidateOptions = {
+  fundTransaction?: boolean;
+} & Pick<TransactionRequestLike, 'gasLimit' | 'gasPrice' | 'bytePrice' | 'maturity'>;
 
 export class Predicate {
   bytes: Uint8Array;
@@ -28,19 +37,22 @@ export class Predicate {
     wallet: Wallet,
     amountToPredicate: BigNumberish,
     assetId: BytesLike = NativeAssetId,
-    options: {
-      fundTransaction?: boolean;
-    } = { fundTransaction: true }
+    predicateOptions?: BuildPrecidateOptions
   ): Promise<ScriptTransactionRequest> {
+    const options = {
+      fundTransaction: true,
+      ...predicateOptions,
+    };
     const request = new ScriptTransactionRequest({
       gasLimit: 1000000,
+      ...options,
     });
 
     // output is locked behind predicate
     request.addCoinOutput(this.address, amountToPredicate, assetId);
 
     const requiredCoinQuantities: CoinQuantityLike[] = [];
-    if (options.fundTransaction) {
+    if (options?.fundTransaction) {
       const amount = request.calculateFee();
       requiredCoinQuantities.push([amount]);
     }
@@ -57,9 +69,7 @@ export class Predicate {
     wallet: Wallet,
     amountToPredicate: BigNumberish,
     assetId: BytesLike = NativeAssetId,
-    options: {
-      fundTransaction?: boolean;
-    } = { fundTransaction: true }
+    options?: BuildPrecidateOptions
   ): Promise<TransactionResult<'success'>> {
     const request = await this.buildPredicateTransaction(
       wallet,
@@ -78,15 +88,18 @@ export class Predicate {
     receiverAddress: BytesLike,
     predicateData?: InputValue[],
     assetId: BytesLike = NativeAssetId,
-    options: {
-      fundTransaction?: boolean;
-    } = { fundTransaction: true }
+    predicateOptions?: BuildPrecidateOptions
   ): Promise<ScriptTransactionRequest> {
     const predicateCoins: Coin[] = await wallet.provider.getCoinsToSpend(this.address, [
       [amountToSpend, assetId],
     ]);
+    const options = {
+      fundTransaction: true,
+      ...predicateOptions,
+    };
     const request = new ScriptTransactionRequest({
       gasLimit: 1000000,
+      ...options,
     });
 
     let encoded: undefined | Uint8Array;
@@ -129,9 +142,7 @@ export class Predicate {
     receiverAddress: BytesLike,
     predicateData?: InputValue[],
     assetId: BytesLike = NativeAssetId,
-    options: {
-      fundTransaction?: boolean;
-    } = { fundTransaction: true }
+    options?: BuildPrecidateOptions
   ): Promise<TransactionResult<'success'>> {
     const request = await this.buildSpendPredicate(
       wallet,


### PR DESCRIPTION
- make predicate methods accept `request` tx params
- add few tests to contract, making sure it fails when gasLimit is too low


Closes #365 