### PR TITLE
fix: adding node shebang to packages bin

### DIFF
--- a/.changeset/lazy-beers-beam.md
+++ b/.changeset/lazy-beers-beam.md
@@ -1,0 +1,7 @@
+---
+"@fuel-ts/abi-typegen": patch
+"fuels": patch
+"@fuel-ts/versions": patch
+---
+
+Adding node shebang to packages bin

--- a/packages/abi-typegen/src/bin.ts
+++ b/packages/abi-typegen/src/bin.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { run } from './cli';
 
 run({

--- a/packages/fuels/src/bin.ts
+++ b/packages/fuels/src/bin.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { run } from './cli';
 
 run(process.argv);

--- a/packages/versions/src/bin.ts
+++ b/packages/versions/src/bin.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { run } from './cli';
 
 run();


### PR DESCRIPTION
Unlike `pnpm`,  `npm` requires binaries to have a `#!/usr/bin/env node` shebang.

This is a hotfix on top of:
 - https://github.com/FuelLabs/fuels-ts/pull/661