### PR TITLE
fix: corrected byteslike comparison with owner

### DIFF
--- a/.changeset/long-starfishes-type.md
+++ b/.changeset/long-starfishes-type.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/providers": minor
+---
+
+corrected comparison of byteslike and strings

--- a/packages/providers/src/transaction-request/transaction-request.ts
+++ b/packages/providers/src/transaction-request/transaction-request.ts
@@ -238,7 +238,7 @@ abstract class BaseTransactionRequest implements BaseTransactionRequestLike {
     return (
       this.inputs.find(
         (input): input is CoinTransactionRequestInput =>
-          input.type === InputType.Coin && input.owner === ownerAddress.toB256()
+          input.type === InputType.Coin && hexlify(input.owner) === ownerAddress.toB256()
       )?.witnessIndex ?? null
     );
   }


### PR DESCRIPTION
Simple fix for an issue I ran into when trying to manually build transactions