### PR TITLE
fix: calculate transaction fee

### DIFF
--- a/.changeset/serious-pans-search.md
+++ b/.changeset/serious-pans-search.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/providers": minor
+---
+
+Fix incorrect gasUsed and fee calculation in calculateTransactionFee function

--- a/packages/providers/src/operations.graphql
+++ b/packages/providers/src/operations.graphql
@@ -168,7 +168,7 @@ query getVersion {
   }
 }
 
-query getInfoAndConsensusParameters {
+query getInfo {
   nodeInfo {
     nodeVersion
     minGasPrice

--- a/packages/providers/src/operations.graphql
+++ b/packages/providers/src/operations.graphql
@@ -168,10 +168,17 @@ query getVersion {
   }
 }
 
-query getInfo {
+query getInfoAndConsensusParameters {
   nodeInfo {
     nodeVersion
     minGasPrice
+  }
+  chain {
+    consensusParameters {
+      gasPerByte
+      maxGasPerTx
+      gasPriceFactor
+    }
   }
 }
 

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -15,7 +15,6 @@ import {
   ReceiptCoder,
   TransactionCoder,
 } from '@fuel-ts/transactions';
-import { MAX_GAS_PER_TX } from '@fuel-ts/transactions/configs';
 import { GraphQLClient } from 'graphql-request';
 import cloneDeep from 'lodash.clonedeep';
 
@@ -509,6 +508,8 @@ export default class Provider {
 
     // Execute dryRun not validated transaction to query gasUsed
     const { receipts } = await this.call(transactionRequest);
+    const transaction = transactionRequest.toTransaction();
+
     const { gasUsed, fee } = calculateTransactionFee({
       gasPrice,
       receipts,
@@ -517,6 +518,7 @@ export default class Provider {
       gasPriceFactor,
       transactionBytes: transactionRequest.toTransactionBytes(),
       transactionType: transactionRequest.type,
+      transactionWitnesses: transaction.witnesses,
     });
 
     return {

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -22,7 +22,7 @@ import { getSdk as getOperationsSdk } from './__generated__/operations';
 import type {
   GqlChainInfoFragmentFragment,
   GqlGetBlocksQueryVariables,
-  GqlGetInfoAndConsensusParametersQuery,
+  GqlGetInfoQuery,
   GqlReceiptFragmentFragment,
 } from './__generated__/operations';
 import type { Coin } from './coin';
@@ -175,8 +175,8 @@ const processGqlChain = (chain: GqlChainInfoFragmentFragment): ChainInfo => {
 };
 
 const processNodeInfoAndConsensusParameters = (
-  nodeInfo: GqlGetInfoAndConsensusParametersQuery['nodeInfo'],
-  consensusParameters: GqlGetInfoAndConsensusParametersQuery['chain']['consensusParameters']
+  nodeInfo: GqlGetInfoQuery['nodeInfo'],
+  consensusParameters: GqlGetInfoQuery['chain']['consensusParameters']
 ) => ({
   minGasPrice: bn(nodeInfo.minGasPrice),
   nodeVersion: nodeInfo.nodeVersion,
@@ -288,8 +288,8 @@ export default class Provider {
   /**
    * Returns node information
    */
-  async getNodeInfoAndConsensusParameters(): Promise<NodeInfoAndConsensusParameters> {
-    const { nodeInfo, chain } = await this.operations.getInfoAndConsensusParameters();
+  async getNodeInfo(): Promise<NodeInfoAndConsensusParameters> {
+    const { nodeInfo, chain } = await this.operations.getInfo();
     return processNodeInfoAndConsensusParameters(nodeInfo, chain.consensusParameters);
   }
 
@@ -495,8 +495,7 @@ export default class Provider {
     tolerance: number = 0.2
   ): Promise<TransactionCost> {
     const transactionRequest = transactionRequestify(cloneDeep(transactionRequestLike));
-    const { minGasPrice, gasPerByte, gasPriceFactor, maxGasPerTx } =
-      await this.getNodeInfoAndConsensusParameters();
+    const { minGasPrice, gasPerByte, gasPriceFactor, maxGasPerTx } = await this.getNodeInfo();
     const gasPrice = max(transactionRequest.gasPrice, minGasPrice);
     const margin = 1 + tolerance;
 

--- a/packages/providers/src/transaction-response/transaction-response.ts
+++ b/packages/providers/src/transaction-response/transaction-response.ts
@@ -143,9 +143,15 @@ export class TransactionResponse {
       }
       case 'FailureStatus': {
         const receipts = transactionWithReceipts.receipts!.map(processGqlReceipt);
+
+        const decodedTransaction =
+          this.decodeTransaction<TTransactionType>(transactionWithReceipts);
+
         const { gasUsed, fee } = calculateTransactionFee({
           receipts,
           gasPrice: bn(transactionWithReceipts?.gasPrice),
+          transactionBytes: arrayify(transactionWithReceipts.rawPayload),
+          transactionType: decodedTransaction.type,
         });
 
         this.gasUsed = gasUsed;
@@ -157,14 +163,20 @@ export class TransactionResponse {
           time: transactionWithReceipts.status.time,
           gasUsed,
           fee,
-          transaction: this.decodeTransaction(transactionWithReceipts),
+          transaction: decodedTransaction,
         };
       }
       case 'SuccessStatus': {
         const receipts = transactionWithReceipts.receipts?.map(processGqlReceipt) || [];
+
+        const decodedTransaction =
+          this.decodeTransaction<TTransactionType>(transactionWithReceipts);
+
         const { gasUsed, fee } = calculateTransactionFee({
           receipts,
           gasPrice: bn(transactionWithReceipts?.gasPrice),
+          transactionBytes: arrayify(transactionWithReceipts.rawPayload),
+          transactionType: decodedTransaction.type,
         });
 
         return {
@@ -175,7 +187,7 @@ export class TransactionResponse {
           time: transactionWithReceipts.status.time,
           gasUsed,
           fee,
-          transaction: this.decodeTransaction(transactionWithReceipts),
+          transaction: decodedTransaction,
         };
       }
       default: {

--- a/packages/providers/src/transaction-response/transaction-response.ts
+++ b/packages/providers/src/transaction-response/transaction-response.ts
@@ -16,6 +16,7 @@ import type {
   ReceiptScriptResult,
   ReceiptMessageOut,
   Transaction,
+  TransactionCreate,
 } from '@fuel-ts/transactions';
 import { TransactionCoder, ReceiptType, ReceiptCoder } from '@fuel-ts/transactions';
 
@@ -152,6 +153,7 @@ export class TransactionResponse {
           gasPrice: bn(transactionWithReceipts?.gasPrice),
           transactionBytes: arrayify(transactionWithReceipts.rawPayload),
           transactionType: decodedTransaction.type,
+          transactionWitnesses: (<TransactionCreate>decodedTransaction).witnesses || [],
         });
 
         this.gasUsed = gasUsed;
@@ -177,6 +179,7 @@ export class TransactionResponse {
           gasPrice: bn(transactionWithReceipts?.gasPrice),
           transactionBytes: arrayify(transactionWithReceipts.rawPayload),
           transactionType: decodedTransaction.type,
+          transactionWitnesses: (<TransactionCreate>decodedTransaction).witnesses || [],
         });
 
         return {

--- a/packages/providers/src/utils/fee.test.ts
+++ b/packages/providers/src/utils/fee.test.ts
@@ -1,0 +1,143 @@
+import { BN } from '@fuel-ts/math';
+import { ReceiptType, type Witness } from '@fuel-ts/transactions';
+
+import type { TransactionResultReceipt } from '../transaction-response';
+
+import {
+  calculatePriceWithFactor,
+  getGasUsedForContractCreated,
+  getGasUsedFromReceipts,
+} from './fee';
+
+describe(__filename, () => {
+  describe('calculatePriceWithFactor', () => {
+    it('should correctly calculate the price with factor', () => {
+      const gasUsed = new BN(10);
+      const gasPrice = new BN(2);
+      const priceFactor = new BN(5);
+
+      const result = calculatePriceWithFactor(gasUsed, gasPrice, priceFactor);
+
+      expect(result.toNumber()).toEqual(4); // ceil(10 / 5) * 2 = 4
+    });
+
+    it('should correctly round up the result', () => {
+      const gasUsed = new BN(11);
+      const gasPrice = new BN(2);
+      const priceFactor = new BN(5);
+
+      const result = calculatePriceWithFactor(gasUsed, gasPrice, priceFactor);
+
+      expect(result.toNumber()).toEqual(6); // ceil(11 / 5) * 2 = 6
+    });
+  });
+
+  describe('getGasUsedForContractCreated', () => {
+    it('should calculate gas used for contract created correctly', () => {
+      const transactionBytes = new Uint8Array([0, 1, 2, 3, 4, 5]);
+      const gasPerByte = new BN(1);
+      const gasPriceFactor = new BN(2);
+      const transactionWitnesses: Witness[] = [{ dataLength: 2, data: 'data' }];
+
+      const result = getGasUsedForContractCreated({
+        transactionBytes,
+        gasPerByte,
+        gasPriceFactor,
+        transactionWitnesses,
+      });
+
+      expect(result.toNumber()).toEqual(2); // (6-2)*1/2 = 2
+    });
+
+    it('should handle an empty witnesses array', () => {
+      const transactionBytes = new Uint8Array([0, 1, 2, 3, 4, 5]);
+      const gasPerByte = new BN(1);
+      const gasPriceFactor = new BN(2);
+      const transactionWitnesses: Witness[] = [];
+
+      const result = getGasUsedForContractCreated({
+        transactionBytes,
+        gasPerByte,
+        gasPriceFactor,
+        transactionWitnesses,
+      });
+
+      expect(result.toNumber()).toEqual(3); // 6*1/2 = 3
+    });
+
+    it('should round up the result', () => {
+      const transactionBytes = new Uint8Array([0, 1, 2]);
+      const gasPerByte = new BN(1);
+      const gasPriceFactor = new BN(2);
+      const transactionWitnesses: Witness[] = [];
+
+      const result = getGasUsedForContractCreated({
+        transactionBytes,
+        gasPerByte,
+        gasPriceFactor,
+        transactionWitnesses,
+      });
+
+      expect(result.toNumber()).toEqual(2); // 3*1/2 = 1.5 which rounds up to 2
+    });
+  });
+
+  describe('getGasUsedFromReceipts', () => {
+    it('should return correct total gas used from ScriptResult receipts', () => {
+      const receipts: Array<TransactionResultReceipt> = [
+        {
+          type: ReceiptType.Return,
+          id: '0xbebd3baab326f895289ecbd4210cf886ce41952316441ae4cac35f00f0e882a6',
+          val: new BN(1),
+          pc: new BN(2),
+          is: new BN(3),
+        },
+        {
+          type: ReceiptType.ScriptResult,
+          result: new BN(4),
+          gasUsed: new BN(5),
+        },
+        {
+          type: ReceiptType.ScriptResult,
+          result: new BN(6),
+          gasUsed: new BN(7),
+        },
+      ];
+
+      const result = getGasUsedFromReceipts(receipts);
+
+      expect(result.toNumber()).toEqual(12); // 5 + 7 = 12
+    });
+
+    it('should return zero if there are no ScriptResult receipts', () => {
+      const receipts: Array<TransactionResultReceipt> = [
+        {
+          type: ReceiptType.Return,
+          id: '0xbebd3baab326f895289ecbd4210cf886ce41952316441ae4cac35f00f0e882a6',
+          val: new BN(1),
+          pc: new BN(2),
+          is: new BN(3),
+        },
+        {
+          type: ReceiptType.Return,
+          id: '0xa703b26833939dabc41d3fcaefa00e62cee8e1ac46db37e0fa5d4c9fe30b4132',
+          val: new BN(4),
+          pc: new BN(5),
+          is: new BN(6),
+        },
+      ];
+
+      const result = getGasUsedFromReceipts(receipts);
+
+      expect(result.toNumber()).toEqual(0);
+    });
+
+    it('should return zero if the receipts array is empty', () => {
+      const receipts: Array<TransactionResultReceipt> = [];
+
+      const result = getGasUsedFromReceipts(receipts);
+
+      expect(result.toNumber()).toEqual(0);
+    });
+  });
+});

--- a/packages/providers/src/utils/fee.ts
+++ b/packages/providers/src/utils/fee.ts
@@ -22,7 +22,7 @@ export const getGasUsedFromReceipts = (receipts: Array<TransactionResultReceipt>
   return gasUsed;
 };
 
-function getGasUsedContractCreated({
+export function getGasUsedForContractCreated({
   transactionBytes,
   gasPerByte,
   gasPriceFactor,
@@ -73,7 +73,7 @@ export const calculateTransactionFee = ({
   const isTypeCreate = transactionType === TransactionType.Create;
 
   if (isTypeCreate) {
-    gasUsed = getGasUsedContractCreated({
+    gasUsed = getGasUsedForContractCreated({
       gasPerByte: gasPerByte || GAS_PER_BYTE,
       gasPriceFactor: gasPriceFactor || GAS_PRICE_FACTOR,
       transactionBytes,

--- a/packages/providers/src/utils/fee.ts
+++ b/packages/providers/src/utils/fee.ts
@@ -22,7 +22,7 @@ export const getGasUsedFromReceipts = (receipts: Array<TransactionResultReceipt>
   return gasUsed;
 };
 
-export function getGasUsedContractCreated({
+function getGasUsedContractCreated({
   transactionBytes,
   gasPerByte,
   gasPriceFactor,
@@ -46,11 +46,12 @@ export function getGasUsedContractCreated({
   return gasUsed;
 }
 
-interface ICalculateTransactionFee {
+export interface ICalculateTransactionFee {
   receipts: TransactionResultReceipt[];
   gasPrice: BN;
   transactionBytes: Uint8Array;
   transactionType: TransactionType;
+  transactionWitnesses: Witness[];
   gasPriceFactor?: BN;
   gasPerByte?: BN;
   margin?: number;
@@ -63,6 +64,7 @@ export const calculateTransactionFee = ({
   gasPerByte,
   transactionBytes,
   transactionType,
+  transactionWitnesses,
   margin,
 }: ICalculateTransactionFee) => {
   let gasUsed;
@@ -75,7 +77,7 @@ export const calculateTransactionFee = ({
       gasPerByte: gasPerByte || GAS_PER_BYTE,
       gasPriceFactor: gasPriceFactor || GAS_PRICE_FACTOR,
       transactionBytes,
-      transactionWitnesses: [],
+      transactionWitnesses,
     });
 
     fee = gasUsed.mul(gasPrice);

--- a/packages/providers/src/utils/fee.ts
+++ b/packages/providers/src/utils/fee.ts
@@ -3,19 +3,22 @@ import { bn, multiply } from '@fuel-ts/math';
 import { ReceiptType } from '@fuel-ts/transactions';
 import { GAS_PRICE_FACTOR } from '@fuel-ts/transactions/configs';
 
-import type { TransactionResultReceipt } from '../transaction-response';
+import type {
+  TransactionResultReceipt,
+  TransactionResultScriptResultReceipt,
+} from '../transaction-response';
 
 export const calculatePriceWithFactor = (gasUsed: BN, gasPrice: BN, priceFactor: BN): BN =>
   bn(Math.ceil(gasUsed.toNumber() / priceFactor.toNumber()) * gasPrice.toNumber());
 
 export const getGasUsedFromReceipts = (receipts: Array<TransactionResultReceipt>): BN => {
-  const scriptResult = receipts.find((receipt) => receipt.type === ReceiptType.ScriptResult);
+  const scriptResult = receipts.filter(
+    (receipt) => receipt.type === ReceiptType.ScriptResult
+  ) as TransactionResultScriptResultReceipt[];
 
-  if (scriptResult && scriptResult.type === ReceiptType.ScriptResult) {
-    return scriptResult.gasUsed;
-  }
+  const gasUsed = scriptResult.reduce((prev, receipt) => prev.add(receipt.gasUsed), bn(0));
 
-  return bn(0);
+  return gasUsed;
 };
 
 export const calculateTransactionFee = ({

--- a/packages/providers/test/provider.test.ts
+++ b/packages/providers/test/provider.test.ts
@@ -166,7 +166,7 @@ describe('Provider', () => {
   it('can get node info including minGasPrice', async () => {
     // #region provider-definition
     const provider = new Provider('http://127.0.0.1:4000/graphql');
-    const { minGasPrice } = await provider.getNodeInfo();
+    const { minGasPrice } = await provider.getNodeInfoAndConsensusParameters();
     // #endregion provider-definition
 
     expect(minGasPrice).toBeDefined();

--- a/packages/providers/test/provider.test.ts
+++ b/packages/providers/test/provider.test.ts
@@ -163,13 +163,18 @@ describe('Provider', () => {
     expect(consensusParameters.maxMessageDataLength).toBeDefined();
   });
 
-  it('can get node info including minGasPrice', async () => {
+  it('can get node info including some consensus parameters properties', async () => {
     // #region provider-definition
     const provider = new Provider('http://127.0.0.1:4000/graphql');
-    const { minGasPrice } = await provider.getNodeInfoAndConsensusParameters();
+    const { minGasPrice, gasPerByte, gasPriceFactor, maxGasPerTx, nodeVersion } =
+      await provider.getNodeInfoAndConsensusParameters();
     // #endregion provider-definition
 
     expect(minGasPrice).toBeDefined();
+    expect(gasPerByte).toBeDefined();
+    expect(gasPriceFactor).toBeDefined();
+    expect(maxGasPerTx).toBeDefined();
+    expect(nodeVersion).toBeDefined();
   });
 
   it('can change the provider url of the current instance', () => {

--- a/packages/providers/test/provider.test.ts
+++ b/packages/providers/test/provider.test.ts
@@ -167,7 +167,7 @@ describe('Provider', () => {
     // #region provider-definition
     const provider = new Provider('http://127.0.0.1:4000/graphql');
     const { minGasPrice, gasPerByte, gasPriceFactor, maxGasPerTx, nodeVersion } =
-      await provider.getNodeInfoAndConsensusParameters();
+      await provider.getNodeInfo();
     // #endregion provider-definition
 
     expect(minGasPrice).toBeDefined();


### PR DESCRIPTION
Pretty much what the title says. 

The `calculateTransactionFee` method was updated based on the version used by `fuels-wallet` 