### PR TITLE
fix: make `walletOrProvider` a required param for the `Contract` constructor

### DIFF
--- a/.changeset/lazy-trains-admire.md
+++ b/.changeset/lazy-trains-admire.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/contract": minor
+---
+
+Make parameter walletOrProvider required in Contract constructor

--- a/packages/contract/src/contracts/contract.ts
+++ b/packages/contract/src/contracts/contract.ts
@@ -21,7 +21,7 @@ export default class Contract implements AbstractContract {
   constructor(
     id: string | AbstractAddress,
     abi: JsonAbi | JsonFlatAbi | Interface,
-    walletOrProvider: BaseWalletLocked | Provider | null = null
+    walletOrProvider: BaseWalletLocked | Provider
   ) {
     this.interface = abi instanceof Interface ? abi : new Interface(abi);
     this.id = Address.fromAddressOrString(id);

--- a/packages/fuel-gauge/src/doc-examples.test.ts
+++ b/packages/fuel-gauge/src/doc-examples.test.ts
@@ -137,7 +137,8 @@ test('it has conversion tools', async () => {
   const address = Address.fromB256(hexedB256);
   const arrayB256: Uint8Array = arrayify(randomB256Bytes);
   const walletLike: WalletLocked = Wallet.fromAddress(address);
-  const contractLike: Contract = new Contract(address, abiJSON);
+  const provider = new Provider('http://localhost:4000/graphql');
+  const contractLike: Contract = new Contract(address, abiJSON, provider);
 
   expect(address.equals(addressify(walletLike) as Address)).toBeTruthy();
   expect(address.equals(contractLike.id as Address)).toBeTruthy();


### PR DESCRIPTION
- Close #755 