### PR TITLE
feat!: refactor predicate support to work through Wallet and Provider directly

### DIFF
--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -26,3 +26,9 @@ export abstract class AbstractWallet {
 export type AddressLike = AbstractAddress | AbstractWallet;
 
 export type ContractIdLike = AbstractAddress | AbstractContract;
+
+export abstract class AbstractPredicate {
+  abstract bytes: Uint8Array;
+  abstract address: AbstractAddress;
+  abstract types?: ReadonlyArray<any>;
+}

--- a/packages/predicate/package.json
+++ b/packages/predicate/package.json
@@ -25,14 +25,14 @@
   "dependencies": {
     "@fuel-ts/abi-coder": "workspace:*",
     "@fuel-ts/address": "workspace:*",
-    "@fuel-ts/constants": "workspace:*",
     "@fuel-ts/contract": "workspace:*",
     "@fuel-ts/interfaces": "workspace:*",
-    "@fuel-ts/keystore": "workspace:*",
-    "@fuel-ts/math": "workspace:*",
-    "@fuel-ts/providers": "workspace:*",
     "@fuel-ts/wallet": "workspace:*",
-    "@fuel-ts/transactions": "workspace:*",
     "@ethersproject/bytes": "^5.5.0"
+  },
+  "devDependencies": {
+    "@fuel-ts/constants": "workspace:*",
+    "@fuel-ts/math": "workspace:*",
+    "@fuel-ts/providers": "workspace:*"
   }
 }

--- a/packages/predicate/src/predicate.ts
+++ b/packages/predicate/src/predicate.ts
@@ -1,174 +1,20 @@
 import type { BytesLike } from '@ethersproject/bytes';
 import { arrayify } from '@ethersproject/bytes';
-import type { JsonAbiFragmentType, InputValue } from '@fuel-ts/abi-coder';
-import { AbiCoder } from '@fuel-ts/abi-coder';
+import type { JsonAbiFragmentType } from '@fuel-ts/abi-coder';
 import { Address } from '@fuel-ts/address';
-import { NativeAssetId } from '@fuel-ts/constants';
 import { ContractUtils } from '@fuel-ts/contract';
+import { AbstractPredicate } from '@fuel-ts/interfaces';
 import type { AbstractAddress } from '@fuel-ts/interfaces';
-import type { BigNumberish } from '@fuel-ts/math';
-import type {
-  CoinQuantityLike,
-  TransactionRequestLike,
-  TransactionResult,
-  Coin,
-} from '@fuel-ts/providers';
-import { ScriptTransactionRequest } from '@fuel-ts/providers';
-import { MAX_GAS_PER_TX } from '@fuel-ts/transactions';
-import type { Wallet } from '@fuel-ts/wallet';
 
-type BuildPredicateOptions = {
-  fundTransaction?: boolean;
-} & Pick<TransactionRequestLike, 'gasLimit' | 'gasPrice' | 'bytePrice' | 'maturity'>;
-
-export class Predicate {
+export class Predicate extends AbstractPredicate {
   bytes: Uint8Array;
   address: AbstractAddress;
   types?: ReadonlyArray<JsonAbiFragmentType>;
 
   constructor(bytes: BytesLike, types?: ReadonlyArray<JsonAbiFragmentType>) {
+    super();
     this.bytes = arrayify(bytes);
     this.address = Address.fromB256(ContractUtils.getContractRoot(this.bytes));
     this.types = types;
-  }
-
-  async getPredicateBalance(wallet: Wallet, assetId: BytesLike = NativeAssetId): Promise<bigint> {
-    return wallet.provider.getBalance(this.address, assetId);
-  }
-
-  async buildPredicateTransaction(
-    wallet: Wallet,
-    amountToPredicate: BigNumberish,
-    assetId: BytesLike = NativeAssetId,
-    predicateOptions?: BuildPredicateOptions
-  ): Promise<ScriptTransactionRequest> {
-    const options = {
-      fundTransaction: true,
-      ...predicateOptions,
-    };
-    const request = new ScriptTransactionRequest({
-      gasLimit: MAX_GAS_PER_TX,
-      ...options,
-    });
-
-    // output is locked behind predicate
-    request.addCoinOutput(this.address, amountToPredicate, assetId);
-
-    const requiredCoinQuantities: CoinQuantityLike[] = [];
-    if (options.fundTransaction) {
-      requiredCoinQuantities.push(request.calculateFee());
-    }
-
-    if (requiredCoinQuantities.length) {
-      const coins = await wallet.getCoinsToSpend(requiredCoinQuantities);
-      request.addCoins(coins);
-    }
-
-    return request;
-  }
-
-  async submitPredicate(
-    wallet: Wallet,
-    amountToPredicate: BigNumberish,
-    assetId: BytesLike = NativeAssetId,
-    options?: BuildPredicateOptions
-  ): Promise<TransactionResult<'success'>> {
-    const request = await this.buildPredicateTransaction(
-      wallet,
-      amountToPredicate,
-      assetId,
-      options
-    );
-
-    const response = await wallet.sendTransaction(request);
-    return response.waitForResult();
-  }
-
-  async buildSpendPredicate(
-    wallet: Wallet,
-    amountToSpend: BigNumberish,
-    receiverAddress: AbstractAddress,
-    predicateData?: InputValue[],
-    assetId: BytesLike = NativeAssetId,
-    predicateOptions?: BuildPredicateOptions
-  ): Promise<ScriptTransactionRequest> {
-    const predicateCoins: Coin[] = await wallet.provider.getCoinsToSpend(this.address, [
-      [amountToSpend, assetId],
-    ]);
-    const options = {
-      fundTransaction: true,
-      ...predicateOptions,
-    };
-    const request = new ScriptTransactionRequest({
-      gasLimit: MAX_GAS_PER_TX,
-      ...options,
-    });
-
-    let encoded: undefined | Uint8Array;
-    if (predicateData && this.types) {
-      const abiCoder = new AbiCoder();
-      encoded = abiCoder.encode(this.types, predicateData);
-    }
-
-    let totalInPredicate = 0n;
-    predicateCoins.forEach((coin: Coin) => {
-      totalInPredicate += coin.amount;
-      request.addCoin({
-        ...coin,
-        predicate: this.bytes,
-        predicateData: encoded,
-      } as Coin);
-      request.outputs = [];
-    });
-
-    // output sent to receiver
-    request.addCoinOutput(receiverAddress, totalInPredicate, assetId);
-
-    const requiredCoinQuantities: CoinQuantityLike[] = [];
-    if (options.fundTransaction) {
-      requiredCoinQuantities.push(request.calculateFee());
-    }
-
-    if (requiredCoinQuantities.length) {
-      const coins = await wallet.getCoinsToSpend(requiredCoinQuantities);
-      request.addCoins(coins);
-    }
-
-    return request;
-  }
-
-  async submitSpendPredicate(
-    wallet: Wallet,
-    amountToSpend: BigNumberish,
-    receiverAddress: AbstractAddress,
-    predicateData?: InputValue[],
-    assetId: BytesLike = NativeAssetId,
-    options?: BuildPredicateOptions
-  ): Promise<TransactionResult<'success'>> {
-    const request = await this.buildSpendPredicate(
-      wallet,
-      amountToSpend,
-      receiverAddress,
-      predicateData,
-      assetId,
-      options
-    );
-
-    try {
-      const response = await wallet.sendTransaction(request);
-      return await response.waitForResult();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      const errors: { message: string }[] = error?.response?.errors || [];
-      if (
-        errors.some(({ message }) =>
-          message.includes('unexpected block execution error TransactionValidity(InvalidPredicate')
-        )
-      ) {
-        throw new Error('Invalid Predicate');
-      }
-
-      throw error;
-    }
   }
 }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -31,6 +31,7 @@
     "@ethersproject/bytes": "^5.4.0",
     "@ethersproject/networks": "^5.5.0",
     "@ethersproject/sha2": "^5.5.0",
+    "@fuel-ts/abi-coder": "workspace:*",
     "@fuel-ts/address": "workspace:*",
     "@fuel-ts/constants": "workspace:*",
     "@fuel-ts/interfaces": "workspace:*",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ethersproject/bytes": "^5.5.0",
+    "@fuel-ts/abi-coder": "workspace:*",
     "@fuel-ts/constants": "workspace:*",
     "@fuel-ts/math": "workspace:*",
     "@fuel-ts/hasher": "workspace:*",

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -1,8 +1,9 @@
 import type { BytesLike } from '@ethersproject/bytes';
+import type { InputValue } from '@fuel-ts/abi-coder';
 import { NativeAssetId } from '@fuel-ts/constants';
 import { hashMessage, hashTransaction } from '@fuel-ts/hasher';
 import { HDWallet } from '@fuel-ts/hdwallet';
-import type { AbstractAddress } from '@fuel-ts/interfaces';
+import type { AbstractAddress, AbstractPredicate } from '@fuel-ts/interfaces';
 import { AbstractWallet } from '@fuel-ts/interfaces';
 import type { BigNumberish } from '@fuel-ts/math';
 import { Mnemonic } from '@fuel-ts/mnemonic';
@@ -15,6 +16,8 @@ import type {
   CoinQuantityLike,
   CoinQuantity,
   CallResult,
+  BuildPredicateOptions,
+  TransactionResult,
 } from '@fuel-ts/providers';
 import { Signer } from '@fuel-ts/signer';
 import { MAX_GAS_PER_TX } from '@fuel-ts/transactions';
@@ -234,6 +237,70 @@ export default class Wallet extends AbstractWallet {
     return this.provider.call(this.populateTransactionWitnessesSignature(transactionRequest), {
       utxoValidation: true,
     });
+  }
+
+  async buildPredicateTransaction(
+    predicateAddress: AbstractAddress,
+    amountToPredicate: BigNumberish,
+    assetId: BytesLike = NativeAssetId,
+    predicateOptions?: BuildPredicateOptions
+  ): Promise<ScriptTransactionRequest> {
+    const options = {
+      fundTransaction: true,
+      ...predicateOptions,
+    };
+    const request = new ScriptTransactionRequest({
+      gasLimit: MAX_GAS_PER_TX,
+      ...options,
+    });
+
+    // output is locked behind predicate
+    request.addCoinOutput(predicateAddress, amountToPredicate, assetId);
+
+    const requiredCoinQuantities: CoinQuantityLike[] = [];
+    if (options.fundTransaction) {
+      requiredCoinQuantities.push(request.calculateFee());
+    }
+
+    if (requiredCoinQuantities.length) {
+      const coins = await this.getCoinsToSpend(requiredCoinQuantities);
+      request.addCoins(coins);
+    }
+
+    return request;
+  }
+
+  async submitPredicate(
+    predicateAddress: AbstractAddress,
+    amountToPredicate: BigNumberish,
+    assetId: BytesLike = NativeAssetId,
+    options?: BuildPredicateOptions
+  ): Promise<TransactionResult<'success'>> {
+    const request = await this.buildPredicateTransaction(
+      predicateAddress,
+      amountToPredicate,
+      assetId,
+      options
+    );
+    const response = await this.sendTransaction(request);
+    return response.waitForResult();
+  }
+
+  async submitSpendPredicate(
+    predicate: AbstractPredicate,
+    amountToSpend: BigNumberish,
+    predicateData?: InputValue[],
+    assetId: BytesLike = NativeAssetId,
+    options?: BuildPredicateOptions
+  ): Promise<TransactionResult<'success'>> {
+    return this.provider.submitSpendPredicate(
+      predicate,
+      amountToSpend,
+      this.address,
+      predicateData,
+      assetId,
+      options
+    );
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,29 +359,27 @@ importers:
       '@fuel-ts/constants': workspace:*
       '@fuel-ts/contract': workspace:*
       '@fuel-ts/interfaces': workspace:*
-      '@fuel-ts/keystore': workspace:*
       '@fuel-ts/math': workspace:*
       '@fuel-ts/providers': workspace:*
-      '@fuel-ts/transactions': workspace:*
       '@fuel-ts/wallet': workspace:*
     dependencies:
       '@ethersproject/bytes': 5.6.1
       '@fuel-ts/abi-coder': link:../abi-coder
       '@fuel-ts/address': link:../address
-      '@fuel-ts/constants': link:../constants
       '@fuel-ts/contract': link:../contract
       '@fuel-ts/interfaces': link:../interfaces
-      '@fuel-ts/keystore': link:../keystore
+      '@fuel-ts/wallet': link:../wallet
+    devDependencies:
+      '@fuel-ts/constants': link:../constants
       '@fuel-ts/math': link:../math
       '@fuel-ts/providers': link:../providers
-      '@fuel-ts/transactions': link:../transactions
-      '@fuel-ts/wallet': link:../wallet
 
   packages/providers:
     specifiers:
       '@ethersproject/bytes': ^5.4.0
       '@ethersproject/networks': ^5.5.0
       '@ethersproject/sha2': ^5.5.0
+      '@fuel-ts/abi-coder': workspace:*
       '@fuel-ts/address': workspace:*
       '@fuel-ts/constants': workspace:*
       '@fuel-ts/interfaces': workspace:*
@@ -403,6 +401,7 @@ importers:
       '@ethersproject/bytes': 5.6.1
       '@ethersproject/networks': 5.6.4
       '@ethersproject/sha2': 5.6.1
+      '@fuel-ts/abi-coder': link:../abi-coder
       '@fuel-ts/address': link:../address
       '@fuel-ts/constants': link:../constants
       '@fuel-ts/interfaces': link:../interfaces
@@ -497,6 +496,7 @@ importers:
   packages/wallet:
     specifiers:
       '@ethersproject/bytes': ^5.5.0
+      '@fuel-ts/abi-coder': workspace:*
       '@fuel-ts/constants': workspace:*
       '@fuel-ts/hasher': workspace:*
       '@fuel-ts/hdwallet': workspace:*
@@ -510,6 +510,7 @@ importers:
       '@fuel-ts/transactions': workspace:*
     dependencies:
       '@ethersproject/bytes': 5.6.1
+      '@fuel-ts/abi-coder': link:../abi-coder
       '@fuel-ts/constants': link:../constants
       '@fuel-ts/hasher': link:../hasher
       '@fuel-ts/hdwallet': link:../hdwallet


### PR DESCRIPTION
Fixes #392

This moves `Predicates` much closer to a streamlined approach. If using a `Wallet`, a developer can then leverage the wallet's address and coin information when interacting with Predicates, both in creation and spending.

If using a Predicate that has fees already pre-paid, developers can work through the `Provider` directly with the receiver address of their choice.