### PR TITLE
fix: add messageId to input message decoder

### DIFF
--- a/.changeset/smooth-cameras-study.md
+++ b/.changeset/smooth-cameras-study.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/providers": patch
+"@fuel-ts/transactions": patch
+---
+
+fix: add messageId to input message decoder

--- a/packages/fuel-gauge/src/coverage-contract.test.ts
+++ b/packages/fuel-gauge/src/coverage-contract.test.ts
@@ -385,6 +385,7 @@ describe('Coverage Contract', () => {
 
     const EXPECTED_MESSAGES_A: Message[] = [
       {
+        messageId: '0x98fcab1a57eaf34c0a2c743f6537f125d3ae46d59cd118a41016321f631584b2',
         sender: WALLET_B.address,
         recipient: WALLET_A.address,
         nonce: bn(1),
@@ -398,6 +399,7 @@ describe('Coverage Contract', () => {
     ];
     const EXPECTED_MESSAGES_B: Message[] = [
       {
+        messageId: '0x5ef913b1853aa1ae27afd51b509dbcb9961fb3b588b2c694a0c526c6034a2157',
         sender: WALLET_A.address,
         recipient: WALLET_B.address,
         nonce: bn('1017517292834129547'),
@@ -430,6 +432,7 @@ describe('Coverage Contract', () => {
     );
 
     const message: Message = {
+      messageId: '0x98fcab1a57eaf34c0a2c743f6537f125d3ae46d59cd118a41016321f631584b2',
       sender: sender.address,
       recipient: recipient.address,
       nonce: bn(1),

--- a/packages/providers/src/message.ts
+++ b/packages/providers/src/message.ts
@@ -9,6 +9,7 @@ import { GqlMessageStatus as MessageStatus } from './__generated__/operations';
  * A Fuel message
  */
 export type Message = {
+  messageId: BytesLike;
   sender: AbstractAddress;
   recipient: AbstractAddress;
   nonce: BN;

--- a/packages/providers/src/operations.graphql
+++ b/packages/providers/src/operations.graphql
@@ -67,6 +67,7 @@ fragment messageFragment on Message {
   nonce
   messageStatus: status
   daHeight
+  messageId
 }
 
 fragment messageProofFragment on MessageProof {

--- a/packages/providers/src/provider.test.ts
+++ b/packages/providers/src/provider.test.ts
@@ -313,6 +313,7 @@ describe('Provider', () => {
     });
     const MessageInput: MessageTransactionRequestInput = {
       type: InputType.Message,
+      messageId: NativeAssetId,
       amount: 100,
       sender: NativeAssetId,
       recipient: NativeAssetId,
@@ -342,6 +343,7 @@ describe('Provider', () => {
     ];
     const MessageInput: MessageTransactionRequestInput = {
       type: InputType.Message,
+      messageId: NativeAssetId,
       amount: 100,
       sender: NativeAssetId,
       recipient: NativeAssetId,
@@ -402,6 +404,7 @@ describe('Provider', () => {
     ];
     const MessageInput: MessageTransactionRequestInput = {
       type: InputType.Message,
+      messageId: NativeAssetId,
       amount: 100,
       sender: NativeAssetId,
       recipient: NativeAssetId,
@@ -477,6 +480,7 @@ describe('Provider', () => {
     ];
     const MessageInput: MessageTransactionRequestInput = {
       type: InputType.Message,
+      messageId: NativeAssetId,
       amount: 100,
       sender: NativeAssetId,
       recipient: NativeAssetId,
@@ -537,6 +541,7 @@ describe('Provider', () => {
     ];
     const MessageInput: MessageTransactionRequestInput = {
       type: InputType.Message,
+      messageId: NativeAssetId,
       amount: 100,
       sender: NativeAssetId,
       recipient: NativeAssetId,

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -549,6 +549,7 @@ export default class Provider {
       }
 
       return {
+        messageId: resource.messageId,
         sender: Address.fromAddressOrString(resource.sender),
         recipient: Address.fromAddressOrString(resource.recipient),
         nonce: bn(resource.nonce),
@@ -741,6 +742,7 @@ export default class Provider {
     const messages = result.messages.edges!.map((edge) => edge!.node!);
 
     return messages.map((message) => ({
+      messageId: message.messageId,
       sender: Address.fromAddressOrString(message.sender),
       recipient: Address.fromAddressOrString(message.recipient),
       nonce: bn(message.nonce),

--- a/packages/providers/src/transaction-request/input.ts
+++ b/packages/providers/src/transaction-request/input.ts
@@ -39,14 +39,17 @@ export type CoinTransactionRequestInput = {
 export type MessageTransactionRequestInput = {
   type: InputType.Message;
 
-  /** Amount of coins */
-  amount: BigNumberish;
+  /** Address of recipient */
+  messageId: BytesLike;
 
   /** Address of sender */
   sender: BytesLike;
 
-  /** Address of sender */
+  /** Address of recipient */
   recipient: BytesLike;
+
+  /** Amount of coins */
+  amount: BigNumberish;
 
   /** Index of witness that authorizes the message */
   witnessIndex: number;
@@ -123,8 +126,10 @@ export const inputify = (value: TransactionRequestInput): Input => {
       const predicate = arrayify(value.predicate ?? '0x');
       const predicateData = arrayify(value.predicateData ?? '0x');
       const data = arrayify(value.data ?? '0x');
+
       return {
         type: InputType.Message,
+        messageId: hexlify(value.messageId),
         sender: hexlify(value.sender),
         recipient: hexlify(value.recipient),
         amount: bn(value.amount),

--- a/packages/transactions/src/coders/input.test.ts
+++ b/packages/transactions/src/coders/input.test.ts
@@ -117,6 +117,7 @@ describe('InputCoder', () => {
   it('Can encode Message Id', () => {
     const input: InputMessage = {
       type: InputType.Message,
+      messageId: '0xa2be1e294136b22c8168159892eb26b2503232f1e711e2e6fbb7f8a8b50633b7',
       amount: bn(1000),
       sender: '0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e',
       recipient: '0xef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a',
@@ -139,6 +140,7 @@ describe('InputCoder', () => {
   it('Can encode Message', () => {
     const input: Input = {
       type: InputType.Message,
+      messageId: '0xa2be1e294136b22c8168159892eb26b2503232f1e711e2e6fbb7f8a8b50633b7',
       amount: bn(1000),
       sender: '0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e',
       recipient: '0xef86afa9696cf0dc6385e2c407a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a',

--- a/packages/transactions/src/coders/input.ts
+++ b/packages/transactions/src/coders/input.ts
@@ -196,14 +196,17 @@ export class InputContractCoder extends Coder<InputContract, InputContract> {
 export type InputMessage = {
   type: InputType.Message;
 
-  /** Amount of coins */
-  amount: BN;
+  /** ID of Message */
+  messageId: string;
 
   /** Address of sender */
   sender: string;
 
-  /** Address of sender */
+  /** Address of recipient */
   recipient: string;
+
+  /** Amount of coins */
+  amount: BN;
 
   /** data of message */
   data: string;
@@ -249,8 +252,8 @@ export class InputMessageCoder extends Coder<InputMessage, InputMessage> {
   encode(value: InputMessage): Uint8Array {
     const parts: Uint8Array[] = [];
     const encodedData = new ByteArrayCoder(value.dataLength).encode(value.data);
-    const mId = InputMessageCoder.getMessageId(value);
-    parts.push(new ByteArrayCoder(32).encode(mId));
+    const messageId = InputMessageCoder.getMessageId(value);
+    parts.push(new ByteArrayCoder(32).encode(messageId));
     parts.push(new ByteArrayCoder(32).encode(value.sender));
     parts.push(new ByteArrayCoder(32).encode(value.recipient));
     parts.push(new U64Coder().encode(value.amount));
@@ -279,6 +282,8 @@ export class InputMessageCoder extends Coder<InputMessage, InputMessage> {
     let o = offset;
 
     [decoded, o] = new B256Coder().decode(data, o);
+    const messageId = decoded;
+    [decoded, o] = new B256Coder().decode(data, o);
     const sender = decoded;
     [decoded, o] = new B256Coder().decode(data, o);
     const recipient = decoded;
@@ -304,6 +309,7 @@ export class InputMessageCoder extends Coder<InputMessage, InputMessage> {
     return [
       {
         type: InputType.Message,
+        messageId,
         sender,
         recipient,
         amount,


### PR DESCRIPTION
input message is broken, this PR fixes it by:
- adding `messageId` field to InputMessage
  - add to messageFragment in operations.graphql, allowing to query it from node
  - include in decoder
  - include `messageId` when adding resources to a transaction
  - fix tests to use `messageId` in input

Closes [FRO-195](https://linear.app/fuel-network/issue/FRO-195/after-sending-transaction-its-showing-incorrect-in-transaction-screen)