### PR TITLE
chore: update default config values for `bn.format`

### DIFF
--- a/.changeset/unlucky-roses-share.md
+++ b/.changeset/unlucky-roses-share.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/math": patch
+---
+
+The default config values for `bn.format` have been changed.

--- a/packages/math/src/bn.test.ts
+++ b/packages/math/src/bn.test.ts
@@ -312,11 +312,11 @@ describe('Math - BN', () => {
   });
 
   it('should format with default configs', () => {
-    expect(bn('1000000000').format()).toEqual('1.0');
+    expect(bn('1000000000').format()).toEqual('1.000');
     expect(bn('2').format()).toEqual('0.000000002');
-    expect(bn('22000').format()).toEqual('0.00002');
-    expect(bn('100000020000').format()).toEqual('100.0');
-    expect(bn('100100000020000').format()).toEqual('100,100.0');
+    expect(bn('22000').format()).toEqual('0.000022');
+    expect(bn('100000020000').format()).toEqual('100.00002');
+    expect(bn('100100000020000').format()).toEqual('100,100.00002');
   });
 
   it('should format with NOT default configs', () => {
@@ -379,7 +379,7 @@ describe('Math - BN', () => {
       bn('22000').format({
         minPrecision: 2,
       })
-    ).toEqual('0.00002');
+    ).toEqual('0.000022');
 
     expect(
       bn('100000020000').format({
@@ -404,25 +404,25 @@ describe('Math - BN', () => {
       bn('100100000020000').format({
         minPrecision: 1,
       })
-    ).toEqual('100,100.0');
+    ).toEqual('100,100.00002');
     expect(
       bn('100100000020000').format({
         minPrecision: 2,
         units: 8,
       })
-    ).toEqual('1,001,000.00');
+    ).toEqual('1,001,000.0002');
 
     expect(
       bn('100100000020000').format({
         minPrecision: 3,
         units: 10,
       })
-    ).toEqual('10,010.000');
+    ).toEqual('10,010.000002');
     expect(
       bn('100100000020000').format({
         units: 10,
       })
-    ).toEqual('10,010.0');
+    ).toEqual('10,010.000002');
 
     expect(
       bn('1001000000200000000').format({
@@ -434,7 +434,7 @@ describe('Math - BN', () => {
       bn('1001000000200000000').format({
         units: 8,
       })
-    ).toEqual('10,010,000,002.0');
+    ).toEqual('10,010,000,002.000');
     expect(
       bn('1001000000200000000').format({
         minPrecision: 2,
@@ -444,7 +444,7 @@ describe('Math - BN', () => {
       bn('1001000000200000000').format({
         minPrecision: 5,
       })
-    ).toEqual('1,001,000,000.200');
+    ).toEqual('1,001,000,000.20000');
     expect(
       bn('1001000000200000000').format({
         minPrecision: 5,

--- a/packages/math/src/constants.ts
+++ b/packages/math/src/constants.ts
@@ -1,3 +1,3 @@
-export const DEFAULT_PRECISION = 3;
-export const DEFAULT_MIN_PRECISION = 1;
+export const DEFAULT_PRECISION = 9;
+export const DEFAULT_MIN_PRECISION = 3;
 export const DECIMAL_UNITS = 9;


### PR DESCRIPTION
## Summary
This PR updates the default config values for the `bn.format` function as requested in #595.

```ts
// constants.ts
DEFAULT_PRECISION = 9 // previously 3
DEFAULT_MIN_PRECISION = 3 // previously 1
```

Closes #595 