### PR TITLE
fix: limiting triggers for markdown lint workflow

### DIFF
--- a/.github/workflows/md-lint.yaml
+++ b/.github/workflows/md-lint.yaml
@@ -2,10 +2,6 @@ name: "Lint markdown files"
 
 on:
   pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
This PR limits the workflow _"Lint markdown files"_ to run only on new PR pushes. We don't need it to run when we change the PR `title` or `description` — the same couldn't be said about the `PR lint` workflow, which validates the PR `title`.