### PR TITLE
refactor: change sign methods to be async

### DIFF
--- a/.changeset/soft-elephants-drum.md
+++ b/.changeset/soft-elephants-drum.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/wallet": minor
+"@fuel-ts/wallet-manager": minor
+---
+
+Change sign methods to be async

--- a/packages/wallet-manager/src/wallet-manager.test.ts
+++ b/packages/wallet-manager/src/wallet-manager.test.ts
@@ -258,7 +258,7 @@ describe('Wallet Manager', () => {
     // Get Wallet instance
     const wallet = walletManager.getWallet(accounts[0].address);
     // Sign message
-    const signedMessage = wallet.signMessage('hello');
+    const signedMessage = await wallet.signMessage('hello');
     // Verify signedMessage is the same from account 0
     const address = Signer.recoverAddress(hashMessage('hello'), signedMessage);
     expect(address).toEqual(accounts[0].address);

--- a/packages/wallet/src/wallet.test.ts
+++ b/packages/wallet/src/wallet.test.ts
@@ -19,7 +19,7 @@ describe('Wallet', () => {
 
   it('Sign a message using wallet instance', async () => {
     const wallet = new Wallet(signMessageTest.privateKey);
-    const signedMessage = wallet.signMessage(signMessageTest.message);
+    const signedMessage = await wallet.signMessage(signMessageTest.message);
     const verifiedAddress = Signer.recoverAddress(
       hashMessage(signMessageTest.message),
       signedMessage
@@ -32,7 +32,7 @@ describe('Wallet', () => {
   it('Sign a transaction using wallet instance', async () => {
     const wallet = new Wallet(signTransactionTest.privateKey);
     const transactionRequest = signTransactionTest.transaction;
-    const signedTransaction = wallet.signTransaction(transactionRequest);
+    const signedTransaction = await wallet.signTransaction(transactionRequest);
     const verifiedAddress = Signer.recoverAddress(
       hashTransaction(transactionRequest),
       signedTransaction
@@ -45,8 +45,10 @@ describe('Wallet', () => {
   it('Populate transaction witnesses signature using wallet instance', async () => {
     const wallet = new Wallet(signTransactionTest.privateKey);
     const transactionRequest = signTransactionTest.transaction;
-    const signedTransaction = wallet.signTransaction(transactionRequest);
-    const populatedTransaction = wallet.populateTransactionWitnessesSignature(transactionRequest);
+    const signedTransaction = await wallet.signTransaction(transactionRequest);
+    const populatedTransaction = await wallet.populateTransactionWitnessesSignature(
+      transactionRequest
+    );
 
     expect(populatedTransaction.witnesses?.[0]).toBe(signedTransaction);
   });
@@ -56,9 +58,9 @@ describe('Wallet', () => {
     const privateKey = randomBytes(32);
     const otherWallet = new Wallet(privateKey);
     const transactionRequest = signTransactionTest.transaction;
-    const signedTransaction = wallet.signTransaction(transactionRequest);
-    const otherSignedTransaction = otherWallet.signTransaction(transactionRequest);
-    const populatedTransaction = wallet.populateTransactionWitnessesSignature({
+    const signedTransaction = await wallet.signTransaction(transactionRequest);
+    const otherSignedTransaction = await otherWallet.signTransaction(transactionRequest);
+    const populatedTransaction = await wallet.populateTransactionWitnessesSignature({
       ...transactionRequest,
       witnesses: [...transactionRequest.witnesses, otherSignedTransaction],
     });
@@ -93,7 +95,7 @@ describe('Wallet', () => {
   it('Generate a new random wallet', async () => {
     const wallet = Wallet.generate();
     const message = 'test';
-    const signedMessage = wallet.signMessage(message);
+    const signedMessage = await wallet.signMessage(message);
     const hashedMessage = hashMessage(message);
     const recoveredAddress = Signer.recoverAddress(hashedMessage, signedMessage);
 
@@ -107,7 +109,7 @@ describe('Wallet', () => {
       entropy: randomBytes(32),
     });
     const message = 'test';
-    const signedMessage = wallet.signMessage(message);
+    const signedMessage = await wallet.signMessage(message);
     const hashedMessage = hashMessage(message);
     const recoveredAddress = Signer.recoverAddress(hashedMessage, signedMessage);
 


### PR DESCRIPTION
This PR changes the sign methods to be async in this way is possible to implement Signer classes that require an async process like Wallet Extension or Hardware Wallets.