### PR TITLE
fix: wallet manager state when unlock fails

### DIFF
--- a/.changeset/famous-doors-refuse.md
+++ b/.changeset/famous-doors-refuse.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/wallet-manager": patch
+---
+
+Fix wallet manager state when unlock fails

--- a/packages/wallet-manager/src/wallet-manager.test.ts
+++ b/packages/wallet-manager/src/wallet-manager.test.ts
@@ -361,4 +361,14 @@ describe('Wallet Manager', () => {
     await walletManager.unlock(newPassword);
     expect(walletManager.isLocked).toBeFalsy();
   });
+
+  it('Wrong password should keep wallet state locked', async () => {
+    const { walletManager } = await setupWallet({
+      type: 'mnemonic',
+      secret: WalletManagerSpec.mnemonic,
+    });
+    await walletManager.lock();
+    await expect(walletManager.unlock('wrongpass')).rejects.toThrowError('Invalid credentials');
+    expect(walletManager.isLocked).toBeTruthy();
+  });
 });

--- a/packages/wallet-manager/src/wallet-manager.ts
+++ b/packages/wallet-manager/src/wallet-manager.ts
@@ -200,7 +200,7 @@ export class WalletManager extends EventEmitter {
   async unlock(passphrase: string) {
     // Set password on state
     this.#passphrase = passphrase;
-    // Set locked state to true
+    // Set locked state to false
     this.#isLocked = false;
     // Try to load state with passphrase
     try {

--- a/packages/wallet-manager/src/wallet-manager.ts
+++ b/packages/wallet-manager/src/wallet-manager.ts
@@ -202,10 +202,18 @@ export class WalletManager extends EventEmitter {
     this.#passphrase = passphrase;
     // Set locked state to true
     this.#isLocked = false;
-    // Load state
-    await this.loadState();
-    // Emit event that wallet is unlocked
-    this.emit('unlock');
+    // Try to load state with passphrase
+    try {
+      // Load state with passphrase
+      await this.loadState();
+      // Emit event that wallet is unlocked
+      this.emit('unlock');
+    } catch (err) {
+      // If passphrase is wrong lock wallet
+      await this.lock();
+      // Forward error
+      throw err;
+    }
   }
 
   /**


### PR DESCRIPTION
Working with the wallet manager, I noticed that when the unlock failed, it was not updating the state back to lock. This fix adds an error handler on `loadState` method and sets the state back to lock if it fails.