### PR TITLE
fix: make sure `pid` is defined before attempting to kill `launchNodeAndGetWallets`

### DIFF
--- a/.changeset/olive-berries-happen.md
+++ b/.changeset/olive-berries-happen.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/wallet": patch
+---
+
+Only attempt to kill process if pid is defined for `launchNodeAndGetWallets`

--- a/packages/wallet/src/test-utils/launchNode.ts
+++ b/packages/wallet/src/test-utils/launchNode.ts
@@ -96,7 +96,9 @@ export const launchNode = async ({
 
     // Cleanup function where fuel-core is stopped.
     const cleanup = () => {
-      kill(Number(child.pid));
+      if (child.pid) {
+        kill(Number(child.pid));
+      }
 
       // Remove all the listeners we've added.
       child.stdout.removeAllListeners();


### PR DESCRIPTION
Closes #1264 

(hopefully :D)