### PR TITLE
fix: predicate check on estimateTxDependencies

### DIFF
--- a/.changeset/shy-students-rush.md
+++ b/.changeset/shy-students-rush.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/providers": patch
+---
+
+Fix predicate check on estimateTxDependencies

--- a/packages/providers/src/transaction-request/transaction-request.ts
+++ b/packages/providers/src/transaction-request/transaction-request.ts
@@ -322,8 +322,7 @@ export abstract class BaseTransactionRequest implements BaseTransactionRequestLi
   hasPredicateInput(): boolean {
     return Boolean(
       this.inputs.find(
-        (input) =>
-          input.type === InputType.Coin && input.predicate && input.predicate !== arrayify('0x')
+        (input) => 'predicate' in input && input.predicate && input.predicate !== arrayify('0x')
       )
     );
   }


### PR DESCRIPTION
On this PR;
- Ensure `hasPredicate` method returns true to any input that contains a predicate field