### PR TITLE
chore: add missing npm readme for `fuels`

### DIFF
--- a/.changeset/dirty-zoos-itch.md
+++ b/.changeset/dirty-zoos-itch.md
@@ -1,0 +1,5 @@
+---
+"fuels": patch
+---
+
+Fix missing npm readme for `fuels`

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -55,6 +55,7 @@
   },
   "scripts": {
     "build": "tsup --dts",
-    "build:watch": "tsup --dts --watch"
+    "build:watch": "tsup --dts --watch",
+    "prepublishOnly": "cp ../../README.md ./dist/README.md"
   }
 }


### PR DESCRIPTION
- Closes #665

- Adding a `prepublish` script again since the initial symlink approach discussed in #692 hasn't fixed the problem.