### PR TITLE
refactor!: remove `chainId` from the `Predicate` constructor

### DIFF
--- a/.changeset/gold-planets-double.md
+++ b/.changeset/gold-planets-double.md
@@ -1,0 +1,14 @@
+---
+"docs": minor
+"@fuel-ts/docs-snippets": minor
+"@fuel-ts/abi-coder": minor
+"@fuel-ts/errors": minor
+"@fuel-ts/predicate": minor
+"@fuel-ts/program": minor
+"@fuel-ts/providers": minor
+"@fuel-ts/script": minor
+"@fuel-ts/wallet": minor
+"@fuel-ts/wallet-manager": minor
+---
+
+Remove `chainId` from the `Predicate` constructor. You don't need to pass in `chainId` anymore since you are passing in a `provider` already.

--- a/apps/docs-snippets/src/guide/predicates/index.test.ts
+++ b/apps/docs-snippets/src/guide/predicates/index.test.ts
@@ -12,8 +12,7 @@ describe(__filename, () => {
     // #context import { Predicate, Provider, FUEL_NETWORK_URL } from 'fuels';
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
-    const chainId = await provider.getChainId();
-    const predicate = new Predicate(binary, chainId, provider, jsonAbi);
+    const predicate = new Predicate(binary, provider, jsonAbi);
     // #endregion predicate-index-2
 
     expect(predicate).toBeTruthy();

--- a/apps/docs-snippets/src/guide/predicates/predicate-with-configurable.test.ts
+++ b/apps/docs-snippets/src/guide/predicates/predicate-with-configurable.test.ts
@@ -19,9 +19,8 @@ describe(__filename, () => {
     const newWhitelistedAddress = getRandomB256();
 
     const configurable = { WHITELISTED: newWhitelistedAddress };
-    const chainId = await wallet.provider.getChainId();
     // instantiate predicate with configurable constants
-    const predicate = new Predicate(bin, chainId, wallet.provider, abi, configurable);
+    const predicate = new Predicate(bin, wallet.provider, abi, configurable);
 
     // set predicate data to be the same as the configurable constant
     predicate.setData(configurable.WHITELISTED);
@@ -50,8 +49,7 @@ describe(__filename, () => {
 
   it('should successfully tranfer to default whitelisted address', async () => {
     // #region predicate-with-configurable-constants-3
-    const chainId = await wallet.provider.getChainId();
-    const predicate = new Predicate(bin, chainId, wallet.provider, abi);
+    const predicate = new Predicate(bin, wallet.provider, abi);
 
     // set predicate data to be the same as the configurable constant
     predicate.setData('0xa703b26833939dabc41d3fcaefa00e62cee8e1ac46db37e0fa5d4c9fe30b4132');

--- a/apps/docs-snippets/src/guide/predicates/send-and-spend-funds-from-predicates.test.ts
+++ b/apps/docs-snippets/src/guide/predicates/send-and-spend-funds-from-predicates.test.ts
@@ -18,8 +18,7 @@ describe(__filename, () => {
   it('should successfully use predicate to spend assets', async () => {
     // #region send-and-spend-funds-from-predicates-2
     const provider = await Provider.create(FUEL_NETWORK_URL);
-    const chainId = await provider.getChainId();
-    const predicate = new Predicate(bin, chainId, provider, abi);
+    const predicate = new Predicate(bin, provider, abi);
     // #endregion send-and-spend-funds-from-predicates-2
 
     // #region send-and-spend-funds-from-predicates-3
@@ -53,11 +52,7 @@ describe(__filename, () => {
 
   it('should fail when trying to spend predicates entire amount', async () => {
     const provider = await Provider.create(FUEL_NETWORK_URL);
-    const predicateOwner = WalletUnlocked.generate({
-      provider,
-    });
-    const chainId = await predicateOwner.provider.getChainId();
-    const predicate = new Predicate(bin, chainId, provider, abi);
+    const predicate = new Predicate(bin, provider, abi);
 
     const amountToPredicate = 100;
 
@@ -89,8 +84,7 @@ describe(__filename, () => {
     const predicateOwner = WalletUnlocked.generate({
       provider,
     });
-    const chainId = await predicateOwner.provider.getChainId();
-    const predicate = new Predicate(bin, chainId, predicateOwner.provider, abi);
+    const predicate = new Predicate(bin, predicateOwner.provider, abi);
 
     const amountToPredicate = 1_000;
 

--- a/packages/abi-typegen/src/templates/predicate/factory.hbs
+++ b/packages/abi-typegen/src/templates/predicate/factory.hbs
@@ -57,11 +57,11 @@ export class {{capitalizedName}}__factory {
   static readonly abi = _abi
   static readonly bin = _bin;
 
-  static createInstance(chainId: number, provider?: Provider, configurables?: {{capitalizedName}}Configurables) {
+  static createInstance(provider: Provider, configurables?: {{capitalizedName}}Configurables) {
 
     const { abi, bin } = {{capitalizedName}}__factory
 
-    const predicate = new Predicate(bin, chainId, abi, provider, configurables);
+    const predicate = new Predicate(bin, provider, abi, configurables);
 
     return predicate;
 

--- a/packages/abi-typegen/test/fixtures/templates/predicate-with-configurable/factory.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/predicate-with-configurable/factory.hbs
@@ -97,11 +97,11 @@ export class MyPredicateAbi__factory {
   static readonly abi = _abi
   static readonly bin = _bin;
 
-  static createInstance(chainId: number, provider?: Provider, configurables?: MyPredicateAbiConfigurables) {
+  static createInstance(provider: Provider, configurables?: MyPredicateAbiConfigurables) {
 
     const { abi, bin } = MyPredicateAbi__factory
 
-    const predicate = new Predicate(bin, chainId, abi, provider, configurables);
+    const predicate = new Predicate(bin, provider, abi, configurables);
 
     return predicate;
 

--- a/packages/abi-typegen/test/fixtures/templates/predicate/factory.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/predicate/factory.hbs
@@ -86,11 +86,11 @@ export class MyPredicateAbi__factory {
   static readonly abi = _abi
   static readonly bin = _bin;
 
-  static createInstance(chainId: number, provider?: Provider, configurables?: MyPredicateAbiConfigurables) {
+  static createInstance(provider: Provider, configurables?: MyPredicateAbiConfigurables) {
 
     const { abi, bin } = MyPredicateAbi__factory
 
-    const predicate = new Predicate(bin, chainId, abi, provider, configurables);
+    const predicate = new Predicate(bin, provider, abi, configurables);
 
     return predicate;
 

--- a/packages/fuel-gauge/src/contract.test.ts
+++ b/packages/fuel-gauge/src/contract.test.ts
@@ -951,9 +951,7 @@ describe('Contract', () => {
     const amountToContract = 200;
     const amountToPredicate = 300;
 
-    const chainId = await provider.getChainId();
-
-    const predicate = new Predicate(predicateBytecode, chainId, provider);
+    const predicate = new Predicate(predicateBytecode, provider);
 
     const tx1 = await wallet.transfer(predicate.address, amountToPredicate);
 

--- a/packages/fuel-gauge/src/doc-examples.test.ts
+++ b/packages/fuel-gauge/src/doc-examples.test.ts
@@ -323,8 +323,7 @@ it('can create a predicate', async () => {
   // #region predicate-basic
   // #context import { Predicate, arrayify } from 'fuels';
   const provider = await Provider.create(FUEL_NETWORK_URL);
-  const chainId = await provider.getChainId();
-  const predicate = new Predicate(testPredicateTrue, chainId, provider);
+  const predicate = new Predicate(testPredicateTrue, provider);
 
   expect(predicate.address).toBeTruthy();
   expect(predicate.bytes).toEqual(arrayify(testPredicateTrue));
@@ -397,8 +396,7 @@ it('can create a predicate and use', async () => {
     loggedTypes: [],
     configurables: [],
   };
-  const chainId = await provider.getChainId();
-  const predicate = new Predicate(predicateTriple, chainId, provider, AbiInputs);
+  const predicate = new Predicate(predicateTriple, provider, AbiInputs);
   const amountToPredicate = 100_000;
   const amountToReceiver = 100;
   const initialPredicateBalance = await predicate.getBalance();

--- a/packages/fuel-gauge/src/predicate-conditional-inputs.test.ts
+++ b/packages/fuel-gauge/src/predicate-conditional-inputs.test.ts
@@ -38,9 +38,7 @@ describe('PredicateConditionalInputs', () => {
       [5_000, assetIdA],
     ]);
 
-    const chainId = await provider.getChainId();
-
-    const predicate = new Predicate(predicateBytecode, chainId, provider, abiJSON, {
+    const predicate = new Predicate(predicateBytecode, provider, abiJSON, {
       MAKER: aliceWallet.address.toB256(),
     });
 
@@ -111,9 +109,7 @@ describe('PredicateConditionalInputs', () => {
       [5_000, assetIdB],
     ]);
 
-    const chainId = await provider.getChainId();
-
-    const predicate = new Predicate(predicateBytecode, chainId, provider, abiJSON, {
+    const predicate = new Predicate(predicateBytecode, provider, abiJSON, {
       MAKER: aliceWallet.address.toB256(),
     });
 

--- a/packages/fuel-gauge/src/predicate/predicate-arguments.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-arguments.test.ts
@@ -18,7 +18,6 @@ describe('Predicate', () => {
   describe('Arguments', () => {
     let wallet: WalletUnlocked;
     let receiver: WalletLocked;
-    let chainId: number;
     let provider: Provider;
 
     const AddressAbiInputs: JsonAbi = {
@@ -179,12 +178,7 @@ describe('Predicate', () => {
 
     it('calls a predicate with invalid address data and returns false', async () => {
       const amountToPredicate = 10;
-      const predicate = new Predicate<[string]>(
-        predicateBytesAddress,
-        chainId,
-        provider,
-        AddressAbiInputs
-      );
+      const predicate = new Predicate<[string]>(predicateBytesAddress, provider, AddressAbiInputs);
 
       const initialPredicateBalance = await fundPredicate(wallet, predicate, amountToPredicate);
       const initialReceiverBalance = await receiver.getBalance();
@@ -201,7 +195,7 @@ describe('Predicate', () => {
     it('calls a predicate with valid u32 data and returns true', async () => {
       const amountToPredicate = 100;
       const amountToReceiver = 50;
-      const predicate = new Predicate<[number]>(predicateBytesU32, chainId, provider, U32AbiInputs);
+      const predicate = new Predicate<[number]>(predicateBytesU32, provider, U32AbiInputs);
 
       const initialPredicateBalance = await fundPredicate(wallet, predicate, amountToPredicate);
       const initialReceiverBalance = await receiver.getBalance();
@@ -221,7 +215,7 @@ describe('Predicate', () => {
 
     it('calls a predicate with invalid u32 data and returns false', async () => {
       const amountToPredicate = 10;
-      const predicate = new Predicate<[number]>(predicateBytesU32, chainId, provider, U32AbiInputs);
+      const predicate = new Predicate<[number]>(predicateBytesU32, provider, U32AbiInputs);
 
       const initialPredicateBalance = await fundPredicate(wallet, predicate, amountToPredicate);
       const initialReceiverBalance = await receiver.getBalance();
@@ -240,7 +234,6 @@ describe('Predicate', () => {
       const amountToReceiver = 50;
       const predicate = new Predicate<[Validation]>(
         predicateBytesStruct,
-        chainId,
         provider,
         StructAbiInputs
       );
@@ -270,7 +263,6 @@ describe('Predicate', () => {
       const amountToPredicate = 10;
       const predicate = new Predicate<[Validation]>(
         predicateBytesStruct,
-        chainId,
         provider,
         StructAbiInputs
       );
@@ -297,7 +289,6 @@ describe('Predicate', () => {
       const amountToReceiver = 50;
       const predicate = new Predicate<[Validation]>(
         predicateBytesMainArgsStruct,
-        chainId,
         provider,
         predicateAbiMainArgsStruct
       );
@@ -330,7 +321,6 @@ describe('Predicate', () => {
       const amountToPredicate = 100;
       const predicate = new Predicate<[Validation]>(
         predicateBytesMainArgsStruct,
-        chainId,
         provider,
         predicateAbiMainArgsStruct
       );
@@ -355,7 +345,6 @@ describe('Predicate', () => {
       const amountToReceiver = 50;
       const predicate = new Predicate<[BigNumberish[]]>(
         predicateBytesMainArgsVector,
-        chainId,
         provider,
         predicateAbiMainArgsVector
       );
@@ -379,7 +368,7 @@ describe('Predicate', () => {
     it('calls a predicate with valid multiple arguments and returns true', async () => {
       const amountToPredicate = 100;
       const amountToReceiver = 50;
-      const predicate = new Predicate(predicateBytesMulti, chainId, provider, predicateAbiMulti);
+      const predicate = new Predicate(predicateBytesMulti, provider, predicateAbiMulti);
 
       const initialPredicateBalance = await fundPredicate(wallet, predicate, amountToPredicate);
       const initialReceiverBalance = await receiver.getBalance();
@@ -403,7 +392,7 @@ describe('Predicate', () => {
 
     it('calls a predicate with invalid multiple arguments and returns false', async () => {
       const amountToPredicate = 100;
-      const predicate = new Predicate(predicateBytesMulti, chainId, provider, predicateAbiMulti);
+      const predicate = new Predicate(predicateBytesMulti, provider, predicateAbiMulti);
 
       const initialPredicateBalance = await fundPredicate(wallet, predicate, amountToPredicate);
 

--- a/packages/fuel-gauge/src/predicate/predicate-arguments.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-arguments.test.ts
@@ -151,19 +151,13 @@ describe('Predicate', () => {
 
     beforeEach(async () => {
       [wallet, receiver] = await setupWallets();
-      chainId = await wallet.provider.getChainId();
       provider = wallet.provider;
     });
 
     it('calls a predicate with valid address data and returns true', async () => {
       const amountToPredicate = 100;
       const amountToReceiver = 50;
-      const predicate = new Predicate<[string]>(
-        predicateBytesAddress,
-        chainId,
-        provider,
-        AddressAbiInputs
-      );
+      const predicate = new Predicate<[string]>(predicateBytesAddress, provider, AddressAbiInputs);
 
       const initialPredicateBalance = await fundPredicate(wallet, predicate, amountToPredicate);
       const initialReceiverBalance = await receiver.getBalance();

--- a/packages/fuel-gauge/src/predicate/predicate-configurables.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-configurables.test.ts
@@ -19,7 +19,6 @@ import { fundPredicate, assertBalance } from './utils/predicate';
 describe('Predicate', () => {
   describe('Configurables', () => {
     let wallet: WalletUnlocked;
-    let chainId: number;
 
     const defaultValues = {
       FEE: 10,
@@ -37,14 +36,11 @@ describe('Predicate', () => {
       ];
 
       wallet = await generateTestWallet(provider, quantities);
-
-      chainId = await wallet.provider.getChainId();
     });
 
     it('calls a predicate with configurables using default values', async () => {
       const predicate = new Predicate(
         predicateBytesConfigurable,
-        chainId,
         wallet.provider,
         predicateAbiConfigurable
       );
@@ -76,7 +72,6 @@ describe('Predicate', () => {
       expect(configurableConstants.FEE).not.toEqual(defaultValues.FEE);
       const predicate = new Predicate(
         predicateBytesConfigurable,
-        chainId,
         wallet.provider,
         predicateAbiConfigurable,
         configurableConstants
@@ -109,7 +104,6 @@ describe('Predicate', () => {
       expect(configurableConstants.ADDRESS).not.toEqual(defaultValues.ADDRESS);
       const predicate = new Predicate(
         predicateBytesConfigurable,
-        chainId,
         wallet.provider,
         predicateAbiConfigurable,
         configurableConstants
@@ -146,7 +140,6 @@ describe('Predicate', () => {
       expect(configurableConstants.ADDRESS).not.toEqual(defaultValues.ADDRESS);
       const predicate = new Predicate(
         predicateBytesConfigurable,
-        chainId,
         wallet.provider,
         predicateAbiConfigurable,
         configurableConstants
@@ -174,7 +167,6 @@ describe('Predicate', () => {
     it('throws when configurable data is not set', async () => {
       const predicate = new Predicate(
         predicateBytesConfigurable,
-        chainId,
         wallet.provider,
         predicateAbiConfigurable
       );
@@ -190,15 +182,9 @@ describe('Predicate', () => {
 
     it('throws when setting configurable but predicate has none', () => {
       expect(() => {
-        const predicate = new Predicate(
-          predicateBytesTrue,
-          chainId,
-          wallet.provider,
-          predicateAbiTrue,
-          {
-            constant: 'NADA',
-          }
-        );
+        const predicate = new Predicate(predicateBytesTrue, wallet.provider, predicateAbiTrue, {
+          constant: 'NADA',
+        });
 
         predicate.setData('NADA');
       }).toThrow('Predicate has no configurable constants to be set');
@@ -210,7 +196,6 @@ describe('Predicate', () => {
       expect(() => {
         const predicate = new Predicate(
           predicateBytesConfigurable,
-          chainId,
           wallet.provider,
           predicateAbiConfigurable,
           {
@@ -226,15 +211,9 @@ describe('Predicate', () => {
       const errMsg = `Error setting configurable constants: Cannot validate configurable constants because the Predicate was instantiated without a JSON ABI.`;
 
       expect(() => {
-        const predicate = new Predicate(
-          predicateBytesConfigurable,
-          chainId,
-          wallet.provider,
-          undefined,
-          {
-            NOPE: 'NADA',
-          }
-        );
+        const predicate = new Predicate(predicateBytesConfigurable, wallet.provider, undefined, {
+          NOPE: 'NADA',
+        });
 
         predicate.setData('NADA');
       }).toThrow(errMsg);

--- a/packages/fuel-gauge/src/predicate/predicate-estimations.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-estimations.test.ts
@@ -23,11 +23,9 @@ describe('Predicate', () => {
 
     beforeEach(async () => {
       provider = await Provider.create(FUEL_NETWORK_URL);
-      const chainId = await provider.getChainId();
-      predicateTrue = new Predicate(predicateTrueBytecode, chainId, provider);
+      predicateTrue = new Predicate(predicateTrueBytecode, provider);
       predicateStruct = new Predicate<[Validation]>(
         predicateBytesMainArgsStruct,
-        chainId,
         provider,
         predicateAbiMainArgsStruct
       );

--- a/packages/fuel-gauge/src/predicate/predicate-evaluations.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-evaluations.test.ts
@@ -11,12 +11,10 @@ describe('Predicate', () => {
     let predicate: Predicate<InputValue[]>;
     let wallet: WalletUnlocked;
     let receiver: WalletLocked;
-    let chainId: number;
     let provider: Provider;
 
     beforeEach(async () => {
       [wallet, receiver] = await setupWallets();
-      chainId = await wallet.provider.getChainId();
       provider = wallet.provider;
     });
 
@@ -25,7 +23,7 @@ describe('Predicate', () => {
       const amountToReceiver = 50;
       const initialReceiverBalance = await receiver.getBalance();
 
-      predicate = new Predicate(predicateBytesTrue, chainId, provider);
+      predicate = new Predicate(predicateBytesTrue, provider);
 
       const initialPredicateBalance = await fundPredicate(wallet, predicate, amountToPredicate);
 
@@ -46,7 +44,7 @@ describe('Predicate', () => {
       const amountToPredicate = 100;
       const amountToReceiver = 50;
 
-      predicate = new Predicate(predicateBytesFalse, chainId, provider);
+      predicate = new Predicate(predicateBytesFalse, provider);
 
       await fundPredicate(wallet, predicate, amountToPredicate);
 

--- a/packages/fuel-gauge/src/predicate/predicate-invalidations.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-invalidations.test.ts
@@ -23,11 +23,9 @@ describe('Predicate', () => {
     beforeAll(async () => {
       [wallet, receiver] = await setupWallets();
       const amountToPredicate = 100;
-      const chainId = await wallet.provider.getChainId();
       provider = wallet.provider;
       predicate = new Predicate<[Validation]>(
         predicateBytesMainArgsStruct,
-        chainId,
         provider,
         predicateAbiMainArgsStruct
       );

--- a/packages/fuel-gauge/src/predicate/predicate-with-contract.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-with-contract.test.ts
@@ -49,10 +49,8 @@ describe('Predicate', () => {
       });
       const contract = await setupContract();
       const amountToPredicate = 100_000;
-      const chainId = await wallet.provider.getChainId();
       const predicate = new Predicate<[Validation]>(
         predicateBytesTrue,
-        chainId,
         provider,
         predicateAbiMainArgsStruct
       );
@@ -101,10 +99,8 @@ describe('Predicate', () => {
       // setup predicate
       const amountToPredicate = 100;
       const amountToReceiver = 50;
-      const chainId = await wallet.provider.getChainId();
       const predicate = new Predicate<[Validation]>(
         predicateBytesStruct,
-        chainId,
         provider,
         predicateAbiMainArgsStruct
       );

--- a/packages/fuel-gauge/src/predicate/predicate-with-script.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-with-script.test.ts
@@ -45,10 +45,8 @@ describe('Predicate', () => {
       // setup predicate
       const amountToPredicate = 100;
       const amountToReceiver = 50;
-      const chainId = await wallet.provider.getChainId();
       const predicate = new Predicate<[Validation]>(
         predicateBytesStruct,
-        chainId,
         provider,
         predicateAbiMainArgsStruct
       );

--- a/packages/fuel-gauge/src/vector-types.test.ts
+++ b/packages/fuel-gauge/src/vector-types.test.ts
@@ -134,12 +134,10 @@ describe('Vector Types Validation', () => {
   it('can use supported vector types [predicate-vector-types]', async () => {
     const wallet = await setup();
     const receiver = Wallet.fromAddress(Address.fromRandom(), wallet.provider);
-    const chainId = await wallet.provider.getChainId();
     const amountToPredicate = 100;
     const amountToReceiver = 50;
     const predicate = new Predicate<MainArgs>(
       predicateVectorTypes,
-      chainId,
       wallet.provider,
       predicateVectorTypesAbi
     );

--- a/packages/predicate/src/predicate.ts
+++ b/packages/predicate/src/predicate.ts
@@ -47,7 +47,6 @@ export class Predicate<ARGS extends InputValue[]> extends Account implements Abs
    */
   constructor(
     bytes: BytesLike,
-    chainId: number,
     provider: Provider,
     jsonAbi?: JsonAbi,
     configurableConstants?: { [name: string]: unknown }
@@ -57,7 +56,7 @@ export class Predicate<ARGS extends InputValue[]> extends Account implements Abs
       jsonAbi,
       configurableConstants
     );
-
+    const chainId = provider.getChainId();
     const address = Address.fromB256(getPredicateRoot(predicateBytes, chainId));
     super(address, provider);
 

--- a/packages/predicate/test/features/predicate-functions.test.ts
+++ b/packages/predicate/test/features/predicate-functions.test.ts
@@ -8,7 +8,6 @@ import { defaultPredicateBytecode } from '../fixtures/bytecode/default';
 
 describe('Predicate', () => {
   describe('Functions', () => {
-    const chainId = 0;
     const predicateAddress = '0x4f780df441f7a02b5c1e718fcd779776499a0d1069697db33f755c82d7bae02b';
     let provider: Provider;
 
@@ -17,17 +16,12 @@ describe('Predicate', () => {
     });
 
     it('sets predicate address for given byte code', () => {
-      const predicate = new Predicate(defaultPredicateBytecode, chainId, provider);
+      const predicate = new Predicate(defaultPredicateBytecode, provider);
       expect(predicate.address.toB256()).toEqual(predicateAddress);
     });
 
     it('sets predicate data for given ABI', () => {
-      const predicate = new Predicate(
-        defaultPredicateBytecode,
-        chainId,
-        provider,
-        defaultPredicateAbi
-      );
+      const predicate = new Predicate(defaultPredicateBytecode, provider, defaultPredicateAbi);
       const b256 = '0x0101010101010101010101010101010101010101010101010101010101010101';
 
       predicate.setData<[string]>(b256);
@@ -47,15 +41,9 @@ describe('Predicate', () => {
       };
 
       expect(() => {
-        const predicate = new Predicate(
-          defaultPredicateBytecode,
-          chainId,
-          provider,
-          abiWithNoMain,
-          {
-            value: 1,
-          }
-        );
+        const predicate = new Predicate(defaultPredicateBytecode, provider, abiWithNoMain, {
+          value: 1,
+        });
 
         predicate.setData('NADA');
       }).toThrow('Cannot use ABI without "main" function');

--- a/packages/predicate/test/features/predicate-transactions.test.ts
+++ b/packages/predicate/test/features/predicate-transactions.test.ts
@@ -19,8 +19,7 @@ describe('Predicate', () => {
 
     beforeAll(async () => {
       provider = await Provider.create(FUEL_NETWORK_URL);
-      const chainId = 0;
-      predicate = new Predicate(defaultPredicateBytecode, chainId, provider, defaultPredicateAbi);
+      predicate = new Predicate(defaultPredicateBytecode, provider, defaultPredicateAbi);
       const predicateAddress = '0x4f780df441f7a02b5c1e718fcd779776499a0d1069697db33f755c82d7bae02b';
 
       predicate.setData<[string]>(b256);

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -403,10 +403,10 @@ export default class Provider {
    * Returns the chain ID
    * @returns A promise that resolves to the chain ID number
    */
-  async getChainId(): Promise<number> {
+  getChainId() {
     const {
       consensusParameters: { chainId },
-    } = await this.getChain();
+    } = this.getChain();
     return chainId.toNumber();
   }
 


### PR DESCRIPTION
We don't need to pass in the `chainId` explicitly now since we are passing in a `Provider` already. We can extract the `chainId` from the `Provider`.

Closes #1261 