### PR TITLE
fix: ignoring possible git errors when auto-committing generated versions file

### DIFF
--- a/scripts/changeset-version-with-docs.ts
+++ b/scripts/changeset-version-with-docs.ts
@@ -3,13 +3,13 @@
 import sh from 'shelljs';
 
 (() => {
-  // Force exit on error
-  sh.set(`-e`);
-
   // Commit versions generated at pre-build step
   sh.exec(`pnpm -C packages/versions prebuild`);
   sh.exec(`git add packages/versions/src/lib/getSupportedVersions.ts`);
   sh.exec(`git commit -m"ci(scripts): update versions"`);
+
+  // Force exit on error
+  sh.set(`-e`);
 
   // Update doc version references
   sh.exec(


### PR DESCRIPTION
The version's auto-commit script should not abort the Github action when the working tree is clean.

 - https://github.com/FuelLabs/fuels-ts/actions/runs/4555333373/jobs/8034228312#step:7:46

I've simply moved the related code block outside the `-e`~`+e` range.