### PR TITLE
refactor: split `calculateTransactionFee` into 2 helpers

### DIFF
--- a/.changeset/green-badgers-roll.md
+++ b/.changeset/green-badgers-roll.md
@@ -2,4 +2,4 @@
 "@fuel-ts/providers": minor
 ---
 
-split calculateTransactionFee into calculateTransactionFeeForScript and calculateTransactionFeeForContractCreated
+add new helpers calculateTransactionFeeForScript and calculateTransactionFeeForContractCreated

--- a/.changeset/green-badgers-roll.md
+++ b/.changeset/green-badgers-roll.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/providers": minor
+---
+
+split calculateTransactionFee into calculateTransactionFeeForScript and calculateTransactionFeeForContractCreated

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    # if: false
+    if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    if: false
+    # if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/packages/providers/src/transaction-summary/assemble-transaction-summary.ts
+++ b/packages/providers/src/transaction-summary/assemble-transaction-summary.ts
@@ -1,12 +1,9 @@
 import { hexlify } from '@ethersproject/bytes';
 import type { BN } from '@fuel-ts/math';
-import { TransactionType, type Transaction } from '@fuel-ts/transactions';
+import { type Transaction } from '@fuel-ts/transactions';
 
 import type { TransactionResultReceipt } from '../transaction-response';
-import {
-  calculateTransactionFeeForContractCreated,
-  calculateTransactionFeeForScript,
-} from '../utils';
+import { calculateTransactionFee } from '../utils';
 
 import {
   getOperations,
@@ -47,24 +44,15 @@ export function assembleTransactionSummary<TTransactionType = void>(
     abiParam,
   } = params;
 
-  let gasUsed: BN;
-  let fee: BN;
-
-  if (transaction.type === TransactionType.Create) {
-    ({ gasUsed, fee } = calculateTransactionFeeForContractCreated({
-      gasPrice,
-      transactionBytes,
-      transactionWitnesses: transaction?.witnesses || [],
-      gasPerByte,
-      gasPriceFactor,
-    }));
-  } else {
-    ({ gasUsed, fee } = calculateTransactionFeeForScript({
-      gasPrice,
-      receipts,
-      gasPriceFactor,
-    }));
-  }
+  const { fee, gasUsed } = calculateTransactionFee({
+    gasPrice,
+    transactionBytes,
+    transactionWitnesses: transaction?.witnesses || [],
+    gasPerByte,
+    gasPriceFactor,
+    transactionType: transaction.type,
+    receipts,
+  });
 
   const operations = getOperations({
     transactionType: transaction.type,

--- a/packages/providers/src/transaction-summary/get-transaction-summary.ts
+++ b/packages/providers/src/transaction-summary/get-transaction-summary.ts
@@ -61,7 +61,7 @@ export async function getTransactionSummaryFromRequest<TTransactionType = void>(
   provider: Provider,
   abiParam?: AbiParam
 ): Promise<TransactionSummary<TTransactionType>> {
-  const { receipts } = await provider.simulate(transactionRequest);
+  const { receipts } = await provider.call(transactionRequest);
 
   const transaction = transactionRequest.toTransaction();
   const transactionBytes = transactionRequest.toTransactionBytes();

--- a/packages/providers/src/utils/fee.test.ts
+++ b/packages/providers/src/utils/fee.test.ts
@@ -5,7 +5,7 @@ import type { TransactionResultReceipt } from '../transaction-response';
 
 import {
   calculatePriceWithFactor,
-  getGasUsedForContractCreated,
+  calculateTransactionFeeForContractCreated,
   getGasUsedFromReceipts,
 } from './fee';
 
@@ -32,21 +32,25 @@ describe(__filename, () => {
     });
   });
 
-  describe('getGasUsedForContractCreated', () => {
+  describe.only('getGasUsedForContractCreated', () => {
     it('should calculate gas used for contract created correctly', () => {
       const transactionBytes = new Uint8Array([0, 1, 2, 3, 4, 5]);
       const gasPerByte = new BN(1);
       const gasPriceFactor = new BN(2);
       const transactionWitnesses: Witness[] = [{ dataLength: 2, data: 'data' }];
 
-      const result = getGasUsedForContractCreated({
+      const gasPrice = new BN(4);
+
+      const { fee, gasUsed } = calculateTransactionFeeForContractCreated({
         transactionBytes,
         gasPerByte,
         gasPriceFactor,
         transactionWitnesses,
+        gasPrice,
       });
 
-      expect(result.toNumber()).toEqual(2); // (6-2)*1/2 = 2
+      expect(gasUsed.toNumber()).toEqual(2); // (6-2)*1/2 = 2
+      expect(fee.toNumber()).toEqual(8); // 4*2 = 8
     });
 
     it('should handle an empty witnesses array', () => {
@@ -55,14 +59,18 @@ describe(__filename, () => {
       const gasPriceFactor = new BN(2);
       const transactionWitnesses: Witness[] = [];
 
-      const result = getGasUsedForContractCreated({
+      const gasPrice = new BN(2);
+
+      const { fee, gasUsed } = calculateTransactionFeeForContractCreated({
         transactionBytes,
         gasPerByte,
         gasPriceFactor,
         transactionWitnesses,
+        gasPrice,
       });
 
-      expect(result.toNumber()).toEqual(3); // 6*1/2 = 3
+      expect(gasUsed.toNumber()).toEqual(3); // 6*1/2 = 3
+      expect(fee.toNumber()).toEqual(6); // 3*2 = 6
     });
 
     it('should round up the result', () => {
@@ -71,14 +79,18 @@ describe(__filename, () => {
       const gasPriceFactor = new BN(2);
       const transactionWitnesses: Witness[] = [];
 
-      const result = getGasUsedForContractCreated({
+      const gasPrice = new BN(1);
+
+      const { fee, gasUsed } = calculateTransactionFeeForContractCreated({
         transactionBytes,
         gasPerByte,
         gasPriceFactor,
         transactionWitnesses,
+        gasPrice,
       });
 
-      expect(result.toNumber()).toEqual(2); // 3*1/2 = 1.5 which rounds up to 2
+      expect(gasUsed.toNumber()).toEqual(2); // 3*1/2 = 1.5 which rounds up to 2
+      expect(fee.toNumber()).toEqual(2); // 2*1 = 2
     });
   });
 

--- a/packages/providers/src/utils/fee.ts
+++ b/packages/providers/src/utils/fee.ts
@@ -47,6 +47,7 @@ export const calculateTransactionFeeForScript = (params: ICalculateTransactionFe
   };
 };
 
+/** @hidden */
 export interface ICalculateTransactionFeeForContractCreated {
   gasPrice: BN;
   transactionBytes: Uint8Array;
@@ -55,6 +56,7 @@ export interface ICalculateTransactionFeeForContractCreated {
   gasPerByte?: BN;
 }
 
+/** @hidden */
 export const calculateTransactionFeeForContractCreated = (
   params: ICalculateTransactionFeeForContractCreated
 ) => {

--- a/packages/providers/src/utils/fee.ts
+++ b/packages/providers/src/utils/fee.ts
@@ -24,31 +24,6 @@ export const getGasUsedFromReceipts = (receipts: Array<TransactionResultReceipt>
   return gasUsed;
 };
 
-/** @hidden */
-export function getGasUsedForContractCreated({
-  transactionBytes,
-  gasPerByte,
-  gasPriceFactor,
-  transactionWitnesses,
-}: {
-  transactionBytes: Uint8Array;
-  gasPerByte: BN;
-  gasPriceFactor: BN;
-  transactionWitnesses: Witness[];
-}) {
-  const witnessSize = transactionWitnesses?.reduce((total, w) => total + w.dataLength, 0) || 0;
-
-  const txChargeableBytes = bn(transactionBytes.length - witnessSize);
-
-  const gasUsed = bn(
-    Math.ceil(
-      (txChargeableBytes.toNumber() * bn(gasPerByte).toNumber()) / bn(gasPriceFactor).toNumber()
-    )
-  );
-
-  return gasUsed;
-}
-
 /**
  * @hidden
  */

--- a/packages/providers/src/utils/fee.ts
+++ b/packages/providers/src/utils/fee.ts
@@ -1,6 +1,6 @@
 import type { BN } from '@fuel-ts/math';
 import { bn, multiply } from '@fuel-ts/math';
-import type { Witness, TransactionType } from '@fuel-ts/transactions';
+import type { Witness } from '@fuel-ts/transactions';
 import { ReceiptType } from '@fuel-ts/transactions';
 import { GAS_PER_BYTE, GAS_PRICE_FACTOR } from '@fuel-ts/transactions/configs';
 
@@ -52,25 +52,18 @@ export function getGasUsedForContractCreated({
 /**
  * @hidden
  */
-export interface ICalculateTransactionFee {
+export interface ICalculateTransactionFeeForScript {
   receipts: TransactionResultReceipt[];
   gasPrice: BN;
-  transactionBytes: Uint8Array;
-  transactionType: TransactionType;
-  transactionWitnesses: Witness[];
   gasPriceFactor?: BN;
-  gasPerByte?: BN;
   margin?: number;
 }
 
 /** @hidden */
-export const calculateTransactionFee = ({
-  receipts,
-  gasPrice,
-  gasPriceFactor,
-  margin,
-}: ICalculateTransactionFee) => {
-  const gasUsed = multiply(getGasUsedFromReceipts(receipts), margin || 1);
+export const calculateTransactionFeeForScript = (params: ICalculateTransactionFeeForScript) => {
+  const { gasPrice, receipts, gasPriceFactor = GAS_PRICE_FACTOR, margin = 1 } = params;
+
+  const gasUsed = multiply(getGasUsedFromReceipts(receipts), margin);
   const fee = calculatePriceWithFactor(gasUsed, gasPrice, gasPriceFactor || GAS_PRICE_FACTOR);
 
   return {

--- a/packages/providers/src/utils/fee.ts
+++ b/packages/providers/src/utils/fee.ts
@@ -27,7 +27,7 @@ export const getGasUsedFromReceipts = (receipts: Array<TransactionResultReceipt>
 /**
  * @hidden
  */
-export interface ICalculateTransactionFeeForScript {
+export interface CalculateTransactionFeeForScriptParams {
   receipts: TransactionResultReceipt[];
   gasPrice: BN;
   gasPriceFactor?: BN;
@@ -35,7 +35,9 @@ export interface ICalculateTransactionFeeForScript {
 }
 
 /** @hidden */
-export const calculateTransactionFeeForScript = (params: ICalculateTransactionFeeForScript) => {
+export const calculateTransactionFeeForScript = (
+  params: CalculateTransactionFeeForScriptParams
+) => {
   const { gasPrice, receipts, gasPriceFactor = GAS_PRICE_FACTOR, margin = 1 } = params;
 
   const gasUsed = multiply(getGasUsedFromReceipts(receipts), margin);
@@ -48,7 +50,7 @@ export const calculateTransactionFeeForScript = (params: ICalculateTransactionFe
 };
 
 /** @hidden */
-export interface ICalculateTransactionFeeForContractCreated {
+export interface CalculateTransactionFeeForContractCreatedParams {
   gasPrice: BN;
   transactionBytes: Uint8Array;
   transactionWitnesses: Witness[];
@@ -58,7 +60,7 @@ export interface ICalculateTransactionFeeForContractCreated {
 
 /** @hidden */
 export const calculateTransactionFeeForContractCreated = (
-  params: ICalculateTransactionFeeForContractCreated
+  params: CalculateTransactionFeeForContractCreatedParams
 ) => {
   const {
     gasPrice,


### PR DESCRIPTION
> UPDATED

This PR introduces and exports two new helper functions: `calculateTransactionFeeForScript` and `calculateTransactionFeeForContractCreated`. These helpers are designed to streamline the process of calculating transaction fees for specific scenarios. The existing `calculateTransactionFee` function will remain available and will make use of these two new helpers.

The motivation behind creating these two new helper functions is to simplify the transaction fee calculation process for users who already know the type of transaction they are dealing with.  Currently, users must provide additional parameters to `calculateTransactionFee`, which can be cumbersome if those parameters are irrelevant to the specific transaction type.
