### PR TITLE
chore: remove pnpm lint from pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,2 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
-
-pnpm lint

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "test": "jest --no-cache --runInBand --coverage",
     "test:watch": "jest --no-cache --watchAll",
     "lint": "run-s lint:check prettier:check",
-    "lint:check": "eslint . --ext .ts --cache --cache-location=./.husky/.lintcache/eslint",
+    "lint:check": "eslint . --ext .ts",
     "lint:fix": "pnpm lint:check --fix",
     "lint:md-links": "tsx ./scripts/lint-md-links",
-    "prettier:check": "prettier --check --cache --cache-location=./.husky/.lintcache/prettier packages",
+    "prettier:check": "prettier --check packages",
     "prettier:format": "prettier --write packages",
     "changeset:publish": "changeset publish --no-git-tag",
     "changeset:next": "tsx ./scripts/changeset-next",
@@ -30,8 +30,7 @@
     "forc:format": "./scripts/forc-format.sh",
     "forc:verify": "tsx ./scripts/verify-forc-version",
     "node:run": "./scripts/run-node.sh",
-    "node:clean": "rimraf .fuel-core/db",
-    "prepare": "husky install"
+    "node:clean": "rimraf .fuel-core/db"
   },
   "repository": {
     "type": "git",
@@ -73,7 +72,6 @@
     "eslint-plugin-tsdoc": "^0.2.17",
     "ethers": "^5.7.2",
     "glob": "^10.2.6",
-    "husky": "^8.0.3",
     "jest": "^29.5.0",
     "jest-text-transformer": "^1.0.4",
     "nodemon": "^2.0.22",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       glob:
         specifier: ^10.2.6
         version: 10.2.6
-      husky:
-        specifier: ^8.0.3
-        version: 8.0.3
       jest:
         specifier: ^29.5.0
         version: 29.5.0(@types/node@18.15.3)
@@ -10402,12 +10399,6 @@ packages:
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-
-  /husky@8.0.3:
-    resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
 
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}


### PR DESCRIPTION
Removed `pnpm lint` from `pre-push.sh` after discussions with the team. We agree that the `pnpm lint` in the workflows is enough.