### PR TITLE
fix: check tx status before awaiting tx status change in `waitForResult`

### DIFF
--- a/.changeset/silver-clouds-lick.md
+++ b/.changeset/silver-clouds-lick.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/providers": patch
+---
+
+Fix a bug in `tx.waitForResult()` where the code would freeze in case a tx was already finalized by the time `waitForResult` was called.


### PR DESCRIPTION
This PR adds a fix that ensures that the transaction has not already been completed before tuning into the `statusChange` subscription to listen for any status changes. This is a critical bug since this could cause the code to freeze.

Closes #1301 