### PR TITLE
fix: cache pnpm dependencies

### DIFF
--- a/.github/actions/ci-setup/action.yaml
+++ b/.github/actions/ci-setup/action.yaml
@@ -10,10 +10,10 @@ runs:
   using: "composite"
   steps:
     - name: Cache PNPM modules
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
-        path: ~/.pnpm-store
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+        path: ~/.local/share/pnpm/store/v3
+        key: ${{ runner.os }}-node-${{ inputs.node-version }}-pnpm-${{ inputs.pnpm-version }}-lock-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-pnpm
 


### PR DESCRIPTION
- Change directory being cached
- Include `node` and `pnpm` versions in caching key.

Now `pnpm install` step is using dependencies previously cached.
<img width="545" alt="image" src="https://user-images.githubusercontent.com/8636507/179569961-fc0985e8-0d4f-4b4f-8414-f2cc08bf7cb1.png">



Fix #409 