### PR TITLE
fix: remove node.js Buffer for better browser compatibility

### DIFF
--- a/.changeset/wet-phones-search.md
+++ b/.changeset/wet-phones-search.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/hasher": patch
+"@fuel-ts/keystore": patch
+---
+
+Remove node.js Buffer for browser compatibility

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -30,6 +30,7 @@
     "@fuel-ts/math": "workspace:*",
     "@fuel-ts/providers": "workspace:*",
     "@fuel-ts/transactions": "workspace:*",
+    "@fuel-ts/keystore": "workspace:*",
     "lodash.clonedeep": "^4.5.0"
   },
   "devDependencies": {

--- a/packages/hasher/src/hasher.ts
+++ b/packages/hasher/src/hasher.ts
@@ -1,6 +1,7 @@
 import type { BytesLike } from '@ethersproject/bytes';
 import { sha256 } from '@ethersproject/sha2';
 import { ZeroBytes32 } from '@fuel-ts/constants';
+import { bufferFromString } from '@fuel-ts/keystore';
 import { bn } from '@fuel-ts/math';
 import type { TransactionRequestLike } from '@fuel-ts/providers';
 import { transactionRequestify, TransactionType } from '@fuel-ts/providers';
@@ -15,7 +16,7 @@ import cloneDeep from 'lodash.clonedeep';
  * @returns A sha256 hash of the message
  */
 export function hashMessage(msg: string) {
-  return sha256(Buffer.from(msg));
+  return sha256(bufferFromString(msg, 'utf-8'));
 }
 
 /**

--- a/packages/keystore/src/aes-ctr-web.ts
+++ b/packages/keystore/src/aes-ctr-web.ts
@@ -16,7 +16,7 @@ export async function encrypt<T>(password: string, data: T): Promise<Keystore> {
   const salt = randomBytes(32);
   const secret = keyFromPassword(password, salt);
   const dataString = JSON.stringify(data);
-  const dataBuffer = bufferFromString(dataString);
+  const dataBuffer = bufferFromString(dataString, 'utf-8');
   const alg = {
     name: ALGORITHM,
     counter: iv,

--- a/packages/keystore/src/aes-ctr-web.ts
+++ b/packages/keystore/src/aes-ctr-web.ts
@@ -15,7 +15,8 @@ export async function encrypt<T>(password: string, data: T): Promise<Keystore> {
   const iv = randomBytes(16);
   const salt = randomBytes(32);
   const secret = keyFromPassword(password, salt);
-  const dataBuffer = Uint8Array.from(Buffer.from(JSON.stringify(data), 'utf-8'));
+  const dataString = JSON.stringify(data);
+  const dataBuffer = bufferFromString(dataString);
   const alg = {
     name: ALGORITHM,
     counter: iv,

--- a/packages/keystore/src/keystore.ts
+++ b/packages/keystore/src/keystore.ts
@@ -4,7 +4,7 @@ import { encrypt as encWeb, decrypt as decWeb } from './aes-ctr-web';
 import { strategy } from './universal-crypto';
 
 export type { Keystore } from './aes-ctr';
-export { keyFromPassword } from './aes-ctr';
+export { keyFromPassword, bufferFromString, stringFromBuffer } from './aes-ctr';
 export { randomBytes } from './randomBytes';
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,7 +86,7 @@ importers:
       prettier: 2.8.0
       shelljs: 0.8.5
       ts-generator: 0.1.1
-      ts-jest: 28.0.2_kruoq7e2diecr2nbswu56pqtoi
+      ts-jest: 28.0.2_si5kktuaregtankxzjwntztd6u
       ts-node: 10.9.1_kluoused5zacjtflizwvdqgpom
       tsup: 5.12.9_2dtigtkb225m7ii7q45utxqwgi
       turbo: 1.6.3
@@ -330,7 +330,7 @@ importers:
       '@jest/types': 28.1.0
       '@types/commander': 2.12.2
       jest: 28.1.0
-      ts-jest: 28.0.2_hxc2yyk23f7yaodouqhhz4a5vi
+      ts-jest: 28.0.2_pi6sfbspjgrf5w5yayhwqeg4au
       typescript: 4.9.3
 
   packages/hasher:
@@ -338,6 +338,7 @@ importers:
       '@ethersproject/bytes': ^5.7.0
       '@ethersproject/sha2': ^5.7.0
       '@fuel-ts/constants': workspace:*
+      '@fuel-ts/keystore': workspace:*
       '@fuel-ts/math': workspace:*
       '@fuel-ts/providers': workspace:*
       '@fuel-ts/testcases': workspace:*
@@ -348,6 +349,7 @@ importers:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/sha2': 5.7.0
       '@fuel-ts/constants': link:../constants
+      '@fuel-ts/keystore': link:../keystore
       '@fuel-ts/math': link:../math
       '@fuel-ts/providers': link:../providers
       '@fuel-ts/transactions': link:../transactions
@@ -5643,7 +5645,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.8
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
@@ -8975,74 +8977,6 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest/28.0.2_hxc2yyk23f7yaodouqhhz4a5vi:
-    resolution: {integrity: sha512-IOZMb3D0gx6IHO9ywPgiQxJ3Zl4ECylEFwoVpENB55aTn5sdO0Ptyx/7noNBxAaUff708RqQL4XBNxxOVjY0vQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: ^28.0.0
-      esbuild: '*'
-      jest: ^28.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 28.1.0
-      jest-util: 28.1.3
-      json5: 2.2.1
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.8
-      typescript: 4.9.3
-      yargs-parser: 20.2.9
-    dev: true
-
-  /ts-jest/28.0.2_kruoq7e2diecr2nbswu56pqtoi:
-    resolution: {integrity: sha512-IOZMb3D0gx6IHO9ywPgiQxJ3Zl4ECylEFwoVpENB55aTn5sdO0Ptyx/7noNBxAaUff708RqQL4XBNxxOVjY0vQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: ^28.0.0
-      esbuild: '*'
-      jest: ^28.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@types/jest': 27.5.1
-      bs-logger: 0.2.6
-      esbuild: 0.14.54
-      fast-json-stable-stringify: 2.1.0
-      jest: 28.1.0_t5wpzltkkzdw6ng6jmtbqvsf2q
-      jest-util: 28.1.3
-      json5: 2.2.1
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.3.8
-      typescript: 4.9.3
-      yargs-parser: 20.2.9
-    dev: true
-
   /ts-jest/28.0.2_pi6sfbspjgrf5w5yayhwqeg4au:
     resolution: {integrity: sha512-IOZMb3D0gx6IHO9ywPgiQxJ3Zl4ECylEFwoVpENB55aTn5sdO0Ptyx/7noNBxAaUff708RqQL4XBNxxOVjY0vQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -9067,7 +9001,43 @@ packages:
       '@babel/core': 7.20.2
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.0_odkjkoia5xunhxkdrka32ib6vi
+      jest: 28.1.0
+      jest-util: 28.1.3
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.8
+      typescript: 4.9.3
+      yargs-parser: 20.2.9
+    dev: true
+
+  /ts-jest/28.0.2_si5kktuaregtankxzjwntztd6u:
+    resolution: {integrity: sha512-IOZMb3D0gx6IHO9ywPgiQxJ3Zl4ECylEFwoVpENB55aTn5sdO0Ptyx/7noNBxAaUff708RqQL4XBNxxOVjY0vQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: ^28.0.0
+      esbuild: '*'
+      jest: ^28.0.0
+      typescript: '>=4.3'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.2
+      '@types/jest': 27.5.1
+      bs-logger: 0.2.6
+      esbuild: 0.14.54
+      fast-json-stable-stringify: 2.1.0
+      jest: 28.1.0_t5wpzltkkzdw6ng6jmtbqvsf2q
       jest-util: 28.1.3
       json5: 2.2.1
       lodash.memoize: 4.1.2
@@ -9506,7 +9476,7 @@ packages:
     dev: true
 
   /verror/1.10.0:
-    resolution: {integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=}
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
     engines: {'0': node >=0.6.0}
     dependencies:
       assert-plus: 1.0.0


### PR DESCRIPTION
When using on browser env's, Buffer is not available, requiring extra bundler configs with polyfills. Using `stringFromBuffer` from the `Keystore` package, it's possible to use Buffer on node env's and TextDecoder on browsers. Fixing the issue.

For now, we don't have a CI for automating the tests on browser #284. Because of this, I have tested it locally this are the following steps;
1. On this branch
2. Inside packages/keystore run `pnpm build` and `pnpm link --global --dir .`
3. Create an react app using `npx create-react-app my-test-app`
4. Inside the app `my-test-app` run `pnpm link --global @fuel-ts/keystore`
5. On the `src/App.js` file, paste the  following code right after `import './App.css'`;
```js
import { decrypt, encrypt } from '@fuel-ts/keystore/dist';

const data = {
  'foo': 'bar'
};

encrypt('password', JSON.stringify(data)).then((encrypted) => {
  decrypt('password', encrypted).then((decrypted) => {
    console.log(JSON.parse(decrypted));
  });
});
```
6. The console.log should show the correct data, after encrypting and decrypting.

Notes: the `/dist` at `@fuel-ts/keystore/dist` is only needed because we are using `pnpm link`