### PR TITLE
fix: update calculate fee outputs

### DIFF
--- a/.changeset/strong-garlics-prove.md
+++ b/.changeset/strong-garlics-prove.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/providers": minor
+---
+
+made calculateTransactionFee to return minFee and maxFee

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -678,7 +678,7 @@ export default class Provider {
 
     const gasUsed = getGasUsedFromReceipts(receipts);
 
-    const { fee } = calculateTransactionFee({
+    const { minFee } = calculateTransactionFee({
       gasPrice,
       gasPerByte,
       gasPriceFactor,
@@ -691,7 +691,7 @@ export default class Provider {
       minGasPrice,
       gasPrice,
       gasUsed,
-      fee,
+      fee: minFee,
     };
   }
 

--- a/packages/providers/src/transaction-summary/assemble-transaction-summary.ts
+++ b/packages/providers/src/transaction-summary/assemble-transaction-summary.ts
@@ -58,7 +58,7 @@ export function assembleTransactionSummary<TTransactionType = void>(
     transactionWitnesses: witnesses,
   });
 
-  const { fee } = calculateTransactionFee({
+  const { minFee: fee } = calculateTransactionFee({
     gasUsed,
     gasPrice,
     gasLimit,

--- a/packages/providers/src/utils/calculate-fee.test.ts
+++ b/packages/providers/src/utils/calculate-fee.test.ts
@@ -54,8 +54,11 @@ describe(__filename, () => {
         Math.ceil(maxGas.mul(gasPrice).toNumber() / gasPriceFactor.toNumber())
       );
 
-      const partialFee = Math.ceil(gasUsed.mul(gasPrice).toNumber() / gasPriceFactor.toNumber());
-      const expectedFee = expectedMinGasToPay.add(partialFee);
+      const expectedFeeFromGasUsed = bn(
+        Math.ceil(gasUsed.mul(gasPrice).toNumber() / gasPriceFactor.toNumber())
+      );
+      const expectedMinFee = expectedMinGasToPay.add(expectedFeeFromGasUsed);
+      const expectedMaxFee = expectedMaxGasToPay.add(expectedFeeFromGasUsed);
 
       const result = calculateTransactionFee({
         gasPrice,
@@ -66,9 +69,11 @@ describe(__filename, () => {
         chargeableBytes,
       });
 
-      expect(result.fee.toNumber()).toEqual(expectedFee.toNumber());
+      expect(result.minFee.toNumber()).toEqual(expectedMinFee.toNumber());
+      expect(result.maxFee.toNumber()).toEqual(expectedMaxFee.toNumber());
       expect(result.minGasToPay.toNumber()).toEqual(expectedMinGasToPay.toNumber());
       expect(result.maxGasToPay.toNumber()).toEqual(expectedMaxGasToPay.toNumber());
+      expect(result.feeFromGasUsed.toNumber()).toEqual(expectedFeeFromGasUsed.toNumber());
     });
 
     it('should calculate transaction fee for multiple receipts', () => {
@@ -89,8 +94,11 @@ describe(__filename, () => {
         Math.ceil(maxGas.mul(gasPrice).toNumber() / gasPriceFactor.toNumber())
       );
 
-      const partialFee = Math.ceil(gasUsed.mul(gasPrice).toNumber() / gasPriceFactor.toNumber());
-      const expectedFee = expectedMinGasToPay.add(partialFee);
+      const expectedFeeFromGasUsed = bn(
+        Math.ceil(gasUsed.mul(gasPrice).toNumber() / gasPriceFactor.toNumber())
+      );
+      const expectedMinFee = expectedMinGasToPay.add(expectedFeeFromGasUsed);
+      const expectedMaxFee = expectedMaxGasToPay.add(expectedFeeFromGasUsed);
 
       const result = calculateTransactionFee({
         gasPrice,
@@ -101,9 +109,11 @@ describe(__filename, () => {
         chargeableBytes,
       });
 
-      expect(result.fee.toNumber()).toEqual(expectedFee.toNumber());
+      expect(result.minFee.toNumber()).toEqual(expectedMinFee.toNumber());
+      expect(result.maxFee.toNumber()).toEqual(expectedMaxFee.toNumber());
       expect(result.minGasToPay.toNumber()).toEqual(expectedMinGasToPay.toNumber());
       expect(result.maxGasToPay.toNumber()).toEqual(expectedMaxGasToPay.toNumber());
+      expect(result.feeFromGasUsed.toNumber()).toEqual(expectedFeeFromGasUsed.toNumber());
     });
   });
 

--- a/packages/providers/src/utils/calculate-fee.ts
+++ b/packages/providers/src/utils/calculate-fee.ts
@@ -64,12 +64,18 @@ export const calculateTransactionFee = ({
   const minGasToPay = bn(Math.ceil(minGas.mul(gasPrice).toNumber() / gasPriceFactor.toNumber()));
   const maxGasToPay = bn(Math.ceil(maxGas.mul(gasPrice).toNumber() / gasPriceFactor.toNumber()));
 
-  const partialFee = Math.ceil(gasUsed.mul(gasPrice).toNumber() / gasPriceFactor.toNumber());
-  const fee = minGasToPay.add(partialFee);
+  const feeFromGasUsed = bn(
+    Math.ceil(gasUsed.mul(gasPrice).toNumber() / gasPriceFactor.toNumber())
+  );
+
+  const minFee = minGasToPay.add(feeFromGasUsed);
+  const maxFee = maxGasToPay.add(feeFromGasUsed);
 
   return {
-    fee,
+    minFee,
+    maxFee,
     minGasToPay,
     maxGasToPay,
+    feeFromGasUsed,
   };
 };


### PR DESCRIPTION
Made `CalculateTransactionFee` to return `minFee` and `maxFee`. 

These values are relevant when calculating the amount of funds a Transaction Request needs before being submitted to the chain

**EDIT**

On [1307](https://github.com/FuelLabs/fuels-ts/pull/1307), I did not return the `maxFee` because I was under the impression that it was not relevant, since the actual fee deducted from the user's wallet was always the `minFee`.

However, I've recently become aware that the [VM always uses](https://github.com/FuelLabs/fuel-vm/blob/94677aa1cfa5a150368c4820a8a757baac479e1f/fuel-vm/src/checked_transaction/balances.rs#L73-L78) the `maxFee` value to estimate if the transaction has enough balances to cover the fee.

In other words, we need `maxFee` in order to properly fund a transaction before submitting it to the chain.