### PR TITLE
feat: update fuel-core v0.13

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,7 @@ const config: Config.InitialOptions = {
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   modulePathIgnorePatterns: ['/dist/'],
   coveragePathIgnorePatterns: ['/dist/'],
+  testTimeout: 15000,
 };
 
 export default config;

--- a/packages/contract/src/contracts/multicall/Forc.toml
+++ b/packages/contract/src/contracts/multicall/Forc.toml
@@ -3,4 +3,3 @@ license = "Apache-2.0"
 name = "multicall"
 
 [dependencies]
-std = { path = "/Users/luizstacio/fuels/sway/sway-lib-std" }

--- a/packages/forc-bin/package.json
+++ b/packages/forc-bin/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "forc-bin",
-  "version": "0.26.1",
+  "version": "0.28.1",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
@@ -28,7 +28,7 @@
     "forc": "./forc.js"
   },
   "config": {
-    "forcVersion": "0.26.0"
+    "forcVersion": "0.28.1"
   },
   "dependencies": {
     "node-fetch": "^2.6.7",

--- a/packages/fuel-gauge/scripts/build.sh
+++ b/packages/fuel-gauge/scripts/build.sh
@@ -6,7 +6,7 @@ for PROJECT_DIR in ./test-projects/* ;
 do
   BIN_DIR="$PROJECT_DIR/out/debug"
 
-  forc build -p $PROJECT_DIR --print-finalized-asm
+  pnpm forc build -p $PROJECT_DIR --print-finalized-asm
   if [[ $PROJECT_DIR == *"predicate-"* ]]; then
     pnpm exec ts-node scripts/process-predicate.ts $PROJECT_DIR
   fi

--- a/packages/fuel-gauge/src/coverage-contract.test.ts
+++ b/packages/fuel-gauge/src/coverage-contract.test.ts
@@ -1,5 +1,7 @@
 import type { BN, Message, Contract } from 'fuels';
 import {
+  zeroPad,
+  arrayify,
   NativeAssetId,
   bn,
   toHex,
@@ -353,7 +355,9 @@ describe('Coverage Contract', () => {
         amount: bn(1),
         sender: WALLET_B.address,
         recipient: WALLET_A.address,
-        data: [8, 7, 6, 5, 4],
+        data: arrayify(
+          '0x00000000000000080000000000000007000000000000000600000000000000050000000000000004'
+        ),
         nonce: bn(1),
         daHeight: bn(0),
       },
@@ -363,7 +367,7 @@ describe('Coverage Contract', () => {
         amount: bn('12704439083013451934'),
         sender: WALLET_A.address,
         recipient: WALLET_B.address,
-        data: [7],
+        data: arrayify('0x0000000000000007'),
         nonce: bn('1017517292834129547'),
         daHeight: bn('3684546456337077810'),
       },
@@ -388,19 +392,17 @@ describe('Coverage Contract', () => {
         amount: bn(900),
         sender: sender.address,
         recipient: receiver.address,
-        data: [12, 13, 14],
+        data: zeroPad([12, 13, 14], 8),
         nonce: bn(823),
         daHeight: bn(0),
       },
     ];
-
     request.addMessages(messages);
     const response = await sender.sendTransaction(request);
-
-    await response.wait();
+    await response.waitForResult();
     const receiverMessages = await receiver.getMessages();
 
-    expect(receiverMessages).toStrictEqual(messages);
+    expect(receiverMessages).toEqual(messages);
   });
 
   it('should test sending input messages [3]', async () => {
@@ -415,7 +417,7 @@ describe('Coverage Contract', () => {
         amount: bn(111),
         sender: sender.address,
         recipient: receiver.address,
-        data: [11, 11, 11],
+        data: zeroPad([11, 11, 11], 8),
         nonce: bn(100),
         daHeight: bn(0),
       },
@@ -423,7 +425,7 @@ describe('Coverage Contract', () => {
         amount: bn(222),
         sender: sender.address,
         recipient: receiver.address,
-        data: [22, 22, 22],
+        data: zeroPad([22, 22, 22], 8),
         nonce: bn(200),
         daHeight: bn(0),
       },
@@ -431,7 +433,7 @@ describe('Coverage Contract', () => {
         amount: bn(333),
         sender: sender.address,
         recipient: receiver.address,
-        data: [33, 33, 33],
+        data: zeroPad([33, 33, 33], 8),
         nonce: bn(300),
         daHeight: bn(0),
       },

--- a/packages/fuel-gauge/test-projects/coverage-contract/src/main.sw
+++ b/packages/fuel-gauge/test-projects/coverage-contract/src/main.sw
@@ -8,7 +8,6 @@ use std::vec::Vec;
 use std::option::Option;
 use std::assert::assert;
 use std::logging::log;
-use std::mem::addr_of;
 
 pub struct U8Struct {
     i: u8,
@@ -154,7 +153,7 @@ impl CoverageContract for Contract {
                 log("vector.len");
                 log(vector.len);
                 log("addr_of vector");
-                log(addr_of(vector));
+                log(__addr_of(vector));
                 true
             },
         }

--- a/packages/providers/fuel-core-schema.graphql
+++ b/packages/providers/fuel-core-schema.graphql
@@ -49,10 +49,8 @@ input BalanceFilterInput {
 
 type Block {
   id: BlockId!
-  height: U64!
+  header: Header!
   transactions: [Transaction!]!
-  time: DateTime!
-  producer: Address!
 }
 
 type BlockConnection {
@@ -281,6 +279,58 @@ type FailureStatus {
   programState: ProgramState
 }
 
+type Header {
+  """
+  Hash of the header
+  """
+  id: BlockId!
+
+  """
+  The layer 1 height of messages and events to include since the last layer 1 block number.
+  """
+  daHeight: U64!
+
+  """
+  Number of transactions in this block.
+  """
+  transactionsCount: U64!
+
+  """
+  Number of output messages in this block.
+  """
+  outputMessagesCount: U64!
+
+  """
+  Merkle root of transactions.
+  """
+  transactionsRoot: Bytes32!
+
+  """
+  Merkle root of messages in this block.
+  """
+  outputMessagesRoot: Bytes32!
+
+  """
+  Fuel block height.
+  """
+  height: U64!
+
+  """
+  Merkle root of all previous block header hashes.
+  """
+  prevRoot: Bytes32!
+
+  """
+  The block producer time.
+  """
+  time: DateTime!
+
+  """
+  Hash of the application header.
+  """
+  applicationHash: Bytes32!
+}
+
 scalar HexString
 
 union Input = InputCoin | InputContract | InputMessage
@@ -323,7 +373,7 @@ type Message {
   sender: Address!
   recipient: Address!
   nonce: U64!
-  data: [Int!]!
+  data: HexString!
   daHeight: U64!
   fuelBlockSpend: U64
 }
@@ -367,6 +417,18 @@ type MessageOutput {
   amount: U64!
 }
 
+type MessageProof {
+  proofSet: [Bytes32!]!
+  proofIndex: U64!
+  sender: Address!
+  recipient: Address!
+  nonce: Bytes32!
+  amount: U64!
+  data: HexString!
+  signature: Signature!
+  header: Header!
+}
+
 type Mutation {
   startSession: ID!
   endSession(id: ID!): Boolean!
@@ -386,12 +448,11 @@ type Mutation {
   Submits transaction to the txpool
   """
   submit(tx: HexString!): Transaction!
-  produceBlocks(blocksToProduce: U64!): U64!
+  produceBlocks(blocksToProduce: U64!, time: TimeParameters): U64!
 }
 
 type NodeInfo {
   utxoValidation: Boolean!
-  predicates: Boolean!
   vmBacktrace: Boolean!
   minGasPrice: U64!
   maxTx: U64!
@@ -542,6 +603,10 @@ type Query {
     last: Int
     before: String
   ): MessageConnection!
+  messageProof(
+    transactionId: TransactionId!
+    messageId: MessageId!
+  ): MessageProof
 
   """
   For each `query_per_asset`, get some spendable resources(of asset specified by the query) owned by
@@ -603,6 +668,7 @@ type Receipt {
   sender: Address
   recipient: Address
   nonce: Bytes32
+  contractId: ContractId
 }
 
 enum ReceiptType {
@@ -650,6 +716,8 @@ enum RunState {
 
 scalar Salt
 
+scalar Signature
+
 input SpendQueryElementInput {
   """
   Identifier of the asset to spend.
@@ -674,20 +742,35 @@ type SubmittedStatus {
 type SuccessStatus {
   block: Block!
   time: DateTime!
-  programState: ProgramState!
+  programState: ProgramState
+}
+
+input TimeParameters {
+  """
+  The time to set on the first block
+  """
+  startTime: U64!
+
+  """
+  The time interval between subsequent blocks
+  """
+  blockTimeInterval: U64!
 }
 
 type Transaction {
   id: TransactionId!
-  inputAssetIds: [AssetId!]!
-  inputContracts: [Contract!]!
-  gasPrice: U64!
-  gasLimit: U64!
-  maturity: U64!
+  inputAssetIds: [AssetId!]
+  inputContracts: [Contract!]
+  gasPrice: U64
+  gasLimit: U64
+  maturity: U64
+  txPointer: TxPointer
   isScript: Boolean!
-  inputs: [Input!]!
+  isCreate: Boolean!
+  isMint: Boolean!
+  inputs: [Input!]
   outputs: [Output!]!
-  witnesses: [HexString!]!
+  witnesses: [HexString!]
   receiptsRoot: Bytes32
   status: TransactionStatus
   receipts: [Receipt!]

--- a/packages/providers/src/message.ts
+++ b/packages/providers/src/message.ts
@@ -1,3 +1,4 @@
+import type { BytesLike } from '@ethersproject/bytes';
 import type { AbstractAddress } from '@fuel-ts/interfaces';
 import type { BN } from '@fuel-ts/math';
 
@@ -8,7 +9,7 @@ export type Message = {
   amount: BN;
   sender: AbstractAddress;
   recipient: AbstractAddress;
-  data: number[];
+  data: BytesLike;
   daHeight: BN;
   nonce: BN;
 };

--- a/packages/providers/src/operations.graphql
+++ b/packages/providers/src/operations.graphql
@@ -39,12 +39,13 @@ fragment receiptFragment on Receipt {
 
 fragment blockFragment on Block {
   id
-  height
-  producer
+  header {
+    height
+    time
+  }
   transactions {
     id
   }
-  time
 }
 
 fragment coinFragment on Coin {

--- a/packages/providers/src/provider.test.ts
+++ b/packages/providers/src/provider.test.ts
@@ -67,7 +67,7 @@ describe('Provider', () => {
   // importing and testing it here can generate cycle dependency
   // as we test this in other modules like call contract its ok to
   // skip for now
-  it('can sendTransaction()', async () => {
+  it.skip('can sendTransaction()', async () => {
     const provider = new Provider('http://127.0.0.1:4000/graphql');
 
     const response = await provider.sendTransaction({

--- a/packages/providers/src/provider.test.ts
+++ b/packages/providers/src/provider.test.ts
@@ -13,7 +13,7 @@ describe('Provider', () => {
 
     const version = await provider.getVersion();
 
-    expect(version).toEqual('0.11.2');
+    expect(version).toEqual('0.13.0');
   });
 
   it('can call()', async () => {
@@ -55,7 +55,7 @@ describe('Provider', () => {
       {
         type: ReceiptType.ScriptResult,
         result: bn(0),
-        gasUsed: bn(0x2c),
+        gasUsed: bn(0x86b),
       },
     ];
 
@@ -67,7 +67,7 @@ describe('Provider', () => {
   // importing and testing it here can generate cycle dependency
   // as we test this in other modules like call contract its ok to
   // skip for now
-  it.skip('can sendTransaction()', async () => {
+  it('can sendTransaction()', async () => {
     const provider = new Provider('http://127.0.0.1:4000/graphql');
 
     const response = await provider.sendTransaction({

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -53,7 +53,6 @@ export type Block = {
   id: string;
   height: BN;
   time: string;
-  producer: string;
   transactionIds: string[];
 };
 
@@ -80,7 +79,6 @@ export type ChainInfo = {
   latestBlock: {
     id: string;
     height: BN;
-    producer: string;
     time: string;
     transactions: Array<{ id: string }>;
   };
@@ -133,9 +131,8 @@ const processGqlChain = (chain: GqlChainInfoFragmentFragment): ChainInfo => ({
   },
   latestBlock: {
     id: chain.latestBlock.id,
-    height: bn(chain.latestBlock.height),
-    producer: chain.latestBlock.producer,
-    time: chain.latestBlock.time,
+    height: bn(chain.latestBlock.header.height),
+    time: chain.latestBlock.header.time,
     transactions: chain.latestBlock.transactions.map((i) => ({
       id: i.id,
     })),
@@ -212,7 +209,7 @@ export default class Provider {
    */
   async getBlockNumber(): Promise<BN> {
     const { chain } = await this.operations.getChain();
-    return bn(chain.latestBlock.height, 10);
+    return bn(chain.latestBlock.header.height, 10);
   }
 
   /**
@@ -428,9 +425,8 @@ export default class Provider {
 
     return {
       id: block.id,
-      height: bn(block.height),
-      time: block.time,
-      producer: block.producer,
+      height: bn(block.header.height),
+      time: block.header.time,
       transactionIds: block.transactions.map((tx) => tx.id),
     };
   }
@@ -459,9 +455,8 @@ export default class Provider {
 
     return {
       id: block.id,
-      height: bn(block.height, 10),
-      time: block.time,
-      producer: block.producer,
+      height: bn(block.header.height, 10),
+      time: block.header.time,
       transactionIds: block.transactions.map((tx) => tx.id),
       transactions: block.transactions.map(
         (tx) => new TransactionCoder().decode(arrayify(tx.rawPayload), 0)?.[0]

--- a/packages/providers/src/resource.ts
+++ b/packages/providers/src/resource.ts
@@ -16,7 +16,7 @@ export type RawMessage = {
   amount: string;
   sender: string;
   recipient: string;
-  data: Array<number>;
+  data: string;
   nonce: string;
   daHeight: string;
 };

--- a/packages/providers/src/transaction-request/input.ts
+++ b/packages/providers/src/transaction-request/input.ts
@@ -52,7 +52,7 @@ export type MessageTransactionRequestInput = {
   witnessIndex: number;
 
   /** data of message */
-  data: number[];
+  data: BytesLike;
 
   /** Unique nonce of message */
   nonce: BigNumberish;
@@ -132,7 +132,7 @@ export const inputify = (value: TransactionRequestInput): Input => {
         dataLength: value.data.length,
         predicateLength: predicate.length,
         predicateDataLength: predicateData.length,
-        data: value.data,
+        data: hexlify(value.data),
         predicate: hexlify(predicate),
         predicateData: hexlify(predicateData),
       };

--- a/packages/providers/src/util.ts
+++ b/packages/providers/src/util.ts
@@ -95,3 +95,11 @@ export const getGasUsedFromReceipts = (receipts: Array<TransactionResultReceipt>
 
   return bn(0);
 };
+
+export function sleep(time: number = 1000) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(true);
+    }, time);
+  });
+}

--- a/packages/transactions/src/coders/input.test.ts
+++ b/packages/transactions/src/coders/input.test.ts
@@ -1,4 +1,4 @@
-import { arrayify, hexlify } from '@ethersproject/bytes';
+import { arrayify, hexlify, zeroPad } from '@ethersproject/bytes';
 import { bn } from '@fuel-ts/math';
 
 import type { Input, InputMessage } from './input';
@@ -69,7 +69,7 @@ describe('InputCoder', () => {
       amount: bn(1000),
       sender: '0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e',
       recipient: '0xef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a',
-      data: [12, 13, 14],
+      data: hexlify(zeroPad([12, 13, 14], 8)),
       nonce: bn(1234),
       witnessIndex: 0,
       dataLength: 3,
@@ -91,7 +91,7 @@ describe('InputCoder', () => {
       amount: bn(1000),
       sender: '0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e',
       recipient: '0xef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a',
-      data: [12, 13, 14],
+      data: hexlify(zeroPad([12, 13, 14], 8)),
       nonce: bn(1234),
       witnessIndex: 0,
       dataLength: 3,

--- a/packages/wallet/src/transfer.test.ts
+++ b/packages/wallet/src/transfer.test.ts
@@ -11,7 +11,8 @@ describe('Wallet', () => {
     const sender = await generateTestWallet(provider, [[100, NativeAssetId]]);
     const receiver = await generateTestWallet(provider);
 
-    await sender.transfer(receiver.address, 1, NativeAssetId);
+    const response = await sender.transfer(receiver.address, 1, NativeAssetId);
+    await response.wait();
 
     const senderBalances = await sender.getBalances();
     expect(senderBalances).toEqual([{ assetId: NativeAssetId, amount: bn(99) }]);
@@ -32,11 +33,12 @@ describe('Wallet', () => {
         gasPrice: 1,
       });
       await result.wait();
-    }).rejects.toThrowError(`gasLimit(${bn(1)}) is lower than the required (${bn(11)})`);
+    }).rejects.toThrowError(`gasLimit(${bn(1)}) is lower than the required (${bn(1335)})`);
 
-    await sender.transfer(receiver.address, 1, NativeAssetId, {
+    const response = await sender.transfer(receiver.address, 1, NativeAssetId, {
       gasLimit: 10000,
     });
+    await response.wait();
     const senderBalances = await sender.getBalances();
     expect(senderBalances).toEqual([{ assetId: NativeAssetId, amount: bn(99) }]);
     const receiverBalances = await receiver.getBalances();

--- a/services/fuel-core/Dockerfile
+++ b/services/fuel-core/Dockerfile
@@ -1,5 +1,5 @@
 # v0.10.1 +plus
-FROM ghcr.io/fuellabs/fuel-core:v0.11.2
+FROM ghcr.io/fuellabs/fuel-core:v0.13.0
 
 ARG IP=0.0.0.0
 ARG PORT=4000
@@ -24,7 +24,6 @@ CMD exec ./fuel-core run \
     --db-path ${DB_PATH} \
     --min-gas-price ${MIN_GAS_PRICE} \
     --vm-backtrace \
-    --predicates \
     --chain ./chainConfig.json
 
 EXPOSE ${PORT}

--- a/services/fuel-core/chainConfig.json
+++ b/services/fuel-core/chainConfig.json
@@ -8,7 +8,7 @@
   "parent_network": {
     "type": "LocalTest"
   },
-  "block_gas_limit": 1000000,
+  "block_gas_limit": 1000000000,
   "initial_state": {
     "coins": [
       {
@@ -285,7 +285,12 @@
     "max_storage_slots": 255,
     "max_predicate_length": 1048576,
     "max_predicate_data_length": 1048576,
-    "gas_price_factor": 1000000,
+    "gas_price_factor": 1000000000,
+    "gas_per_byte": 4,
     "max_message_data_length": 1048576
+  },
+  "block_producer": {
+    "utxo_validation": true,
+    "coinbase_recipient": "0x0000000000000000000000000000000000000000000000000000000000000000"
   }
 }


### PR DESCRIPTION
This PR update fuels-ts to work with fuel-core v0.13.

On this PR, I had to update message handling. The previous implementation led to errors in the message Id calculation, it would be great to get a deeper look from @camsjams. Looking at the specs, it looks like message data should be encoded and decoded in the same way predicateData is.
On the sway side, we have a blocker related to storage persistency, as the latest is not yet compatible with fuel-core v0.13.

Blockers;
https://github.com/FuelLabs/sway/pull/3181
https://github.com/FuelLabs/fuel-core/pull/737