### PR TITLE
fix: remove permissions item from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,9 +11,6 @@ jobs:
   release:
     name: "Release"
     runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This tries to fix the CI error from the last merge.

I am removing the `permissions` item from the `release.yaml` workflow to avoid all other permissions being set as `none`

> ref 1: https://github.com/FuelLabs/fuels-ts/actions/runs/4574396787/jobs/8079391507#step:7:167
> ref 2: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview