### PR TITLE
feat: Add ExcludeId to filter out utxo_ids on coinsToSpend

### DIFF
--- a/.changeset/tidy-parrots-care.md
+++ b/.changeset/tidy-parrots-care.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/providers": minor
+"@fuel-ts/wallet": minor
+---
+
+Add `excludeId` to getCoinsToSpend

--- a/packages/providers/src/operations.graphql
+++ b/packages/providers/src/operations.graphql
@@ -208,8 +208,14 @@ query getCoinsToSpend(
   $owner: Address!
   $spendQuery: [SpendQueryElementInput!]!
   $maxInputs: Int
+  $excludedIds: [UtxoId!]
 ) {
-  coinsToSpend(owner: $owner, spendQuery: $spendQuery, maxInputs: $maxInputs) {
+  coinsToSpend(
+    owner: $owner
+    spendQuery: $spendQuery
+    maxInputs: $maxInputs
+    excludedIds: $excludedIds
+  ) {
     ...coinFragment
   }
 }

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -371,7 +371,9 @@ export default class Provider {
     /** The quantitites to get */
     quantities: CoinQuantityLike[],
     /** Maximum number of coins to return */
-    maxInputs?: number
+    maxInputs?: number,
+    /** IDs of coins to exclude */
+    excludedIds?: BytesLike[]
   ): Promise<Coin[]> {
     const result = await this.operations.getCoinsToSpend({
       owner: owner.toB256(),
@@ -380,6 +382,7 @@ export default class Provider {
         amount: quantity.amount.toString(),
       })),
       maxInputs,
+      excludedIds: excludedIds?.map((id) => hexlify(id)),
     });
 
     const coins = result.coinsToSpend;

--- a/packages/wallet/src/transfer.test.ts
+++ b/packages/wallet/src/transfer.test.ts
@@ -1,6 +1,5 @@
 import { NativeAssetId } from '@fuel-ts/constants';
 import { Provider, ScriptTransactionRequest } from '@fuel-ts/providers';
-import { assert } from 'console';
 
 import { generateTestWallet } from './test-utils';
 

--- a/packages/wallet/src/transfer.test.ts
+++ b/packages/wallet/src/transfer.test.ts
@@ -1,5 +1,6 @@
 import { NativeAssetId } from '@fuel-ts/constants';
 import { Provider, ScriptTransactionRequest } from '@fuel-ts/providers';
+import { assert } from 'console';
 
 import { generateTestWallet } from './test-utils';
 
@@ -41,6 +42,26 @@ describe('Wallet', () => {
     expect(senderBalances).toEqual([{ assetId: NativeAssetId, amount: 99n }]);
     const receiverBalances = await receiver.getBalances();
     expect(receiverBalances).toEqual([{ assetId: NativeAssetId, amount: 1n }]);
+  });
+
+  it('can exclude IDs when getCoinsToSpend is called', async () => {
+    const provider = new Provider('http://127.0.0.1:4000/graphql');
+
+    const assetIdA = '0x0101010101010101010101010101010101010101010101010101010101010101';
+    const assetIdB = '0x0202020202020202020202020202020202020202020202020202020202020202';
+
+    const user = await generateTestWallet(provider, [
+      [1n, assetIdA],
+      [1n, assetIdB],
+      [10n, NativeAssetId],
+    ]);
+
+    const coins = await user.getCoins();
+
+    // Test excludes the UTXO where the assetIdA gets added to the senders wallet
+    await expect(user.getCoinsToSpend([[1n, assetIdA]], 100, [coins[0].id])).rejects.toThrow(
+      /enough coins could not be found/
+    );
   });
 
   it('can transfer multiple types of coins to multiple destinations', async () => {

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -108,8 +108,14 @@ export default class Wallet extends AbstractWallet {
   /**
    * Returns coins satisfying the spend query.
    */
-  async getCoinsToSpend(quantities: CoinQuantityLike[]): Promise<Coin[]> {
-    return this.provider.getCoinsToSpend(this.address, quantities);
+  async getCoinsToSpend(
+    quantities: CoinQuantityLike[],
+    /** Maximum number of coins to return */
+    maxInputs?: number,
+    /** IDs of coins to exclude */
+    excludedIds?: BytesLike[]
+  ): Promise<Coin[]> {
+    return this.provider.getCoinsToSpend(this.address, quantities, maxInputs, excludedIds);
   }
 
   /**


### PR DESCRIPTION
Closes out https://github.com/FuelLabs/fuels-ts/pull/226

## TLDR

Users can filter out utxo's from `getCoinsToSpend`