### PR TITLE
fix: dryRun should fundTransaction with required coins

### DIFF
--- a/.changeset/slimy-timers-hope.md
+++ b/.changeset/slimy-timers-hope.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/contract": minor
+---
+
+Fix contract dryRun await for required funds to be populated

--- a/packages/contract/src/contracts/functions/base-invocation-scope.ts
+++ b/packages/contract/src/contracts/functions/base-invocation-scope.ts
@@ -233,7 +233,7 @@ export class BaseInvocationScope<TReturn = any> {
     const provider = (this.contract.wallet?.provider || this.contract.provider) as Provider;
     assert(provider, 'Wallet or Provider is required!');
 
-    this.prepareTransaction(options);
+    await this.prepareTransaction(options);
     const request = transactionRequestify(this.transactionRequest);
     const response = await provider.call(request, {
       utxoValidation: false,

--- a/packages/fuel-gauge/src/contract.test.ts
+++ b/packages/fuel-gauge/src/contract.test.ts
@@ -376,7 +376,6 @@ describe('Contract', () => {
 
   it('Get transaction cost with gasPrice 1', async () => {
     const contract = await setupContract();
-
     const invocationScope = contract
       .multiCall([
         contract.functions.return_context_amount().callParams({
@@ -548,5 +547,33 @@ describe('Contract', () => {
       .call();
 
     expect(enumStrReturnData).toEqual('efg');
+  });
+
+  it('dryRun and get should not validate the signature', async () => {
+    const contract = await setupContract();
+    const { value } = await contract
+      .multiCall([
+        contract.functions.return_context_amount().callParams({
+          forward: [100, NativeAssetId],
+        }),
+        contract.functions.return_context_amount().callParams({
+          forward: [200, AltToken],
+        }),
+      ])
+      .dryRun();
+    expect(JSON.stringify(value)).toEqual(JSON.stringify([bn(100), bn(200)]));
+  });
+
+  it('get should not fundTransaction', async () => {
+    const contract = await setupContract();
+
+    expect(async () => {
+      await contract.functions
+        .return_context_amount()
+        .callParams({
+          forward: [200, AltToken],
+        })
+        .get();
+    }).rejects.toThrow();
   });
 });


### PR DESCRIPTION
The code was missing an await on the `prepareTransaction`, making it run without adding the required funds.