### PR TITLE
fix: exports configs in packages' json files

### DIFF
--- a/.changeset/young-gorillas-destroy.md
+++ b/.changeset/young-gorillas-destroy.md
@@ -1,0 +1,30 @@
+---
+"@fuel-ts/abi-coder": patch
+"@fuel-ts/abi-typegen": patch
+"@fuel-ts/address": patch
+"@fuel-ts/constants": patch
+"@fuel-ts/contract": patch
+"fuels": patch
+"@fuel-ts/hasher": patch
+"@fuel-ts/hdwallet": patch
+"@fuel-ts/interfaces": patch
+"@fuel-ts/keystore": patch
+"@fuel-ts/math": patch
+"@fuel-ts/merkle": patch
+"@fuel-ts/merkle-shared": patch
+"@fuel-ts/merklesum": patch
+"@fuel-ts/mnemonic": patch
+"@fuel-ts/predicate": patch
+"@fuel-ts/program": patch
+"@fuel-ts/providers": patch
+"@fuel-ts/script": patch
+"@fuel-ts/signer": patch
+"@fuel-ts/sparsemerkle": patch
+"@fuel-ts/transactions": patch
+"@fuel-ts/versions": patch
+"@fuel-ts/wallet": patch
+"@fuel-ts/wallet-manager": patch
+"@fuel-ts/wordlists": patch
+---
+
+Adjusting export fields for all packages

--- a/packages/abi-coder/package.json
+++ b/packages/abi-coder/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/abi-typegen/package.json
+++ b/packages/abi-typegen/package.json
@@ -23,18 +23,18 @@
     },
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       },
       "./cli": {
+        "import": "./dist/cli.mjs",
         "require": "./dist/cli.js",
-        "default": "./dist/cli.mjs",
         "types": "./dist/cli.d.ts"
       },
       "./runTypegen": {
+        "import": "./dist/runTypegen.mjs",
         "require": "./dist/runTypegen.js",
-        "default": "./dist/runTypegen.mjs",
         "types": "./dist/runTypegen.d.ts"
       }
     }

--- a/packages/abi-typegen/src/templates/predicate/factory.test.ts
+++ b/packages/abi-typegen/src/templates/predicate/factory.test.ts
@@ -1,7 +1,6 @@
 import { contractPaths } from '../../../test/fixtures/index';
 import factoryTemplate from '../../../test/fixtures/templates/predicate/factory.hbs';
 import { executeAndCatch } from '../../../test/utils/executeAndCatch';
-import { getNewAbiTypegen } from '../../../test/utils/getNewAbiTypegen';
 import { mockVersions } from '../../../test/utils/mockVersions';
 import { buildSway } from '../../../test/utils/sway/buildSway';
 import { Abi } from '../../abi/Abi';
@@ -30,8 +29,6 @@ describe('factory.ts', () => {
     restore();
 
     expect(rendered).toEqual(factoryTemplate);
-
-    getNewAbiTypegen;
   });
 
   test('should throw for invalid Predicate ABI', async () => {

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -23,18 +23,18 @@
     },
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       },
       "./cli": {
+        "import": "./dist/cli.mjs",
         "require": "./dist/cli.js",
-        "default": "./dist/cli.mjs",
         "types": "./dist/cli.d.ts"
       },
       "./runTypegen": {
+        "import": "./dist/runTypegen.mjs",
         "require": "./dist/runTypegen.js",
-        "default": "./dist/runTypegen.mjs",
         "types": "./dist/runTypegen.d.ts"
       }
     }

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -31,11 +31,6 @@
         "import": "./dist/cli.mjs",
         "require": "./dist/cli.js",
         "types": "./dist/cli.d.ts"
-      },
-      "./runTypegen": {
-        "import": "./dist/runTypegen.mjs",
-        "require": "./dist/runTypegen.js",
-        "types": "./dist/runTypegen.d.ts"
       }
     }
   },

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/hdwallet/package.json
+++ b/packages/hdwallet/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/keystore/package.json
+++ b/packages/keystore/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/merkle-shared/package.json
+++ b/packages/merkle-shared/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/merkle/package.json
+++ b/packages/merkle/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/merklesum/package.json
+++ b/packages/merklesum/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/mnemonic/package.json
+++ b/packages/mnemonic/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/predicate/package.json
+++ b/packages/predicate/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/program/package.json
+++ b/packages/program/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/sparsemerkle/package.json
+++ b/packages/sparsemerkle/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -22,13 +22,13 @@
     },
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       },
       "./cli": {
+        "import": "./dist/cli.mjs",
         "require": "./dist/cli.js",
-        "default": "./dist/cli.mjs",
         "types": "./dist/cli.d.ts"
       }
     }

--- a/packages/wallet-manager/package.json
+++ b/packages/wallet-manager/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -16,13 +16,13 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       },
       "./test-utils": {
+        "import": "./dist/test-utils.mjs",
         "require": "./dist/test-utils.js",
-        "default": "./dist/test-utils.mjs",
         "types": "./dist/test-utils.d.ts"
       }
     }

--- a/packages/wordlists/package.json
+++ b/packages/wordlists/package.json
@@ -15,8 +15,8 @@
     "types": "dist/index.d.ts",
     "exports": {
       ".": {
+        "import": "./dist/index.mjs",
         "require": "./dist/index.js",
-        "default": "./dist/index.mjs",
         "types": "./dist/index.d.ts"
       }
     }


### PR DESCRIPTION
When using the `exports` field in `package.json` files, the `default` key must [always be the last](https://nodejs.org/api/packages.html#conditional-exports):

![last](https://user-images.githubusercontent.com/26660/223971561-8c55a94c-3773-4d16-bc3b-fbeb548d2b1e.png)

In my [last PR](https://github.com/FuelLabs/fuels-ts/pull/810), I added the `types` keys after the `default`, breaking all packages.

To be free from the object's ordering shenanigans, I'm changing all `default` entries to `import`, which should have the same effect without being subjected to a specific ordering.