### PR TITLE
ci: ignore changeset-release on pr validate

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -32,4 +32,5 @@ jobs:
         uses: ./.github/actions/ci-setup
 
       - name: Validate Changeset
+        if: ${{ github.ref != 'refs/heads/changeset-release/master' }}
         run: pnpm changeset status --since=origin/master


### PR DESCRIPTION
Ignore validate changeset when the branch name matches the ci release changeset