### PR TITLE
feat: bump all versions

### DIFF
--- a/.changeset/real-shrimps-tan.md
+++ b/.changeset/real-shrimps-tan.md
@@ -1,0 +1,30 @@
+---
+"@fuel-ts/abi-coder": minor
+"@fuel-ts/constants": minor
+"@fuel-ts/contract": minor
+"@fuel-ts/example-contract": minor
+"forc-bin": minor
+"fuels": minor
+"@fuel-ts/hasher": minor
+"@fuel-ts/hdwallet": minor
+"@fuel-ts/interfaces": minor
+"@fuel-ts/keystore": minor
+"@fuel-ts/math": minor
+"@fuel-ts/merkle": minor
+"@fuel-ts/merkle-shared": minor
+"@fuel-ts/merklesum": minor
+"@fuel-ts/mnemonic": minor
+"@fuel-ts/predicate": minor
+"@fuel-ts/providers": minor
+"@fuel-ts/script": minor
+"@fuel-ts/signer": minor
+"@fuel-ts/sparsemerkle": minor
+"@fuel-ts/testcases": minor
+"@fuel-ts/transactions": minor
+"typechain-target-fuels": minor
+"@fuel-ts/wallet": minor
+"@fuel-ts/wallet-manager": minor
+"@fuel-ts/wordlists": minor
+---
+
+Bumping all packages to next minor version


### PR DESCRIPTION
I am bumping all packages with a minor bump, should effectively make everything `v0.8.0`

Looks like the _first_ successful new build on the npm publishing pipeline didn't have a chance to push to git.

The version `0.7.1` was pushed to npm:
![image](https://user-images.githubusercontent.com/833485/178905277-bd3f97b9-6741-4591-8265-41500afdd434.png)

But we didn't make it to the `git push` step due to the predicate library issue.