### PR TITLE
ci: create a single GitHub release/tag

### DIFF
--- a/.changeset/khaki-fishes-allow.md
+++ b/.changeset/khaki-fishes-allow.md
@@ -1,5 +1,4 @@
 ---
-"forc-bin": patch
 ---
 
 Update forc version

--- a/.changeset/wild-ants-tie.md
+++ b/.changeset/wild-ants-tie.md
@@ -1,0 +1,4 @@
+---
+---
+
+Create one single aggregated release for fuels repository

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,12 +42,14 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: FuelLabs/changesets-action@aggregate-release-mode
         with:
           publish: pnpm changeset:publish
           commit: "ci(changesets): versioning packages"
           title: "ci(changesets): versioning packages"
-          createGithubReleases: false
+          createGithubReleases: aggregate
+          githubReleaseName: v${{ env.BUILD_VERSION }}
+          githubTagName: v${{ env.BUILD_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: FuelLabs/changesets-action@aggregate-release-mode
+        uses: FuelLabs/changesets-action@main
         with:
           publish: pnpm changeset:publish
           commit: "ci(changesets): versioning packages"

--- a/docs/Requirements.md
+++ b/docs/Requirements.md
@@ -1,0 +1,3 @@
+### Requirements
+
+- [Node.js v16.15.0 or latest stable](https://nodejs.org/en/). We recommend using [nvm](https://github.com/nvm-sh/nvm) to install.


### PR DESCRIPTION
Changeset has a default behavior of creating a release for each package; this is not needed, as we already use a Monorepo approach all the releases would have redundant source code. This is not only our need but also of other teams.

The approach for solving this in the meantime. Was;
- Found this PR open with the aggregate solution https://github.com/changesets/action/pull/193
- Create a Fork on https://github.com/FuelLabs/changesets-action
- Merge desire changes on `main` branch and protect the branch from changes
- Change CI to use: `FuelLabs/changesets-action@main`

The idea here is to **use our Forked version as long as needed**. As the current PR on changesets is a candidate solution but not a final solution.