### PR TITLE
fix: package configs for `fuels`

### DIFF
--- a/.changeset/cuddly-moles-perform.md
+++ b/.changeset/cuddly-moles-perform.md
@@ -1,0 +1,5 @@
+---
+"fuels": patch
+---
+
+Fixing `fuels` package configs

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -8,8 +8,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./cli": "./src/cli.ts",
-    "./runTypegen": "./src/runTypegen.ts"
+    "./cli": "./src/cli.ts"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
Removing misplaced entry-point _(residual from Typegen configs duplication)_.