### PR TITLE
fix: adjust `testcases` configs

### DIFF
--- a/.changeset/three-adults-tease.md
+++ b/.changeset/three-adults-tease.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/testcases": patch
+---
+
+Re-adding `testcases` package to the publishing pool

--- a/packages/testcases/package.json
+++ b/packages/testcases/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@fuel-ts/testcases",
   "version": "0.34.0",
   "description": "",


### PR DESCRIPTION
The package `testcaseas` still needs to be published at:
 - https://www.npmjs.com/package/@fuel-ts/testcases

I mistakenly marked it as `private`, breaking the last release.

This is the hotfix for it.

> Thanks @LuizAsFight for the heads up. 🙌 