### PR TITLE
fix: adjusting constants evaluation by removing usage of `process.env`

### DIFF
--- a/.changeset/empty-waves-appear.md
+++ b/.changeset/empty-waves-appear.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/wallet": patch
+---
+
+Adjusting constants evaluation by removing usage of `process.env`

--- a/packages/wallet/src/account.ts
+++ b/packages/wallet/src/account.ts
@@ -26,9 +26,7 @@ import {
 } from '@fuel-ts/providers';
 import { MAX_GAS_PER_TX } from '@fuel-ts/transactions/configs';
 
-import { getFuelNetworkURL } from './configs';
-
-const { FUEL_NETWORK_URL } = getFuelNetworkURL({ source: process.env });
+import { FUEL_NETWORK_URL } from './configs';
 
 /**
  * Account

--- a/packages/wallet/src/base-unlocked-wallet.ts
+++ b/packages/wallet/src/base-unlocked-wallet.ts
@@ -10,9 +10,7 @@ import { transactionRequestify } from '@fuel-ts/providers';
 import { Signer } from '@fuel-ts/signer';
 
 import { Account } from './account';
-import { getFuelNetworkURL } from './configs';
-
-const { FUEL_NETWORK_URL } = getFuelNetworkURL({ source: process.env });
+import { FUEL_NETWORK_URL } from './configs';
 
 /**
  * BaseWalletUnlocked

--- a/packages/wallet/src/configs.ts
+++ b/packages/wallet/src/configs.ts
@@ -1,9 +1,1 @@
-export const getFuelNetworkURL = (params: {
-  source: Record<string, string | undefined> | undefined;
-}) => {
-  const { source } = params;
-
-  return {
-    FUEL_NETWORK_URL: source?.FUEL_NETWORK_URL || 'http://127.0.0.1:4000/graphql',
-  };
-};
+export const FUEL_NETWORK_URL = 'http://127.0.0.1:4000/graphql';

--- a/packages/wallet/src/wallet.test.ts
+++ b/packages/wallet/src/wallet.test.ts
@@ -5,11 +5,9 @@ import { transactionRequestify, Provider } from '@fuel-ts/providers';
 
 import { generateTestWallet } from '../test/utils/generateTestWallet';
 
-import { getFuelNetworkURL } from './configs';
+import { FUEL_NETWORK_URL } from './configs';
 import { Wallet } from './wallet';
 import type { WalletUnlocked } from './wallets';
-
-const { FUEL_NETWORK_URL } = getFuelNetworkURL({ source: process.env });
 
 describe('Wallet', () => {
   let wallet: WalletUnlocked;

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -2,10 +2,8 @@ import type { BytesLike } from '@ethersproject/bytes';
 import type { AbstractAddress } from '@fuel-ts/interfaces';
 import type { Provider } from '@fuel-ts/providers';
 
-import { getFuelNetworkURL } from './configs';
+import { FUEL_NETWORK_URL } from './configs';
 import { WalletLocked, WalletUnlocked } from './wallets';
-
-const { FUEL_NETWORK_URL } = getFuelNetworkURL({ source: process.env });
 
 export class Wallet {
   static fromAddress(


### PR DESCRIPTION
 - Close #846