### PR TITLE
fix: decoding for base64 at `stringFromBuffer` browser version

### DIFF
--- a/.changeset/odd-laws-change.md
+++ b/.changeset/odd-laws-change.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/crypto": minor
+---
+
+fix base64 decoding on helper stringFromBuffer for browser

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    # if: false
+    if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    if: false
+    # if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/packages/crypto/src/browser/stringFromBuffer.ts
+++ b/packages/crypto/src/browser/stringFromBuffer.ts
@@ -1,5 +1,7 @@
 import type { CryptoApi, Encoding } from '../types';
 
+import { btoa } from './crypto';
+
 export const stringFromBuffer: CryptoApi['stringFromBuffer'] = (
   buffer: Uint8Array,
   encoding: Encoding = 'base64'
@@ -9,12 +11,7 @@ export const stringFromBuffer: CryptoApi['stringFromBuffer'] = (
       return new TextDecoder().decode(buffer);
     }
     case 'base64': {
-      let binary = '';
-      const len = buffer.byteLength;
-      for (let i = 0; i < len; i += 1) {
-        binary += String.fromCharCode(buffer[i]);
-      }
-
+      const binary = String.fromCharCode.apply(null, new Uint8Array(buffer) as unknown as number[]);
       return btoa(binary);
     }
 

--- a/packages/providers/src/transaction-summary/index.ts
+++ b/packages/providers/src/transaction-summary/index.ts
@@ -5,3 +5,4 @@ export * from './status';
 export * from './operations';
 export * from './get-transaction-summary';
 export * from './assemble-transaction-summary';
+export * from './receipt';


### PR DESCRIPTION
The current approach was refactored by me on #1157

It seems it does not always work, therefore, I am rolling back to the previous approach instead.