### PR TITLE
fix: inputify should manipulate value.data as possibly string

### DIFF
--- a/.changeset/flat-coats-swim.md
+++ b/.changeset/flat-coats-swim.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/providers": patch
+---
+
+fix: inputify should accept string for data prop (0x for instance)

--- a/packages/providers/src/transaction-request/input.ts
+++ b/packages/providers/src/transaction-request/input.ts
@@ -122,6 +122,7 @@ export const inputify = (value: TransactionRequestInput): Input => {
     case InputType.Message: {
       const predicate = arrayify(value.predicate ?? '0x');
       const predicateData = arrayify(value.predicateData ?? '0x');
+      const data = arrayify(value.data ?? '0x');
       return {
         type: InputType.Message,
         sender: hexlify(value.sender),
@@ -129,10 +130,10 @@ export const inputify = (value: TransactionRequestInput): Input => {
         amount: bn(value.amount),
         nonce: bn(value.nonce),
         witnessIndex: value.witnessIndex,
-        dataLength: value.data.length,
+        dataLength: data.length,
         predicateLength: predicate.length,
         predicateDataLength: predicateData.length,
-        data: hexlify(value.data),
+        data: hexlify(data),
         predicate: hexlify(predicate),
         predicateData: hexlify(predicateData),
       };


### PR DESCRIPTION
`value.data` is a `BytesLike`, which means it can be a string. but it was manipulated like if it was always an array, resulting in incorrect encoding when receiving an empty string, for example: `0x`.

this PR address the issue and apply same pattern used to `value.predicate` and `value.predicateData`, which probably was probably forgotten to be added to `value.data` also

ps: this PR is a blocker for bridge project