### PR TITLE
refactor: purge usage of `GAS_PRICE_FACTOR` and other 'dynamic' constants

### DIFF
--- a/.changeset/fair-walls-mate.md
+++ b/.changeset/fair-walls-mate.md
@@ -1,0 +1,8 @@
+---
+"@fuel-ts/program": patch
+"@fuel-ts/providers": patch
+"@fuel-ts/script": patch
+"@fuel-ts/wallet": patch
+---
+
+Purge usage of hard-coded of constants like `GAS_PRICE_FACTOR`

--- a/packages/program/src/functions/base-invocation-scope.ts
+++ b/packages/program/src/functions/base-invocation-scope.ts
@@ -69,19 +69,24 @@ export class BaseInvocationScope<TReturn = any> {
     this.transactionRequest.setScript(contractCallScript, calls);
   }
 
-  protected getRequiredCoins(): Array<CoinQuantity> {
+  protected async getRequiredCoins(): Promise<Array<CoinQuantity>> {
+    const {
+      consensusParameters: { gasPriceFactor },
+      // @ts-expect-error TODO: fix this
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    } = await this.program.provider!.getChain();
     const assets = this.calls
       .map((call) => ({
         assetId: String(call.assetId),
         amount: bn(call.amount || 0),
       }))
-      .concat(this.transactionRequest.calculateFee())
+      .concat(this.transactionRequest.calculateFee(gasPriceFactor))
       .filter(({ assetId, amount }) => assetId && !bn(amount).isZero());
     return assets;
   }
 
-  protected updateRequiredCoins() {
-    const assets = this.getRequiredCoins();
+  protected async updateRequiredCoins() {
+    const assets = await this.getRequiredCoins();
     const reduceForwardCoins = (
       requiredCoins: Map<any, CoinQuantity>,
       { assetId, amount }: CoinQuantity
@@ -98,15 +103,15 @@ export class BaseInvocationScope<TReturn = any> {
     );
   }
 
-  protected addCall(funcScope: InvocationScopeLike) {
-    this.addCalls([funcScope]);
+  protected async addCall(funcScope: InvocationScopeLike) {
+    await this.addCalls([funcScope]);
     return this;
   }
 
-  protected addCalls(funcScopes: Array<InvocationScopeLike>) {
+  protected async addCalls(funcScopes: Array<InvocationScopeLike>) {
     this.functionInvocationScopes.push(...funcScopes);
     this.updateScriptRequest();
-    this.updateRequiredCoins();
+    await this.updateRequiredCoins();
     return this;
   }
 
@@ -115,7 +120,7 @@ export class BaseInvocationScope<TReturn = any> {
     this.updateScriptRequest();
 
     // Update required coins before call
-    this.updateRequiredCoins();
+    await this.updateRequiredCoins();
 
     // Check if gasLimit is less than the
     // sum of all call gasLimits

--- a/packages/program/src/functions/multicall-scope.ts
+++ b/packages/program/src/functions/multicall-scope.ts
@@ -10,11 +10,11 @@ export class MultiCallInvocationScope<TReturn = any> extends BaseInvocationScope
     this.addCalls(funcScopes);
   }
 
-  addCall(funcScope: FunctionInvocationScope) {
+  async addCall(funcScope: FunctionInvocationScope) {
     return super.addCalls([funcScope]);
   }
 
-  addCalls(funcScopes: Array<FunctionInvocationScope>) {
+  async addCalls(funcScopes: Array<FunctionInvocationScope>) {
     return super.addCalls(funcScopes);
   }
 }

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -423,10 +423,9 @@ export default class Provider {
 
     // Execute dryRun not validated transaction to query gasUsed
     const { receipts } = await this.call(transactionRequest);
-    const { chain } = await this.operations.getChain();
     const {
       consensusParameters: { gasPriceFactor },
-    } = processGqlChain(chain);
+    } = await this.getChain();
     const { gasUsed, fee } = calculateTransactionFee({
       gasPrice,
       receipts,

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -423,10 +423,15 @@ export default class Provider {
 
     // Execute dryRun not validated transaction to query gasUsed
     const { receipts } = await this.call(transactionRequest);
+    const { chain } = await this.operations.getChain();
+    const {
+      consensusParameters: { gasPriceFactor },
+    } = processGqlChain(chain);
     const { gasUsed, fee } = calculateTransactionFee({
       gasPrice,
       receipts,
       margin,
+      gasPriceFactor,
     });
 
     return {

--- a/packages/providers/src/transaction-request/transaction-request.ts
+++ b/packages/providers/src/transaction-request/transaction-request.ts
@@ -13,7 +13,6 @@ import type { BigNumberish, BN } from '@fuel-ts/math';
 import { bn } from '@fuel-ts/math';
 import type { TransactionCreate, TransactionScript } from '@fuel-ts/transactions';
 import { TransactionType, TransactionCoder, InputType, OutputType } from '@fuel-ts/transactions';
-import { GAS_PRICE_FACTOR } from '@fuel-ts/transactions/configs';
 
 import type { CoinQuantity, CoinQuantityLike } from '../coin-quantity';
 import { coinQuantityfy } from '../coin-quantity';
@@ -360,8 +359,8 @@ abstract class BaseTransactionRequest implements BaseTransactionRequestLike {
    *
    * Note: this is required even gasPrice = 0
    */
-  calculateFee(): CoinQuantity {
-    const gasFee = calculatePriceWithFactor(this.gasLimit, this.gasPrice, GAS_PRICE_FACTOR);
+  calculateFee(gasPriceFactor: BN): CoinQuantity {
+    const gasFee = calculatePriceWithFactor(this.gasLimit, this.gasPrice, gasPriceFactor);
 
     return {
       assetId: NativeAssetId,

--- a/packages/providers/src/transaction-response/transaction-response.ts
+++ b/packages/providers/src/transaction-response/transaction-response.ts
@@ -143,9 +143,13 @@ export class TransactionResponse {
       }
       case 'FailureStatus': {
         const receipts = transactionWithReceipts.receipts!.map(processGqlReceipt);
+        const {
+          consensusParameters: { gasPriceFactor },
+        } = await this.provider.getChain();
         const { gasUsed, fee } = calculateTransactionFee({
           receipts,
           gasPrice: bn(transactionWithReceipts?.gasPrice),
+          gasPriceFactor,
         });
 
         this.gasUsed = gasUsed;
@@ -162,9 +166,13 @@ export class TransactionResponse {
       }
       case 'SuccessStatus': {
         const receipts = transactionWithReceipts.receipts?.map(processGqlReceipt) || [];
+        const {
+          consensusParameters: { gasPriceFactor },
+        } = await this.provider.getChain();
         const { gasUsed, fee } = calculateTransactionFee({
           receipts,
           gasPrice: bn(transactionWithReceipts?.gasPrice),
+          gasPriceFactor,
         });
 
         return {

--- a/packages/providers/src/utils/fee.ts
+++ b/packages/providers/src/utils/fee.ts
@@ -1,7 +1,6 @@
 import type { BN } from '@fuel-ts/math';
 import { bn, multiply } from '@fuel-ts/math';
 import { ReceiptType } from '@fuel-ts/transactions';
-import { GAS_PRICE_FACTOR } from '@fuel-ts/transactions/configs';
 
 import type { TransactionResultReceipt } from '../transaction-response';
 
@@ -22,13 +21,15 @@ export const calculateTransactionFee = ({
   receipts,
   gasPrice,
   margin,
+  gasPriceFactor,
 }: {
   receipts: TransactionResultReceipt[];
   gasPrice: BN;
   margin?: number;
+  gasPriceFactor: BN;
 }) => {
   const gasUsed = multiply(getGasUsedFromReceipts(receipts), margin || 1);
-  const fee = calculatePriceWithFactor(gasUsed, gasPrice, GAS_PRICE_FACTOR);
+  const fee = calculatePriceWithFactor(gasUsed, gasPrice, gasPriceFactor);
 
   return {
     gasUsed,

--- a/packages/transactions/src/configs.ts
+++ b/packages/transactions/src/configs.ts
@@ -9,13 +9,6 @@ export const MAX_WITNESSES = 16;
 /** Maximum gas per transaction. */
 export const MAX_GAS_PER_TX = bn(100000000);
 
-/**
- * Gas Price factor this is used to calculate
- * This is used to calculate the gas fee in Native Coins.
- * Ex.: transactionFee = Math.ceil(<gasUsed> / MAX_GAS_PER_TX);
- */
-export const GAS_PRICE_FACTOR = bn(1000000000);
-
 /** Gas charged per byte of the transaction. */
 export const GAS_PER_BYTE = bn(4);
 

--- a/packages/wallet/src/account.ts
+++ b/packages/wallet/src/account.ts
@@ -167,7 +167,10 @@ export class Account extends AbstractAccount {
    * Adds resources to the transaction enough to fund it.
    */
   async fund<T extends TransactionRequest>(request: T): Promise<void> {
-    const fee = request.calculateFee();
+    const {
+      consensusParameters: { gasPriceFactor },
+    } = await this.provider.getChain();
+    const fee = request.calculateFee(gasPriceFactor);
     const resources = await this.getResourcesToSpend([fee]);
 
     request.addResources(resources);
@@ -190,7 +193,10 @@ export class Account extends AbstractAccount {
 
     const request = new ScriptTransactionRequest(params);
     request.addCoinOutput(destination, amount, assetId);
-    const fee = request.calculateFee();
+    const {
+      consensusParameters: { gasPriceFactor },
+    } = await this.provider.getChain();
+    const fee = request.calculateFee(gasPriceFactor);
     let quantities: CoinQuantityLike[] = [];
 
     if (fee.assetId === hexlify(assetId)) {
@@ -234,7 +240,10 @@ export class Account extends AbstractAccount {
     const params = { script, gasLimit: MAX_GAS_PER_TX, ...txParams };
     const request = new ScriptTransactionRequest(params);
     request.addMessageOutputs();
-    const fee = request.calculateFee();
+    const {
+      consensusParameters: { gasPriceFactor },
+    } = await this.provider.getChain();
+    const fee = request.calculateFee(gasPriceFactor);
     let quantities: CoinQuantityLike[] = [];
     fee.amount = fee.amount.add(amount);
     quantities = [fee];


### PR DESCRIPTION
## Summary

- This PR purges the hardcoded `GAS_PRICE_FACTOR` constant, and instead fetches the gas price factor from the chain via the provider everywhere.
- Please see [this comment](https://github.com/FuelLabs/fuels-ts/pull/856#discussion_r1149415127) for the one major issue with this approach.
- `MAX_GAS_PER_TX` seems to be the only other constant which needs to be fetched _dynamically_ from the chain instead of it using a hardcoded value. I will go about purging its hardcoded usage once we are happy with the approach we have used for `GAS_PRICE_FACTOR` to avoid any unnecessary refactoring work which might need to reverted later.

Closes #825
Closes #784 