### PR TITLE
Add `typegen` subcommand for command examples

### DIFF
--- a/docs/_guide/abi-typegen/generating-types-from-abi.md
+++ b/docs/_guide/abi-typegen/generating-types-from-abi.md
@@ -35,7 +35,7 @@ Options:
 We can omit the `--contract` option here; its the default:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types
 ```
 
 **Notes**
@@ -49,7 +49,7 @@ yarn exec fuels -i ./abis/*-abi.json -o ./types
 Note how we make use of the option `--script` in this case:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types --script
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types --script
 ```
 
 ## Generating Types for Predicates
@@ -57,7 +57,7 @@ yarn exec fuels -i ./abis/*-abi.json -o ./types --script
 Note how we make use of the option `--predicate` in this case:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types --predicate
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types --predicate
 ```
 
 ---

--- a/docs/_guide/abi-typegen/using-generated-types.md
+++ b/docs/_guide/abi-typegen/using-generated-types.md
@@ -7,7 +7,7 @@
 After generating types via:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types
 ```
 
 We can use these files like so:
@@ -31,7 +31,7 @@ console.log(transactionId, value);
 After generating types via:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types --script
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types --script
 ```
 
 We can use these files like so:
@@ -57,7 +57,7 @@ Consider the following predicate:
 Now, after generating types via:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types --predicate
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types --predicate
 ```
 
 We can use these files like so:

--- a/docs/guide/abi-typegen/generating-types-from-abi.md
+++ b/docs/guide/abi-typegen/generating-types-from-abi.md
@@ -43,7 +43,7 @@ Options:
 We can omit the `--contract` option here; its the default:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types
 ```
 
 **Notes**
@@ -57,7 +57,7 @@ yarn exec fuels -i ./abis/*-abi.json -o ./types
 Note how we make use of the option `--script` in this case:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types --script
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types --script
 ```
 
 ## Generating Types for Predicates
@@ -65,7 +65,7 @@ yarn exec fuels -i ./abis/*-abi.json -o ./types --script
 Note how we make use of the option `--predicate` in this case:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types --predicate
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types --predicate
 ```
 
 ---

--- a/docs/guide/abi-typegen/using-generated-types.md
+++ b/docs/guide/abi-typegen/using-generated-types.md
@@ -15,7 +15,7 @@ nav_order: 1
 After generating types via:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types
 ```
 
 We can use these files like so:
@@ -39,7 +39,7 @@ console.log(transactionId, value);
 After generating types via:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types --script
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types --script
 ```
 
 We can use these files like so:
@@ -84,7 +84,7 @@ fn main(received: Validation) -> bool {
 Now, after generating types via:
 
 ```console
-yarn exec fuels -i ./abis/*-abi.json -o ./types --predicate
+yarn exec fuels typegen -i ./abis/*-abi.json -o ./types --predicate
 ```
 
 We can use these files like so:


### PR DESCRIPTION
Not sure if I should be editing both `_guide` and `guide` -- noticed the example commands were missing the `typegen` subcomment