### PR TITLE
feat: change fundTransaction default to false on contract get

### DIFF
--- a/.changeset/short-cobras-remain.md
+++ b/.changeset/short-cobras-remain.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/contract": minor
+---
+
+Change contract get to not fund transaction by default

--- a/packages/contract/src/contracts/functions/base-invocation-scope.ts
+++ b/packages/contract/src/contracts/functions/base-invocation-scope.ts
@@ -244,9 +244,14 @@ export class BaseInvocationScope<TReturn = any> {
   /**
    * Executes a readonly contract method call.
    *
-   * Under the hood it uses the `dryRun` method.
+   * Under the hood it uses the `dryRun` method but don't fund the transaction
+   * with coins by default, for emulating executions with forward coins use `dryRun`
+   * or pass the options.fundTransaction as true
    */
   async get<T = TReturn>(options?: CallOptions): Promise<InvocationCallResult<T>> {
-    return this.dryRun<T>(options);
+    return this.dryRun<T>({
+      fundTransaction: false,
+      ...options,
+    });
   }
 }


### PR DESCRIPTION
When using the get method on contract calls the users probably just want to read the value and not forward coins, etc. To emulate contract calls with forwarding the correct method would be `dryRun`.