### PR TITLE
docs: Update QUICKSTART.md to use `run` with `fuel-core`

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -132,7 +132,7 @@ all the time, if you close the terminal/window the node will automatically stop 
 Inside `my-fuel-dapp` run;
 
 ```sh
-fuel-core --ip 127.0.0.1 --port 4000 --chain ./chainConfig.json
+fuel-core run --ip 127.0.0.1 --port 4000 --chain ./chainConfig.json
 ```
 
 You should see the following output:


### PR DESCRIPTION
To avoid a deprecation warning.