### PR TITLE
feat: adding new `versions` package

### DIFF
--- a/.changeset/fluffy-dancers-beam.md
+++ b/.changeset/fluffy-dancers-beam.md
@@ -1,0 +1,11 @@
+---
+"@fuel-ts/abi-coder": minor
+"@fuel-ts/address": minor
+"@fuel-ts/contract": minor
+"forc-bin": minor
+"fuels": minor
+"@fuel-ts/predicate": minor
+"@fuel-ts/versions": minor
+---
+
+Adding new `versions` package for exposing and managing compatibility versions of Fuel toolchain components

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          pnpm build
+          BUILD_VERSION="0.0.0-${{ github.ref_name }}-$(git rev-parse --short $GITHUB_SHA)" pnpm build
 
       - name: Lint
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          BUILD_VERSION="0.0.0-${{ github.ref_name }}-$(git rev-parse --short $GITHUB_SHA)" pnpm build
+          pnpm build
 
       - name: Lint
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts=true

--- a/packages/abi-coder/package.json
+++ b/packages/abi-coder/package.json
@@ -30,9 +30,10 @@
     "@ethersproject/sha2": "^5.7.0",
     "@ethersproject/strings": "^5.7.0",
     "@fuel-ts/math": "workspace:*",
+    "@fuel-ts/versions": "workspace:*",
     "type-fest": "^3.1.0"
   },
   "scripts": {
-    "build": "tsup --dts --env.BUILD_VERSION $BUILD_VERSION"
+    "build": "tsup --dts"
   }
 }

--- a/packages/abi-coder/src/abi-coder.ts
+++ b/packages/abi-coder/src/abi-coder.ts
@@ -2,6 +2,7 @@
 import type { BytesLike } from '@ethersproject/bytes';
 import { concat, arrayify } from '@ethersproject/bytes';
 import { Logger } from '@ethersproject/logger';
+import { versions } from '@fuel-ts/versions';
 
 import type { DecodedValue, InputValue } from './coders/abstract-coder';
 import type Coder from './coders/abstract-coder';
@@ -29,7 +30,7 @@ import {
 import type { JsonAbiFragmentType } from './json-abi';
 import { filterEmptyParams, getVectorAdjustments, hasOptionTypes } from './utilities';
 
-const logger = new Logger(process.env.BUILD_VERSION || '~');
+const logger = new Logger(versions.FUELS_TS_SDK);
 
 export default class AbiCoder {
   constructor() {

--- a/packages/abi-coder/src/abi-coder.ts
+++ b/packages/abi-coder/src/abi-coder.ts
@@ -30,7 +30,7 @@ import {
 import type { JsonAbiFragmentType } from './json-abi';
 import { filterEmptyParams, getVectorAdjustments, hasOptionTypes } from './utilities';
 
-const logger = new Logger(versions.FUELS_TS_SDK);
+const logger = new Logger(versions.FUELS);
 
 export default class AbiCoder {
   constructor() {

--- a/packages/abi-coder/src/coders/abstract-coder.ts
+++ b/packages/abi-coder/src/coders/abstract-coder.ts
@@ -5,7 +5,7 @@ import { versions } from '@fuel-ts/versions';
 
 import type { Option } from './option';
 
-const logger = new Logger(versions.FUELS_TS_SDK);
+const logger = new Logger(versions.FUELS);
 
 type Primitive = string | number | boolean;
 

--- a/packages/abi-coder/src/coders/abstract-coder.ts
+++ b/packages/abi-coder/src/coders/abstract-coder.ts
@@ -1,8 +1,11 @@
 import type { BytesLike } from '@ethersproject/bytes';
 import { Logger } from '@ethersproject/logger';
 import type { BN } from '@fuel-ts/math';
+import { versions } from '@fuel-ts/versions';
 
-const logger = new Logger(process.env.BUILD_VERSION || '~');
+import type { Option } from './option';
+
+const logger = new Logger(versions.FUELS_TS_SDK);
 
 type Primitive = string | number | boolean;
 

--- a/packages/abi-coder/src/interface.ts
+++ b/packages/abi-coder/src/interface.ts
@@ -4,6 +4,7 @@ import { arrayify, concat, hexlify } from '@ethersproject/bytes';
 import { Logger } from '@ethersproject/logger';
 import { sha256 } from '@ethersproject/sha2';
 import { toUtf8Bytes } from '@ethersproject/strings';
+import { versions } from '@fuel-ts/versions';
 
 import AbiCoder from './abi-coder';
 import type { InputValue } from './coders/abstract-coder';
@@ -20,7 +21,7 @@ import type {
 import { isFlatJsonAbi, ABI, isReferenceType } from './json-abi';
 import { filterEmptyParams } from './utilities';
 
-const logger = new Logger(process.env.BUILD_VERSION || '~');
+const logger = new Logger(versions.FUELS_TS_SDK);
 
 const coerceFragments = (value: ReadonlyArray<JsonAbiFragment>): Array<Fragment> => {
   const fragments: Array<Fragment> = [];

--- a/packages/abi-coder/src/interface.ts
+++ b/packages/abi-coder/src/interface.ts
@@ -21,7 +21,7 @@ import type {
 import { isFlatJsonAbi, ABI, isReferenceType } from './json-abi';
 import { filterEmptyParams } from './utilities';
 
-const logger = new Logger(versions.FUELS_TS_SDK);
+const logger = new Logger(versions.FUELS);
 
 const coerceFragments = (value: ReadonlyArray<JsonAbiFragment>): Array<Fragment> => {
   const fragments: Array<Fragment> = [];

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -25,6 +25,7 @@
     "@fuel-ts/constants": "workspace:*",
     "@fuel-ts/interfaces": "workspace:*",
     "@fuel-ts/keystore": "workspace:*",
+    "@fuel-ts/versions": "workspace:*",
     "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/logger": "^5.7.0",
     "@ethersproject/sha2": "^5.7.0",

--- a/packages/address/src/address.ts
+++ b/packages/address/src/address.ts
@@ -13,7 +13,7 @@ import {
   getRandomB256,
 } from './utils';
 
-const logger = new Logger(versions.FUELS_TS_SDK);
+const logger = new Logger(versions.FUELS);
 
 export default class Address extends AbstractAddress {
   readonly bech32Address: Bech32Address;

--- a/packages/address/src/address.ts
+++ b/packages/address/src/address.ts
@@ -2,6 +2,7 @@ import { Logger } from '@ethersproject/logger';
 import { sha256 } from '@ethersproject/sha2';
 import { AbstractAddress } from '@fuel-ts/interfaces';
 import type { Bech32Address, B256Address } from '@fuel-ts/interfaces';
+import { versions } from '@fuel-ts/versions';
 
 import {
   normalizeBech32,
@@ -12,7 +13,7 @@ import {
   getRandomB256,
 } from './utils';
 
-const logger = new Logger(process.env.BUILD_VERSION || '~');
+const logger = new Logger(versions.FUELS_TS_SDK);
 
 export default class Address extends AbstractAddress {
   readonly bech32Address: Bech32Address;

--- a/packages/address/src/utils.ts
+++ b/packages/address/src/utils.ts
@@ -14,7 +14,7 @@ import { versions } from '@fuel-ts/versions';
 import type { Decoded } from 'bech32';
 import { bech32m } from 'bech32';
 
-const logger = new Logger(versions.FUELS_TS_SDK);
+const logger = new Logger(versions.FUELS);
 
 // Fuel Network HRP (human-readable part) for bech32 encoding
 export const FUEL_BECH32_HRP_PREFIX = 'fuel';

--- a/packages/address/src/utils.ts
+++ b/packages/address/src/utils.ts
@@ -10,10 +10,11 @@ import type {
   AbstractAddress,
 } from '@fuel-ts/interfaces';
 import { randomBytes } from '@fuel-ts/keystore';
+import { versions } from '@fuel-ts/versions';
 import type { Decoded } from 'bech32';
 import { bech32m } from 'bech32';
 
-const logger = new Logger(process.env.BUILD_VERSION || '~');
+const logger = new Logger(versions.FUELS_TS_SDK);
 
 // Fuel Network HRP (human-readable part) for bech32 encoding
 export const FUEL_BECH32_HRP_PREFIX = 'fuel';

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup --dts --env.BUILD_VERSION $BUILD_VERSION"
+    "build": "tsup --dts"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -38,7 +38,8 @@
     "@fuel-ts/script": "workspace:*",
     "@fuel-ts/sparsemerkle": "workspace:*",
     "@fuel-ts/wallet": "workspace:*",
-    "@fuel-ts/transactions": "workspace:*"
+    "@fuel-ts/transactions": "workspace:*",
+    "@fuel-ts/versions": "workspace:*"
   },
   "devDependencies": {
     "forc-bin": "workspace:*"

--- a/packages/contract/src/contracts/contract-factory.ts
+++ b/packages/contract/src/contracts/contract-factory.ts
@@ -14,7 +14,7 @@ import { getContractId, getContractStorageRoot, includeHexPrefix } from '../util
 
 import Contract from './contract';
 
-const logger = new Logger(versions.FUELS_TS_SDK);
+const logger = new Logger(versions.FUELS);
 
 type DeployContractOptions = {
   salt?: BytesLike;

--- a/packages/contract/src/contracts/contract-factory.ts
+++ b/packages/contract/src/contracts/contract-factory.ts
@@ -7,13 +7,14 @@ import type { CreateTransactionRequestLike } from '@fuel-ts/providers';
 import { Provider, CreateTransactionRequest } from '@fuel-ts/providers';
 import type { StorageSlot } from '@fuel-ts/transactions';
 import { MAX_GAS_PER_TX } from '@fuel-ts/transactions';
+import { versions } from '@fuel-ts/versions';
 import { BaseWalletLocked } from '@fuel-ts/wallet';
 
 import { getContractId, getContractStorageRoot, includeHexPrefix } from '../util';
 
 import Contract from './contract';
 
-const logger = new Logger(process.env.BUILD_VERSION || '~');
+const logger = new Logger(versions.FUELS_TS_SDK);
 
 type DeployContractOptions = {
   salt?: BytesLike;

--- a/packages/forc-bin/package.json
+++ b/packages/forc-bin/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "forc-bin",
-  "version": "0.26.3",
+  "version": "0.21.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",

--- a/packages/fuels/bin.mjs
+++ b/packages/fuels/bin.mjs
@@ -1,0 +1,3 @@
+import { run } from "@fuel-ts/versions/dist/cli";
+
+run({ programName: "fuels versions" });

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -44,7 +44,8 @@
     "@fuel-ts/transactions": "workspace:*",
     "@fuel-ts/wallet": "workspace:*",
     "@fuel-ts/wallet-manager": "workspace:*",
-    "@fuel-ts/wordlists": "workspace:*"
+    "@fuel-ts/wordlists": "workspace:*",
+    "@fuel-ts/versions": "workspace:*"
   },
   "scripts": {
     "build": "tsup --dts"

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -5,6 +5,7 @@
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "typedocMain": "src/index.ts",
   "main": "src/index.ts",
+  "bin": "./bin.mjs",
   "publishConfig": {
     "main": "dist/index.js",
     "module": "dist/index.mjs",

--- a/packages/fuels/src/index.ts
+++ b/packages/fuels/src/index.ts
@@ -10,3 +10,4 @@ export * from '@fuel-ts/transactions';
 export * from '@fuel-ts/wallet';
 export * from '@fuel-ts/predicate';
 export * from '@fuel-ts/address';
+export * from '@fuel-ts/versions';

--- a/packages/predicate/package.json
+++ b/packages/predicate/package.json
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup --dts --env.BUILD_VERSION $BUILD_VERSION"
+    "build": "tsup --dts"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/packages/versions/README.md
+++ b/packages/versions/README.md
@@ -2,21 +2,15 @@
 
 **@fuel-ts/versions** is a sub-module for interacting with **Fuel**.
 
-It automatically assembles all compatible versions of the Fuel toolchain curentlu in use across the packages.
-
-This includes:
+It automatically assembles all supported versions of the Fuel toolchain, including:
 
 - `FUELS` — comes from `packages/fuels/package.json`
 - `FUEL_CORE` — comes from `services/fuel-core/Dockerfile`
 - `FORC` — comes from `packages/forc-bin/package.json`
 
-This should be an automatic build step, which require'sa commit to be made.
+There is a `prebuild` script to ensure that the `src/index.ts` file never goes outdated.
 
-There is a `prebuild` script to ensure this file never goes outdated.
-
-Mind you the libraty can also be used as a CLI tool to validate user environments.
-
-See documentation below
+Aditionally, the library also be used as a CLI tool to help checking/validating user environments.
 
 # Table of contents
 
@@ -32,9 +26,7 @@ See documentation below
 
 See [Fuel-ts Documentation](https://fuellabs.github.io/fuels-ts/packages/fuel-ts-versions/)
 
-## Usage
-
-### Installation
+## Installation
 
 ```sh
 yarn add @fuel-ts/versions
@@ -42,7 +34,18 @@ yarn add @fuel-ts/versions
 npm add @fuel-ts/versions
 ```
 
-### Checking versions
+### Programatic Usage
+
+```ts
+import { versions } from "@fuel-ts/versions";
+
+const logger = new Logger(versions.FUELS);
+
+console.log(versions);
+// { FUELS: '0.21.2', FUEL_CORE: '0.14.0', FORC: '0.30.0' }
+```
+
+### CLI Usage
 
 ```console
 $ npx fuels-versions
@@ -51,7 +54,7 @@ You have all the right versions! ⚡
  fuel-core: 0.14.1
 ```
 
-### Full SDK Installation
+## Full SDK Installation
 
 Alternatively, we recommend you install the [complete SDK](https://github.com/FuelLabs/fuels-ts) using the umbrella package:
 
@@ -61,9 +64,20 @@ yarn add fuels
 npm add fuels
 ```
 
-### Checking versions
+### Programatic Usage
 
-Then you need to prefix typegen command with fuels:
+```ts
+import { versions } from "fuels";
+
+const logger = new Logger(versions.FUELS);
+
+console.log(versions);
+// { FUELS: '0.21.2', FUEL_CORE: '0.14.0', FORC: '0.30.0' }
+```
+
+### CLI Usage
+
+Here you need to prefix typegen command with `fuels`:
 
 ```console
 $ npx fuels versions

--- a/packages/versions/README.md
+++ b/packages/versions/README.md
@@ -34,7 +34,7 @@ yarn add @fuel-ts/versions
 npm add @fuel-ts/versions
 ```
 
-### Programatic Usage
+### Programmatic Usage
 
 ```ts
 import { versions } from "@fuel-ts/versions";
@@ -64,7 +64,7 @@ yarn add fuels
 npm add fuels
 ```
 
-### Programatic Usage
+### Programmatic Usage
 
 ```ts
 import { versions } from "fuels";

--- a/packages/versions/README.md
+++ b/packages/versions/README.md
@@ -14,6 +14,10 @@ This should be an automatic build step, which require'sa commit to be made.
 
 There is a `prebuild` script to ensure this file never goes outdated.
 
+Mind you the libraty can also be used as a CLI tool to validate user environments.
+
+See documentation below
+
 # Table of contents
 
 - [Documentation](#documentation)
@@ -30,14 +34,21 @@ See [Fuel-ts Documentation](https://fuellabs.github.io/fuels-ts/packages/fuel-ts
 
 ## Usage
 
-TODO: Add CLI usage
-
 ### Installation
 
 ```sh
 yarn add @fuel-ts/versions
 # or
 npm add @fuel-ts/versions
+```
+
+### Checking versions
+
+```console
+$ npx fuels-versions
+You have all the right versions! ⚡
+ Forc: 0.30.0
+ fuel-core: 0.14.1
 ```
 
 ### Full SDK Installation
@@ -48,6 +59,19 @@ Alternatively, we recommend you install the [complete SDK](https://github.com/Fu
 yarn add fuels
 # or
 npm add fuels
+```
+
+### Checking versions
+
+Then you need to prefix typegen command with fuels:
+
+```console
+$ npx fuels versions
+Supported fuel-core: 0.14.1
+You're using fuel-core: 0.14.0
+
+You can install/update them with:
+ https://github.com/fuellabs/fuelup
 ```
 
 ## Contributing

--- a/packages/versions/README.md
+++ b/packages/versions/README.md
@@ -6,7 +6,7 @@ It automatically assembles all compatible versions of the Fuel toolchain curentl
 
 This includes:
 
-- `FUELS_TS_SDK` — comes from `packages/fuels/package.json`
+- `FUELS` — comes from `packages/fuels/package.json`
 - `FUEL_CORE` — comes from `services/fuel-core/Dockerfile`
 - `FORC` — comes from `packages/forc-bin/package.json`
 

--- a/packages/versions/README.md
+++ b/packages/versions/README.md
@@ -1,0 +1,63 @@
+# `@fuel-ts/versions`
+
+**@fuel-ts/versions** is a sub-module for interacting with **Fuel**.
+
+It automatically assembles all compatible versions of the Fuel toolchain curentlu in use across the packages.
+
+This includes:
+
+- `FUELS_TS_SDK` — comes from `packages/fuels/package.json`
+- `FUEL_CORE` — comes from `services/fuel-core/Dockerfile`
+- `FORC` — comes from `packages/forc-bin/package.json`
+
+This should be an automatic build step, which require'sa commit to be made.
+
+There is a `prebuild` script to ensure this file never goes outdated.
+
+# Table of contents
+
+- [Documentation](#documentation)
+- [Usage](#usage)
+  - [Installation](#installation)
+  - [Full SDK Installation](#full-sdk-installation)
+- [Contributing](#contributing)
+- [Changelog](#changelog)
+- [License](#license)
+
+## Documentation
+
+See [Fuel-ts Documentation](https://fuellabs.github.io/fuels-ts/packages/fuel-ts-versions/)
+
+## Usage
+
+TODO: Add CLI usage
+
+### Installation
+
+```sh
+yarn add @fuel-ts/versions
+# or
+npm add @fuel-ts/versions
+```
+
+### Full SDK Installation
+
+Alternatively, we recommend you install the [complete SDK](https://github.com/FuelLabs/fuels-ts) using the umbrella package:
+
+```sh
+yarn add fuels
+# or
+npm add fuels
+```
+
+## Contributing
+
+In order to contribute to `@fuel-ts/versions`, please see the main [fuels-ts](https://github.com/FuelLabs/fuels-ts) monorepo.
+
+## Changelog
+
+The `@fuel-ts/versions` changelog can be found at [CHANGELOG](./CHANGELOG.md).
+
+## License
+
+The primary license for `@fuel-ts/versions` is `Apache 2.0`, see [LICENSE](./LICENSE).

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -32,7 +32,9 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/chalk": "^2.2.0",
     "@types/node": "^18.11.9",
+    "@types/semver": "^7.3.13",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
   },
@@ -41,6 +43,8 @@
     "build": "tsup --dts"
   },
   "dependencies": {
-    "@types/yargs": "^17.0.13"
+    "@types/yargs": "^17.0.13",
+    "chalk": "4",
+    "semver": "^7.3.8"
   }
 }

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "prebuild": "ts-node ./scripts/injectVersions.ts",
-    "build": "tsup --dts"
+    "build": "tsup --dts --env.BUILD_VERSION $BUILD_VERSION"
   },
   "dependencies": {
     "@types/yargs": "^17.0.13",

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@fuel-ts/versions",
+  "version": "0.21.2",
+  "description": "Validates supported versions of the Fuel toolchain",
+  "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
+  "typedocMain": "./src/index.ts",
+  "main": "src/index.ts",
+  "bin": {
+    "fuels-versions": "dist/bin.js"
+  },
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "default": "./dist/index.mjs"
+    },
+    "./dist/cli": "./dist/cli.js"
+  },
+  "publishConfig": {
+    "main": "dist/index.js",
+    "module": "dist/index.mjs",
+    "types": "dist/index.d.ts",
+    "typings": "dist/index.d.ts",
+    "exports": {
+      ".": {
+        "require": "./dist/index.js",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@types/node": "^18.11.9",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.8.4"
+  },
+  "scripts": {
+    "prebuild": "ts-node ./scripts/injectVersions.ts",
+    "build": "tsup --dts"
+  },
+  "dependencies": {
+    "@types/yargs": "^17.0.13"
+  }
+}

--- a/packages/versions/scripts/expectCleanIndex.ts
+++ b/packages/versions/scripts/expectCleanIndex.ts
@@ -1,0 +1,14 @@
+import { execSync } from 'child_process';
+import { join } from 'path';
+
+export function expectCleanIndex() {
+  const indexFilepath = join(__dirname, '..', 'src', 'index.ts');
+  const status = execSync(`git status --short ${indexFilepath}`);
+  const isClean = status.toString() === '';
+
+  // exit(1) unless file is up-to-date and has been committed
+  if (!isClean) {
+    console.error(`Please, commit this file and try again:\n\t${indexFilepath}\n`);
+    process.exit(1);
+  }
+}

--- a/packages/versions/scripts/injectVersions.ts
+++ b/packages/versions/scripts/injectVersions.ts
@@ -1,0 +1,48 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { expectCleanIndex } from './expectCleanIndex';
+
+const dockerFilepath = join(__dirname, '..', '..', '..', 'services', 'fuel-core', 'Dockerfile');
+const forcPackagePath = join(__dirname, '..', '..', 'forc-bin', 'package.json');
+const fuelsPackagePath = join(__dirname, '..', '..', 'fuels', 'package.json');
+
+function getLocalVersions() {
+  const dockerContents = readFileSync(dockerFilepath, 'utf-8');
+  const forcJson = JSON.parse(readFileSync(forcPackagePath, 'utf-8'));
+  const fuelsJson = JSON.parse(readFileSync(fuelsPackagePath, 'utf-8'));
+
+  const dockerMatch = /fuel-core:v([0-9.]+)$/gm.exec(dockerContents);
+
+  if (!dockerMatch?.length) {
+    throw new Error(`Could not read version from ${dockerFilepath}`);
+  }
+
+  const fuelCore = dockerMatch[1];
+  const forc = forcJson.config.forcVersion;
+  const fuels = fuelsJson.version;
+
+  return {
+    fuelCore,
+    forc,
+    fuels,
+  };
+}
+
+export function rewriteIndex() {
+  const indexFilepath = join(__dirname, '..', 'src', 'index.ts');
+
+  const { fuelCore, forc, fuels } = getLocalVersions();
+
+  let contents = readFileSync(indexFilepath, 'utf-8');
+
+  contents = contents.replace(/FUELS_TS_SDK.+/, `FUELS_TS_SDK: '${fuels}',`);
+  contents = contents.replace(/FUEL_CORE.+/, `FUEL_CORE: '${fuelCore}',`);
+  contents = contents.replace(/FORC.+/, `FORC: '${forc}',`);
+
+  writeFileSync(indexFilepath, contents);
+
+  expectCleanIndex();
+}
+
+rewriteIndex();

--- a/packages/versions/scripts/injectVersions.ts
+++ b/packages/versions/scripts/injectVersions.ts
@@ -36,9 +36,9 @@ export function rewriteIndex() {
 
   let contents = readFileSync(indexFilepath, 'utf-8');
 
-  contents = contents.replace(/FUELS.+/, `FUELS: '${fuels}',`);
-  contents = contents.replace(/FUEL_CORE.+/, `FUEL_CORE: '${fuelCore}',`);
-  contents = contents.replace(/FORC.+/, `FORC: '${forc}',`);
+  contents = contents.replace(/FUELS:.+/, `FUELS: (process.env.BUILD_VERSION || '${fuels}'),`);
+  contents = contents.replace(/FUEL_CORE:.+/, `FUEL_CORE: '${fuelCore}',`);
+  contents = contents.replace(/FORC:.+/, `FORC: '${forc}',`);
 
   writeFileSync(indexFilepath, contents);
 

--- a/packages/versions/scripts/injectVersions.ts
+++ b/packages/versions/scripts/injectVersions.ts
@@ -36,7 +36,7 @@ export function rewriteIndex() {
 
   let contents = readFileSync(indexFilepath, 'utf-8');
 
-  contents = contents.replace(/FUELS_TS_SDK.+/, `FUELS_TS_SDK: '${fuels}',`);
+  contents = contents.replace(/FUELS.+/, `FUELS: '${fuels}',`);
   contents = contents.replace(/FUEL_CORE.+/, `FUEL_CORE: '${fuelCore}',`);
   contents = contents.replace(/FORC.+/, `FORC: '${forc}',`);
 

--- a/packages/versions/src/bin.ts
+++ b/packages/versions/src/bin.ts
@@ -1,0 +1,3 @@
+import { run } from './cli';
+
+run({ programName: 'fuels-versions' });

--- a/packages/versions/src/cli.ts
+++ b/packages/versions/src/cli.ts
@@ -1,17 +1,47 @@
+import { bold, red, green } from 'chalk';
 import { execSync } from 'child_process';
+import semver from 'semver';
 
 import { versions } from './index';
 
 export async function run(_params: { programName: string }) {
   const { log } = console;
 
-  const userForc = execSync('forc --version');
-  const userFuelCore = execSync('fuel-core --version');
+  const errorFooter: string = [
+    '\nYou can install/update them with:',
+    ` ${green('https://github.com/fuellabs/fuelup')}`,
+  ].join('\n');
 
-  console.log({ versions });
-  console.log({ userForc, userFuelCore });
+  let userForc: string | undefined;
+  let userFuelCore: string | undefined;
 
-  // TODO: Implement version's check
+  try {
+    const reg = /[^0-9.]+/g;
+    userForc = execSync('forc --version').toString().replace(reg, '');
+    userFuelCore = execSync('fuel-core --version').toString().replace(reg, '');
+  } catch (err) {
+    log('Make sure you have Forc and fuel-core installed.');
+    log(errorFooter);
+    throw err;
+  }
 
-  log('\nDone.⚡');
+  const forcOk = semver.satisfies(userForc, versions.FORC);
+  const coreOk = semver.satisfies(userFuelCore, versions.FUEL_CORE);
+
+  if (!forcOk) {
+    log(`Supported Forc version: ${green(versions.FORC)}`);
+    log(`You're using Forc: ${red(userForc)}`);
+    log(errorFooter);
+    process.exit(1);
+  } else if (!coreOk) {
+    log(`Supported ${bold('fuel-core')} version: ${green(versions.FUEL_CORE)}`);
+    log(`You're using ${bold('fuel-core')}: ${red(userFuelCore)}`);
+    log(errorFooter);
+    process.exit(1);
+  }
+  log(`You have all the right versions! ⚡`);
+  log(` ${bold('Forc')}: ${green(userForc)}`);
+  log(` ${bold('fuel-core')}: ${green(userFuelCore)}`);
+
+  process.exit(0);
 }

--- a/packages/versions/src/cli.ts
+++ b/packages/versions/src/cli.ts
@@ -1,0 +1,17 @@
+import { execSync } from 'child_process';
+
+import { versions } from './index';
+
+export async function run(_params: { programName: string }) {
+  const { log } = console;
+
+  const userForc = execSync('forc --version');
+  const userFuelCore = execSync('fuel-core --version');
+
+  console.log({ versions });
+  console.log({ userForc, userFuelCore });
+
+  // TODO: Implement version's check
+
+  log('\nDone.⚡');
+}

--- a/packages/versions/src/index.test.ts
+++ b/packages/versions/src/index.test.ts
@@ -1,0 +1,9 @@
+import { versions } from './index';
+
+describe('index.js', () => {
+  test('should export toolchain versions', async () => {
+    expect(versions.FUELS_TS_SDK).toBeTruthy();
+    expect(versions.FUEL_CORE).toBeTruthy();
+    expect(versions.FORC).toBeTruthy();
+  });
+});

--- a/packages/versions/src/index.test.ts
+++ b/packages/versions/src/index.test.ts
@@ -2,7 +2,7 @@ import { versions } from './index';
 
 describe('index.js', () => {
   test('should export toolchain versions', async () => {
-    expect(versions.FUELS_TS_SDK).toBeTruthy();
+    expect(versions.FUELS).toBeTruthy();
     expect(versions.FUEL_CORE).toBeTruthy();
     expect(versions.FORC).toBeTruthy();
   });

--- a/packages/versions/src/index.ts
+++ b/packages/versions/src/index.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  FUELS_TS_SDK: '0.21.2',
+  FUELS: '0.21.2',
   FUEL_CORE: '0.14.0',
   FORC: '0.30.0',
 };

--- a/packages/versions/src/index.ts
+++ b/packages/versions/src/index.ts
@@ -6,10 +6,14 @@
 
   Check the injection script at:
       ../scripts/injectVersions.ts
+
+  NOTE:
+    The entry `process.env.BUILD_VERSION` will be replaced
+    at build time by the CI routine prior to release
 */
 
 export const versions = {
-  FUELS: '0.21.2',
+  FUELS: process.env.BUILD_VERSION || '0.21.2',
   FUEL_CORE: '0.14.0',
   FORC: '0.30.0',
 };

--- a/packages/versions/src/index.ts
+++ b/packages/versions/src/index.ts
@@ -1,0 +1,5 @@
+export const versions = {
+  FUELS_TS_SDK: '0.21.2',
+  FUEL_CORE: '0.14.0',
+  FORC: '0.30.0',
+};

--- a/packages/versions/src/index.ts
+++ b/packages/versions/src/index.ts
@@ -13,7 +13,7 @@
 */
 
 export const versions = {
-  FUELS: process.env.BUILD_VERSION || '0.21.2',
+  FUELS: (process.env.BUILD_VERSION || '0.21.2'),
   FUEL_CORE: '0.14.0',
   FORC: '0.30.0',
 };

--- a/packages/versions/src/index.ts
+++ b/packages/versions/src/index.ts
@@ -1,3 +1,13 @@
+/*
+  Variables:
+    `FUELS` — comes from `/packages/fuels/package.json`
+    `FUEL_CORE` — comes from `/services/fuel-core/Dockerfile`
+    `FORC` — comes from `/packages/forc-bin/package.json`
+
+  Check the injection script at:
+      ../scripts/injectVersions.ts
+*/
+
 export const versions = {
   FUELS: '0.21.2',
   FUEL_CORE: '0.14.0',

--- a/packages/versions/tsconfig.json
+++ b/packages/versions/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./",
+    "baseUrl": "./"
+  },
+  "include": ["src"]
+}

--- a/packages/versions/tsup.config.ts
+++ b/packages/versions/tsup.config.ts
@@ -2,7 +2,11 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig((options) => ({
-  entry: ['src/index.ts'],
+  entry: {
+    index: 'src/index.ts',
+    cli: 'src/cli.ts',
+    bin: 'src/bin.ts',
+  },
   format: ['cjs', 'esm', 'iife'],
   splitting: false,
   sourcemap: true,

--- a/packages/versions/tsup.config.ts
+++ b/packages/versions/tsup.config.ts
@@ -1,0 +1,11 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { defineConfig } from 'tsup';
+
+export default defineConfig((options) => ({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm', 'iife'],
+  splitting: false,
+  sourcemap: true,
+  clean: false,
+  minify: !options.watch,
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,7 @@ importers:
       '@ethersproject/sha2': ^5.7.0
       '@ethersproject/strings': ^5.7.0
       '@fuel-ts/math': workspace:*
+      '@fuel-ts/versions': workspace:*
       type-fest: ^3.1.0
     dependencies:
       '@ethersproject/abi': 5.7.0
@@ -118,6 +119,7 @@ importers:
       '@ethersproject/sha2': 5.7.0
       '@ethersproject/strings': 5.7.0
       '@fuel-ts/math': link:../math
+      '@fuel-ts/versions': link:../versions
       type-fest: 3.2.0
 
   packages/address:
@@ -129,6 +131,7 @@ importers:
       '@fuel-ts/interfaces': workspace:*
       '@fuel-ts/keystore': workspace:*
       '@fuel-ts/testcases': workspace:*
+      '@fuel-ts/versions': workspace:*
       bech32: ^2.0.0
     dependencies:
       '@ethersproject/bytes': 5.7.0
@@ -137,6 +140,7 @@ importers:
       '@fuel-ts/constants': link:../constants
       '@fuel-ts/interfaces': link:../interfaces
       '@fuel-ts/keystore': link:../keystore
+      '@fuel-ts/versions': link:../versions
       bech32: 2.0.0
     devDependencies:
       '@fuel-ts/testcases': link:../testcases
@@ -159,6 +163,7 @@ importers:
       '@fuel-ts/script': workspace:*
       '@fuel-ts/sparsemerkle': workspace:*
       '@fuel-ts/transactions': workspace:*
+      '@fuel-ts/versions': workspace:*
       '@fuel-ts/wallet': workspace:*
       forc-bin: workspace:*
     dependencies:
@@ -175,6 +180,7 @@ importers:
       '@fuel-ts/script': link:../script
       '@fuel-ts/sparsemerkle': link:../sparsemerkle
       '@fuel-ts/transactions': link:../transactions
+      '@fuel-ts/versions': link:../versions
       '@fuel-ts/wallet': link:../wallet
     devDependencies:
       forc-bin: link:../forc-bin
@@ -550,6 +556,19 @@ importers:
       typescript: 4.8.4
     devDependencies:
       fuels: link:../fuels
+
+  packages/versions:
+    specifiers:
+      '@types/node': ^18.11.9
+      '@types/yargs': ^17.0.13
+      ts-node: ^10.9.1
+      typescript: ^4.8.4
+    dependencies:
+      '@types/yargs': 17.0.13
+    devDependencies:
+      '@types/node': 18.11.9
+      ts-node: 10.9.1_cbe7ovvae6zqfnmtgctpgpys54
+      typescript: 4.8.4
 
   packages/wallet:
     specifiers:
@@ -2470,7 +2489,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       chalk: 4.1.2
       jest-message-util: 28.1.3
       jest-util: 28.1.3
@@ -2491,14 +2510,14 @@ packages:
       '@jest/test-result': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.5.0
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 28.1.3
-      jest-config: 28.1.3_t5wpzltkkzdw6ng6jmtbqvsf2q
+      jest-config: 28.1.3_odkjkoia5xunhxkdrka32ib6vi
       jest-haste-map: 28.1.3
       jest-message-util: 28.1.3
       jest-regex-util: 28.0.2
@@ -2526,7 +2545,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       jest-mock: 28.1.3
     dev: true
 
@@ -2553,7 +2572,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@sinonjs/fake-timers': 9.1.2
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       jest-message-util: 28.1.3
       jest-mock: 28.1.3
       jest-util: 28.1.3
@@ -2585,7 +2604,7 @@ packages:
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
       '@jridgewell/trace-mapping': 0.3.17
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -2674,7 +2693,7 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       '@types/yargs': 17.0.13
       chalk: 4.1.2
     dev: true
@@ -2686,7 +2705,7 @@ packages:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       '@types/yargs': 17.0.13
       chalk: 4.1.2
     dev: true
@@ -2927,7 +2946,7 @@ packages:
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
     dev: true
 
   /@types/is-ci/3.0.0:
@@ -3002,7 +3021,7 @@ packages:
   /@types/mkdirp/0.5.2:
     resolution: {integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==}
     dependencies:
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
     dev: true
 
   /@types/mkdirp/1.0.2:
@@ -3018,7 +3037,7 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       form-data: 3.0.1
     dev: true
 
@@ -3047,7 +3066,7 @@ packages:
   /@types/resolve/0.0.8:
     resolution: {integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==}
     dependencies:
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
     dev: true
 
   /@types/semver/6.2.3:
@@ -3062,7 +3081,7 @@ packages:
     resolution: {integrity: sha512-x9yaMvEh5BEaZKeVQC4vp3l+QoFj3BXcd4aYfuKSzIIyihjdVARAadYy3SMNIz0WCCdS2vB9JL/U6GQk5PaxQw==}
     dependencies:
       '@types/glob': 8.0.0
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
     dev: true
 
   /@types/stack-utils/2.0.1:
@@ -3081,13 +3100,11 @@ packages:
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
-    dev: true
 
   /@types/yargs/17.0.13:
     resolution: {integrity: sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==}
     dependencies:
       '@types/yargs-parser': 21.0.0
-    dev: true
 
   /@typescript-eslint/eslint-plugin/5.42.1_2udltptbznfmezdozpdoa2aemq:
     resolution: {integrity: sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==}
@@ -4007,7 +4024,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   /confusing-browser-globals/1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
@@ -6121,7 +6138,7 @@ packages:
       '@jest/expect': 28.1.3
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -6166,6 +6183,46 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
+    dev: true
+
+  /jest-config/28.1.3_odkjkoia5xunhxkdrka32ib6vi:
+    resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.2
+      '@jest/test-sequencer': 28.1.3
+      '@jest/types': 28.1.3
+      '@types/node': 18.11.9
+      babel-jest: 28.1.3_@babel+core@7.20.2
+      chalk: 4.1.2
+      ci-info: 3.5.0
+      deepmerge: 4.2.2
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-circus: 28.1.3
+      jest-environment-node: 28.1.3
+      jest-get-type: 28.0.2
+      jest-regex-util: 28.0.2
+      jest-resolve: 28.1.3
+      jest-runner: 28.1.3
+      jest-util: 28.1.3
+      jest-validate: 28.1.3
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 28.1.3
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+      ts-node: 10.9.1_yodorn5kzjgomblrsstrk2spaa
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /jest-config/28.1.3_t5wpzltkkzdw6ng6jmtbqvsf2q:
@@ -6253,7 +6310,7 @@ packages:
       '@jest/environment': 28.1.3
       '@jest/fake-timers': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       jest-mock: 28.1.3
       jest-util: 28.1.3
     dev: true
@@ -6274,7 +6331,7 @@ packages:
     dependencies:
       '@jest/types': 28.1.3
       '@types/graceful-fs': 4.1.5
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       anymatch: 3.1.2
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -6335,7 +6392,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
     dev: true
 
   /jest-pnp-resolver/1.2.2_jest-resolve@28.1.3:
@@ -6389,7 +6446,7 @@ packages:
       '@jest/test-result': 28.1.3
       '@jest/transform': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       chalk: 4.1.2
       emittery: 0.10.2
       graceful-fs: 4.2.10
@@ -6475,7 +6532,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       chalk: 4.1.2
       ci-info: 3.5.0
       graceful-fs: 4.2.10
@@ -6500,7 +6557,7 @@ packages:
     dependencies:
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
@@ -6512,7 +6569,7 @@ packages:
     resolution: {integrity: sha512-CqRA220YV/6jCo8VWvAt1KKx6eek1VIHMPeLEbpcfSfkEeWyBNppynM/o6q+Wmw+sOhos2ml34wZbSX3G13//g==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@types/node': 14.18.33
+      '@types/node': 18.11.9
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -8603,6 +8660,37 @@ packages:
 
   /ts-log/2.2.5:
     resolution: {integrity: sha512-PGcnJoTBnVGy6yYNFxWVNkdcAuAMstvutN9MgDJIV6L0oG8fB+ZNNy1T+wJzah8RPGor1mZuPQkVfXNDpy9eHA==}
+    dev: true
+
+  /ts-node/10.9.1_cbe7ovvae6zqfnmtgctpgpys54:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 18.11.9
+      acorn: 8.8.1
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.8.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
     dev: true
 
   /ts-node/10.9.1_typescript@4.8.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,7 @@ importers:
       '@fuel-ts/sparsemerkle': workspace:*
       '@fuel-ts/testcases': workspace:*
       '@fuel-ts/transactions': workspace:*
+      '@fuel-ts/versions': workspace:*
       '@fuel-ts/wallet': workspace:*
       '@fuel-ts/wallet-manager': workspace:*
       '@fuel-ts/wordlists': workspace:*
@@ -312,6 +313,7 @@ importers:
       '@fuel-ts/sparsemerkle': link:../sparsemerkle
       '@fuel-ts/testcases': link:../testcases
       '@fuel-ts/transactions': link:../transactions
+      '@fuel-ts/versions': link:../versions
       '@fuel-ts/wallet': link:../wallet
       '@fuel-ts/wallet-manager': link:../wallet-manager
       '@fuel-ts/wordlists': link:../wordlists

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,14 +559,22 @@ importers:
 
   packages/versions:
     specifiers:
+      '@types/chalk': ^2.2.0
       '@types/node': ^18.11.9
+      '@types/semver': ^7.3.13
       '@types/yargs': ^17.0.13
+      chalk: '4'
+      semver: ^7.3.8
       ts-node: ^10.9.1
       typescript: ^4.8.4
     dependencies:
       '@types/yargs': 17.0.13
+      chalk: 4.1.2
+      semver: 7.3.8
     devDependencies:
+      '@types/chalk': 2.2.0
       '@types/node': 18.11.9
+      '@types/semver': 7.3.13
       ts-node: 10.9.1_cbe7ovvae6zqfnmtgctpgpys54
       typescript: 4.8.4
 
@@ -2914,6 +2922,13 @@ packages:
     dependencies:
       '@types/node': 18.11.9
 
+  /@types/chalk/2.2.0:
+    resolution: {integrity: sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==}
+    deprecated: This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!
+    dependencies:
+      chalk: 5.1.2
+    dev: true
+
   /@types/command-line-args/5.2.0:
     resolution: {integrity: sha512-UuKzKpJJ/Ief6ufIaIzr3A/0XnluX7RvFgwkV89Yzvm77wCh1kFaFmqN8XEnGcN62EuHdedQjEMb8mYxFLGPyA==}
     dev: true
@@ -3823,6 +3838,11 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  /chalk/5.1.2:
+    resolution: {integrity: sha512-E5CkT4jWURs1Vy5qGJye+XwCkNj7Od3Af7CP6SujMetSMkLs8Do2RWJK5yx1wamHV/op8Rz+9rltjaTQWDnEFQ==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
 
   /change-case-all/1.0.14:
     resolution: {integrity: sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==}
@@ -7002,7 +7022,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: true
 
   /lunr/2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
@@ -8092,7 +8111,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /sentence-case/3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
@@ -9322,7 +9340,6 @@ packages:
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
 
   /yaml-ast-parser/0.0.43:
     resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}


### PR DESCRIPTION
# Summary

- Close #609
  - _Adds a new `versions` package_
  -  _Concentrates all important versions together_
  - _Handle `BUILD_VERSION` env variable on a single place_
  - _Provides all SDK-supported versions of the Fuel toolchain components_
  - _Provides CLI utility for comparing user-installed versions against the SDK ones_

> _More on the package [README](https://github.com/FuelLabs/fuels-ts/blob/aa/feat/adding-versions-package/packages/versions/README.md), and a few snippets bellow._

# Programmatic usage

It gives accurate versions of the Fuel toolchain supported by the SDK.

```ts
import { versions } from "@fuel-ts/versions";

const logger = new Logger(versions.FUELS);

console.log(versions);
// { FUELS: '0.21.2', FUEL_CORE: '0.14.0', FORC: '0.30.0' }
```

# CLI usage

Help users compare their local version against the supported ones.

```console
$ npx fuels versions
Supported fuel-core: 0.14.1
You're using fuel-core: 0.14.0

You can install/update them with:
 https://github.com/fuellabs/fuelup
```
