### PR TITLE
chore: adjust pr-lint action to skip changeset file check on bot PR

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   validate-changeset:
     name: Validate PR Changeset
-    if: github.ref != 'changeset-release/master'
+    if: github.head_ref != 'changeset-release/master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Main Idea

`github.head_ref`

> The `head_ref` or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.

`github.ref` 
As noted by @luizstacio, we can't use this:
> The branch or tag ref that triggered the workflow run. For workflows triggered by push, this is the branch or tag ref that was pushed. For **workflows triggered by pull_request, this is the pull request merge branch**.

See https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

## Additional Notes
See previous PR request from changeset github action bot:
https://github.com/FuelLabs/fuels-ts/pull/424

Note that `Validate PR Changeset` didn't pass but is currently not `Required` per this repo's settings
![image](https://user-images.githubusercontent.com/833485/181439192-9d337e78-0745-47bb-80f5-f414784901e4.png)
