### PR TITLE
chore: remove the tag after the commit has been merged

### DIFF
--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      
       - name: CI Setup
         uses: ./.github/actions/ci-setup
 
@@ -19,9 +22,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Unpublish NPM tag: pr-${{ github.event.pull_request.number }}
-        id: unpublish
-        run: npm --force unpublish pr-${{ github.event.pull_request.number }}
+      - name: Get package versions for PR tag
+        id: pr_versions
+        run: |
+          VERSIONS=$(npm view fuels --json)
+          PR_VERSIONS=$(echo "$VERSIONS" | tr ',' '\n' | tr -d '[]"' | grep -F "pr-${{ github.event.pull_request.number }}" | xargs)
+          echo "::set-output name=versions::$PR_VERSIONS"
+          
+      - name: Unpublish NPM PR Tag Versions
+        if: steps.pr_versions.outputs.versions != ''
+        run: |
+          for VERSION in ${{ steps.pr_versions.outputs.versions }}
+          do
+            echo "Unpublishing version $VERSION"
+            npm --force unpublish fuels@${VERSION}
+          done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -1,4 +1,4 @@
-name: Clean up npm pr tags on release
+name: Unpublish Pull Request NPM tag
 
 on:
   pull_request_target:
@@ -6,9 +6,8 @@ on:
       - closed
 
 jobs:
-  release-pr:
-    if: github.event.pull_request.merged == true
-    name: "Clean up npm pr tags on release"
+  unpublish-pr:
+    name: "Unpublish Pull Request NPM tag"
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
@@ -20,10 +19,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Unpublish the package with the tag @pr-${{ github.event.pull_request.number }} from npm
+      - name: Unpublish NPM tag: pr-${{ github.event.pull_request.number }}
         id: unpublish
-        run: |
-          echo ::set-output name=version::$(npm --force unpublish pr-${{ github.event.pull_request.number }})
+        run: npm --force unpublish pr-${{ github.event.pull_request.number }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -1,0 +1,29 @@
+name: Clean up npm pr tags on release
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release-pr:
+    name: "Clean up npm pr tags on release"
+    runs-on: ubuntu-latest
+    # comment out if:false to enable release PR to npm
+    if: false
+    permissions: write-all
+    steps:
+      - name: CI Setup
+        uses: ./.github/actions/ci-setup
+
+      - name: Ensure NPM access
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Unpublish the package with the tag @pr-${{ github.event.pull_request.number }} from npm
+        id: unpublish
+        run: |
+          echo ::set-output name=version::$(npm --force unpublish pr-${{ github.event.pull_request.number }})
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -1,11 +1,13 @@
 name: Clean up npm pr tags on release
+
 on:
-  push:
-    branches:
-      - master
+  pull_request_target:
+    types:
+      - closed
 
 jobs:
   release-pr:
+    if: github.event.pull_request.merged == true
     name: "Clean up npm pr tags on release"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -22,9 +22,15 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Install PNPM
+        uses: pnpm/action-setup@v2
+        with:
+          version: 6.0.2
+
       - name: Get package versions for PR tag
         id: pr_versions
         run: |
+          source /home/runner/.bashrc
           PACKAGES=$(pnpm list -r --depth=-1 | awk '{ if($0 !~ /^[[:space:]]*$/) print $1}' | sed 's/@[0-9\.]*$//')
           PACKAGE_VERSION=""
           for PACKAGE in $PACKAGES
@@ -37,9 +43,9 @@ jobs:
                   fi
               fi
           done 
-          echo "name=packages::$PACKAGE@$PACKAGE_VERSIONS" >> $GITHUB_OUTPUT
+          echo "::set-output name=packages::$PACKAGE@$PACKAGE_VERSIONS"
+
       - name: Unpublish NPM PR Tag Versions
-        if: steps.pr_versions.outputs.versions != ''
         run: |
           for PACKAGE in ${{ steps.pr_versions.outputs.packages }}
           do

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -43,9 +43,10 @@ jobs:
                   fi
               fi
           done 
-          echo "::set-output name=packages::$PACKAGE@$PACKAGE_VERSIONS"
+          echo "packages=$PACKAGE@$PACKAGE_VERSIONS" >> $GITHUB_OUTPUT
 
       - name: Unpublish NPM PR Tag Versions
+        if: steps.pr_versions.outputs.packages != ''
         run: |
           for PACKAGE in ${{ steps.pr_versions.outputs.packages }}
           do

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -25,16 +25,26 @@ jobs:
       - name: Get package versions for PR tag
         id: pr_versions
         run: |
-          VERSIONS=$(npm view fuels --json)
-          PR_VERSIONS=$(echo "$VERSIONS" | tr ',' '\n' | tr -d '[]"' | grep -F "pr-${{ github.event.pull_request.number }}" | xargs)
-          echo "name=versions::$PR_VERSIONS" >> $GITHUB_OUTPUT
+          PACKAGES=$(pnpm list -r --depth=-1 | awk '{ if($0 !~ /^[[:space:]]*$/) print $1}' | sed 's/@[0-9\.]*$//')
+          PACKAGE_VERSION=""
+          for PACKAGE in $PACKAGES
+          do
+              if $(npm view $PACKAGE &> >(grep -q "npm ERR! code E404")); then
+                  VERSIONS=$(npm view $PACKAGE --json)
+                  PR_VERSIONS=$(echo "$VERSIONS" | tr ',' '\n' | tr -d '[]"' | grep -F "pr-${{ github.event.pull_request.number }}" | xargs)
+                  if [ ! -z "$PR_VERSIONS" ]; then
+                      PACKAGE_VERSIONS="${PACKAGE_VERSIONS} ${PR_VERSIONS}"
+                  fi
+              fi
+          done 
+          echo "name=packages::$PACKAGE@$PACKAGE_VERSIONS" >> $GITHUB_OUTPUT
       - name: Unpublish NPM PR Tag Versions
         if: steps.pr_versions.outputs.versions != ''
         run: |
-          for VERSION in ${{ steps.pr_versions.outputs.versions }}
+          for PACKAGE in ${{ steps.pr_versions.outputs.packages }}
           do
-            echo "Unpublishing version $VERSION"
-            npm --force unpublish fuels@${VERSION}
+            echo "Unpublishing ${PACKAGE}"
+            npm --force unpublish ${PACKAGE}
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      
+
       - name: CI Setup
         uses: ./.github/actions/ci-setup
 
@@ -27,8 +27,7 @@ jobs:
         run: |
           VERSIONS=$(npm view fuels --json)
           PR_VERSIONS=$(echo "$VERSIONS" | tr ',' '\n' | tr -d '[]"' | grep -F "pr-${{ github.event.pull_request.number }}" | xargs)
-          echo "::set-output name=versions::$PR_VERSIONS"
-          
+          echo "name=versions::$PR_VERSIONS" >> $GITHUB_OUTPUT
       - name: Unpublish NPM PR Tag Versions
         if: steps.pr_versions.outputs.versions != ''
         run: |

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -10,8 +10,6 @@ jobs:
     if: github.event.pull_request.merged == true
     name: "Clean up npm pr tags on release"
     runs-on: ubuntu-latest
-    # comment out if:false to enable release PR to npm
-    if: false
     permissions: write-all
     steps:
       - name: CI Setup

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -7,8 +7,6 @@ jobs:
   release-pr:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
-    # comment out if:false to enable release PR to npm
-    if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -7,6 +7,8 @@ jobs:
   release-pr:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
+    # comment out if:false to enable release PR to npm
+    if: false
     permissions: write-all
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR: 
Shall unpublish the npm tags after the PR has been merged, thus solving #901. For testing I was thinking we can change line 5 to trigger the action when merging in another branch, but opened to other ideas.