### PR TITLE
feat(abi): Update interface to handle array and enum contract arguments

### DIFF
--- a/.changeset/six-cherries-share.md
+++ b/.changeset/six-cherries-share.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/abi-coder": minor
+"@fuel-ts/contract": minor
+---
+
+Update interface to handle array and enum contract arguments

--- a/packages/abi-coder/src/abi-coder.test.ts
+++ b/packages/abi-coder/src/abi-coder.test.ts
@@ -40,6 +40,26 @@ describe('AbiCoder', () => {
     expect(decoded).toEqual([B256, B256]);
   });
 
+  it('encodes and decodes arrays', () => {
+    const types = [
+      {
+        name: 'a',
+        type: '[u64; 3]',
+        components: [
+          {
+            name: '__array_element',
+            type: 'u64',
+            components: null,
+          },
+        ],
+      },
+    ];
+
+    const encoded = abiCoder.encode(types, [[1, 2, 3]]);
+
+    expect(hexlify(encoded)).toBe('0x000000000000000100000000000000020000000000000003');
+  });
+
   it('encodes and decodes nested reference types', () => {
     const types = [
       {

--- a/packages/abi-coder/src/abi-coder.ts
+++ b/packages/abi-coder/src/abi-coder.ts
@@ -18,7 +18,7 @@ import type { JsonAbiFragmentType } from './json-abi';
 import { filterEmptyParams } from './utilities';
 
 export const stringRegEx = /str\[(?<length>[0-9]+)\]/;
-export const arrayRegEx = /\[(?<item>[\w\s]+);\s*(?<length>[0-9]+)\]/;
+export const arrayRegEx = /\[(?<item>[\w\s\\[\]]+);\s*(?<length>[0-9]+)\]/;
 export const structRegEx = /^struct (?<name>\w+)$/;
 export const enumRegEx = /^enum (?<name>\w+)$/;
 export const tupleRegEx = /^\((?<items>.*)\)$/;
@@ -46,13 +46,6 @@ export default class AbiCoder {
       default:
     }
 
-    const stringMatch = stringRegEx.exec(param.type)?.groups;
-    if (stringMatch) {
-      const length = parseInt(stringMatch.length, 10);
-
-      return new StringCoder(length);
-    }
-
     const arrayMatch = arrayRegEx.exec(param.type)?.groups;
     if (arrayMatch) {
       const length = parseInt(arrayMatch.length, 10);
@@ -62,6 +55,13 @@ export default class AbiCoder {
       }
       const itemCoder = this.getCoder(itemComponent);
       return new ArrayCoder(itemCoder, length);
+    }
+
+    const stringMatch = stringRegEx.exec(param.type)?.groups;
+    if (stringMatch) {
+      const length = parseInt(stringMatch.length, 10);
+
+      return new StringCoder(length);
     }
 
     const structMatch = structRegEx.exec(param.type)?.groups;

--- a/packages/abi-coder/src/fragments/function-fragment.ts
+++ b/packages/abi-coder/src/fragments/function-fragment.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { FormatTypes, ParamType } from '@ethersproject/abi';
 
-import { arrayRegEx, structRegEx } from '../abi-coder';
+import { arrayRegEx, enumRegEx, structRegEx } from '../abi-coder';
 import type { JsonAbiFragment } from '../json-abi';
 
 import { Fragment } from './fragment';
@@ -18,7 +18,12 @@ function formatOverride(this: ParamType, format?: string): string {
 
     const arrayMatch = arrayRegEx.exec(this.type)?.groups;
     if (arrayMatch) {
-      return `[${arrayMatch.item}; ${arrayMatch.length}]`;
+      return `a[${arrayMatch.item};${arrayMatch.length}]`;
+    }
+
+    const enumMatch = enumRegEx.exec(this.type)?.groups;
+    if (enumMatch) {
+      return `e${this.format(format)}`;
     }
   }
 

--- a/packages/contract/src/__test__/call-test-contract/src/main.sw
+++ b/packages/contract/src/__test__/call-test-contract/src/main.sw
@@ -4,9 +4,9 @@ use std::logging::log;
 use std::context::{*, call_frames::*, registers::context_gas};
 use std::contract_id::ContractId;
 
-enum TestEnum {
-    Value: bool,
-    Data: bool,
+enum TestB256Enum {
+    Value: b256,
+    Data: b256,
 }
 
 struct TestStruct {
@@ -45,7 +45,7 @@ abi TestContract {
   fn take_array_string_return_single_element(a: [str[3];3]) -> str[3];
   fn take_array_number(a: [u64;3]) -> u64;
   fn take_array_boolean(a: [bool;3]) -> bool;
-  fn take_enum(a: TestEnum) -> bool;
+  fn take_b256_enum(a: TestB256Enum) -> b256;
 }
 
 impl TestContract for Contract {
@@ -119,9 +119,9 @@ impl TestContract for Contract {
   fn take_array_boolean(a: [bool;3]) -> bool {
     a[0]
   }
-  fn take_enum(enum_arg: TestEnum) -> bool {
+  fn take_b256_enum(enum_arg: TestB256Enum) -> b256 {
     let enum_arg = match enum_arg {
-        TestEnum::Value(val) => val, TestEnum::Data(val) => val, 
+        TestB256Enum::Value(val) => val, TestB256Enum::Data(val) => val, 
     };
     enum_arg
   }

--- a/packages/contract/src/__test__/call-test-contract/src/main.sw
+++ b/packages/contract/src/__test__/call-test-contract/src/main.sw
@@ -9,6 +9,16 @@ enum TestB256Enum {
     Data: b256,
 }
 
+enum TestBoolEnum {
+    Value: bool,
+    Data: bool,
+}
+
+enum TestStringEnum {
+    Value: str[3],
+    Data: str[3],
+}
+
 struct TestStruct {
   a: bool,
   b: u64,
@@ -46,6 +56,8 @@ abi TestContract {
   fn take_array_number(a: [u64;3]) -> u64;
   fn take_array_boolean(a: [bool;3]) -> bool;
   fn take_b256_enum(a: TestB256Enum) -> b256;
+  fn take_bool_enum(enum_arg: TestBoolEnum) -> bool;
+  fn take_string_enum(enum_arg: TestStringEnum) -> str[3];
 }
 
 impl TestContract for Contract {
@@ -122,6 +134,18 @@ impl TestContract for Contract {
   fn take_b256_enum(enum_arg: TestB256Enum) -> b256 {
     let enum_arg = match enum_arg {
         TestB256Enum::Value(val) => val, TestB256Enum::Data(val) => val, 
+    };
+    enum_arg
+  }
+  fn take_bool_enum(enum_arg: TestBoolEnum) -> bool {
+    let enum_arg = match enum_arg {
+        TestBoolEnum::Value(val) => val, TestBoolEnum::Data(val) => val, 
+    };
+    enum_arg
+  }
+  fn take_string_enum(enum_arg: TestStringEnum) -> str[3] {
+    let enum_arg = match enum_arg {
+        TestStringEnum::Value(val) => val, TestStringEnum::Data(val) => val, 
     };
     enum_arg
   }

--- a/packages/contract/src/__test__/call-test-contract/src/main.sw
+++ b/packages/contract/src/__test__/call-test-contract/src/main.sw
@@ -4,6 +4,11 @@ use std::logging::log;
 use std::context::{*, call_frames::*, registers::context_gas};
 use std::contract_id::ContractId;
 
+enum TestEnum {
+    Value: bool,
+    Data: bool,
+}
+
 struct TestStruct {
   a: bool,
   b: u64,
@@ -35,6 +40,12 @@ abi TestContract {
   fn return_context_amount() -> u64;
   fn return_context_asset() -> b256;
   fn return_context_gas() -> u64;
+  fn take_array_string_shuffle(a: [str[3];3]) -> [str[3];3];
+  fn take_array_string_return_single(a: [str[3];3]) -> [str[3];1];
+  fn take_array_string_return_single_element(a: [str[3];3]) -> str[3];
+  fn take_array_number(a: [u64;3]) -> u64;
+  fn take_array_boolean(a: [bool;3]) -> bool;
+  fn take_enum(a: TestEnum) -> bool;
 }
 
 impl TestContract for Contract {
@@ -92,5 +103,26 @@ impl TestContract for Contract {
   }
   fn return_context_gas() -> u64 {
     context_gas()
+  }
+  fn take_array_string_shuffle(a: [str[3];3]) -> [str[3];3] {
+    [a[2], a[0], a[1]]
+  }
+  fn take_array_string_return_single(a: [str[3];3]) -> [str[3];1] {
+    [a[0]]
+  }
+  fn take_array_string_return_single_element(a: [str[3];3]) -> str[3] {
+    a[0]
+  }
+  fn take_array_number(a: [u64;3]) -> u64 {
+    a[0]
+  }
+  fn take_array_boolean(a: [bool;3]) -> bool {
+    a[0]
+  }
+  fn take_enum(enum_arg: TestEnum) -> bool {
+    let enum_arg = match enum_arg {
+        TestEnum::Value(val) => val, TestEnum::Data(val) => val, 
+    };
+    enum_arg
   }
 }

--- a/packages/contract/src/__test__/contract.test.ts
+++ b/packages/contract/src/__test__/contract.test.ts
@@ -460,25 +460,56 @@ describe('Contract', () => {
   it('calls enum functions', async () => {
     const contract = await setup();
 
-    const { value: enumReturnValue } = await contract.functions
+    const { value: enumB256ReturnValue } = await contract.functions
       .take_b256_enum({
         Value: '0xd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b',
       })
-
       .call();
 
-    expect(enumReturnValue).toEqual(
+    expect(enumB256ReturnValue).toEqual(
       '0xd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
     );
 
-    const { value: enumReturnData } = await contract.functions
+    const { value: enumB256ReturnData } = await contract.functions
       .take_b256_enum({
         Data: '0x1111111111111111111111111111111111111111111111111111111111111111',
       })
       .call();
 
-    expect(enumReturnData).toEqual(
+    expect(enumB256ReturnData).toEqual(
       '0x1111111111111111111111111111111111111111111111111111111111111111'
     );
+
+    const { value: enumBoolReturnValue } = await contract.functions
+      .take_bool_enum({
+        Value: true,
+      })
+      .call();
+
+    expect(enumBoolReturnValue).toEqual(true);
+
+    const { value: enumBoolReturnData } = await contract.functions
+      .take_bool_enum({
+        Data: false,
+      })
+      .call();
+
+    expect(enumBoolReturnData).toEqual(false);
+
+    const { value: enumStrReturnValue } = await contract.functions
+      .take_string_enum({
+        Value: 'abc',
+      })
+      .call();
+
+    expect(enumStrReturnValue).toEqual('abc');
+
+    const { value: enumStrReturnData } = await contract.functions
+      .take_string_enum({
+        Data: 'efg',
+      })
+      .call();
+
+    expect(enumStrReturnData).toEqual('efg');
   });
 });

--- a/packages/contract/src/__test__/contract.test.ts
+++ b/packages/contract/src/__test__/contract.test.ts
@@ -430,4 +430,46 @@ describe('Contract', () => {
         .call<bigint>();
     }).rejects.toThrowError(`gasLimit(${gasLimit}) is lower than the required (${gasUsed})`);
   });
+
+  it('calls array functions', async () => {
+    const contract = await setup();
+
+    const { value: arrayBoolean } = await contract.functions
+      .take_array_boolean([true, false, false])
+      .call();
+
+    expect(arrayBoolean).toEqual(true);
+
+    const { value: arrayNumber } = await contract.functions.take_array_number([1, 2, 3]).call();
+
+    expect(arrayNumber).toEqual(1n);
+
+    const { value: arrayReturnShuffle } = await contract.functions
+      .take_array_string_shuffle(['abc', 'efg', 'hij'])
+      .call();
+
+    expect(arrayReturnShuffle).toEqual(['hij', 'abc', 'efg']);
+
+    const { value: arrayReturnSingle } = await contract.functions
+      .take_array_string_return_single(['abc', 'efg', 'hij'])
+      .call();
+
+    expect(arrayReturnSingle).toEqual(['abc']);
+  });
+
+  it('calls enum functions', async () => {
+    const contract = await setup();
+
+    const { value: enumReturnValue } = await contract.functions
+      .take_enum({ Value: { value: false } })
+      .call();
+
+    expect(enumReturnValue).toEqual(true);
+
+    const { value: enumReturnData } = await contract.functions
+      .take_enum({ Data: { value: true } })
+      .call();
+
+    expect(enumReturnData).toEqual(true);
+  });
 });

--- a/packages/contract/src/__test__/contract.test.ts
+++ b/packages/contract/src/__test__/contract.test.ts
@@ -461,15 +461,24 @@ describe('Contract', () => {
     const contract = await setup();
 
     const { value: enumReturnValue } = await contract.functions
-      .take_enum({ Value: { value: false } })
+      .take_b256_enum({
+        Value: '0xd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b',
+      })
+
       .call();
 
-    expect(enumReturnValue).toEqual(true);
+    expect(enumReturnValue).toEqual(
+      '0xd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'
+    );
 
     const { value: enumReturnData } = await contract.functions
-      .take_enum({ Data: { value: true } })
+      .take_b256_enum({
+        Data: '0x1111111111111111111111111111111111111111111111111111111111111111',
+      })
       .call();
 
-    expect(enumReturnData).toEqual(true);
+    expect(enumReturnData).toEqual(
+      '0x1111111111111111111111111111111111111111111111111111111111111111'
+    );
   });
 });

--- a/packages/forc-bin/package.json
+++ b/packages/forc-bin/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "forc-bin",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",


### PR DESCRIPTION
Update the function fragment to  match specs and return the correct format for `enums` and `arrays`.  Some refactors were done to make sure it works with arrays with different types.

There is still an underlying issue with one of the functions; returning a single element from an array is raising an error; see below.