### PR TITLE
fix: temp comment out

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,8 +37,8 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Generate typedoc
-        run: npx typedoc
+      # - name: Generate typedoc
+      #   run: npx typedoc
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
The typedoc command had a weird Type issue so I am commenting out to unblock release builds