### PR TITLE
chore: Add and export explicit return types for `launchNodeAndGetWallets` and `launchNode`

### DIFF
--- a/.changeset/twenty-cups-shop.md
+++ b/.changeset/twenty-cups-shop.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/wallet": patch
+---
+
+Add and export explicit return types for `launchNodeAndGetWallets` and `launchNode`

--- a/packages/wallet/src/test-utils/launchNode.ts
+++ b/packages/wallet/src/test-utils/launchNode.ts
@@ -25,6 +25,12 @@ type LaunchNodeOptions = {
   useSystemFuelCore?: boolean;
 };
 
+export type LaunchNodeResult = Promise<{
+  cleanup: () => void;
+  ip: string;
+  port: string;
+}>;
+
 /**
  * Launches a fuel-core node.
  * @param chainConfigPath - path to the chain configuration file.
@@ -41,11 +47,7 @@ export const launchNode = async ({
   port,
   args = defaultFuelCoreArgs,
   useSystemFuelCore = false,
-}: LaunchNodeOptions): Promise<{
-  cleanup: () => void;
-  ip: string;
-  port: string;
-}> =>
+}: LaunchNodeOptions): LaunchNodeResult =>
   // eslint-disable-next-line no-async-promise-executor
   new Promise(async (resolve) => {
     // This string is logged by the client when the node has successfully started. We use it to know when to resolve.
@@ -146,6 +148,12 @@ const generateWallets = async (count: number, provider: Provider) => {
   return wallets;
 };
 
+export type LaunchNodeAndGetWalletsResult = Promise<{
+  wallets: WalletUnlocked[];
+  stop: () => void;
+  provider: Provider;
+}>;
+
 /**
  * Launches a fuel-core node and returns a provider, 10 wallets, and a cleanup function to stop the node.
  * @param launchNodeOptions - options to launch the fuel-core node with.
@@ -157,7 +165,7 @@ export const launchNodeAndGetWallets = async ({
 }: {
   launchNodeOptions?: Partial<LaunchNodeOptions>;
   walletCount?: number;
-} = {}) => {
+} = {}): LaunchNodeAndGetWalletsResult => {
   const defaultNodeOptions: LaunchNodeOptions = {
     chainConfigPath: launchNodeOptions?.chainConfigPath,
     consensusKey: launchNodeOptions?.consensusKey,


### PR DESCRIPTION
Closes #1265 