### PR TITLE
feat: add `Predicate.getTransferTxId` helper

### DIFF
--- a/.changeset/kind-glasses-brake.md
+++ b/.changeset/kind-glasses-brake.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/predicate": patch
+"@fuel-ts/wallet": patch
+---
+
+New helper method `Predicate.getTransferTxId`, which lets you calculate the transaction ID for a Predicate.transfer transaction, before actually sending it.

--- a/apps/docs-snippets/src/guide/predicates/send-and-spend-funds-from-predicates.test.ts
+++ b/apps/docs-snippets/src/guide/predicates/send-and-spend-funds-from-predicates.test.ts
@@ -27,7 +27,7 @@ describe(__filename, () => {
     ({ minGasPrice: gasPrice } = walletWithFunds.provider.getGasConfig());
   });
 
-  it.only('should successfully use predicate to spend assets', async () => {
+  it('should successfully use predicate to spend assets', async () => {
     // #region send-and-spend-funds-from-predicates-2
     const provider = await Provider.create(FUEL_NETWORK_URL);
     const predicate = new Predicate(bin, provider, abi);
@@ -40,7 +40,7 @@ describe(__filename, () => {
       gasPrice,
     });
 
-    // await tx.waitForResult();
+    await tx.waitForResult();
     // #endregion send-and-spend-funds-from-predicates-3
 
     const initialPredicateBalance = new BN(await predicate.getBalance()).toNumber();
@@ -53,17 +53,12 @@ describe(__filename, () => {
     predicate.setData(inputAddress);
     // #endregion send-and-spend-funds-from-predicates-4
 
-    // #region send-and-spend-funds-from-predicates-5
     const receiverWallet = WalletUnlocked.generate({
       provider,
     });
 
-    console.log({
-      predicateBalances: await predicate.getBalances(),
-    });
-
     // #region send-and-spend-funds-from-predicates-8
-    const txId = await predicate.getTransferTransactionId(
+    const txId = await predicate.getTransferTxId(
       receiverWallet.address,
       amountToPredicate - 150_000,
       BaseAssetId,
@@ -71,7 +66,9 @@ describe(__filename, () => {
         gasPrice,
       }
     );
+    // #endregion send-and-spend-funds-from-predicates-8
 
+    // #region send-and-spend-funds-from-predicates-5
     const tx2 = await predicate.transfer(
       receiverWallet.address,
       amountToPredicate - 150_000,
@@ -83,10 +80,8 @@ describe(__filename, () => {
 
     await tx2.waitForResult();
     // #endregion send-and-spend-funds-from-predicates-5
-
     const txIdFromExecutedTx = tx2.id;
 
-    // #endregion send-and-spend-funds-from-predicates-8
     expect(txId).toEqual(txIdFromExecutedTx);
   });
 

--- a/apps/docs-snippets/src/guide/predicates/send-and-spend-funds-from-predicates.test.ts
+++ b/apps/docs-snippets/src/guide/predicates/send-and-spend-funds-from-predicates.test.ts
@@ -9,7 +9,10 @@ import {
   BaseAssetId,
 } from 'fuels';
 
-import { DocSnippetProjectsEnum, getDocsSnippetsForcProject } from '../../../test/fixtures/forc-projects';
+import {
+  DocSnippetProjectsEnum,
+  getDocsSnippetsForcProject,
+} from '../../../test/fixtures/forc-projects';
 import { getTestWallet } from '../../utils';
 
 describe(__filename, () => {
@@ -24,7 +27,7 @@ describe(__filename, () => {
     ({ minGasPrice: gasPrice } = walletWithFunds.provider.getGasConfig());
   });
 
-  it('should successfully use predicate to spend assets', async () => {
+  it.only('should successfully use predicate to spend assets', async () => {
     // #region send-and-spend-funds-from-predicates-2
     const provider = await Provider.create(FUEL_NETWORK_URL);
     const predicate = new Predicate(bin, provider, abi);
@@ -37,7 +40,7 @@ describe(__filename, () => {
       gasPrice,
     });
 
-    await tx.waitForResult();
+    // await tx.waitForResult();
     // #endregion send-and-spend-funds-from-predicates-3
 
     const initialPredicateBalance = new BN(await predicate.getBalance()).toNumber();
@@ -55,6 +58,20 @@ describe(__filename, () => {
       provider,
     });
 
+    console.log({
+      predicateBalances: await predicate.getBalances(),
+    });
+
+    // #region send-and-spend-funds-from-predicates-8
+    const txId = await predicate.getTransferTransactionId(
+      receiverWallet.address,
+      amountToPredicate - 150_000,
+      BaseAssetId,
+      {
+        gasPrice,
+      }
+    );
+
     const tx2 = await predicate.transfer(
       receiverWallet.address,
       amountToPredicate - 150_000,
@@ -66,6 +83,11 @@ describe(__filename, () => {
 
     await tx2.waitForResult();
     // #endregion send-and-spend-funds-from-predicates-5
+
+    const txIdFromExecutedTx = tx2.id;
+
+    // #endregion send-and-spend-funds-from-predicates-8
+    expect(txId).toEqual(txIdFromExecutedTx);
   });
 
   it('should fail when trying to spend predicates entire amount', async () => {

--- a/apps/docs/src/guide/predicates/send-and-spend-funds-from-predicates.md
+++ b/apps/docs/src/guide/predicates/send-and-spend-funds-from-predicates.md
@@ -38,6 +38,12 @@ Note the method transfer has two parameters: the recipient's address and the int
 
 Once the predicate resolves with a return value `true` based on its predefined condition, our predicate successfully spends its funds by means of a transfer to a desired wallet.
 
+---
+
+You can also use the `getTransferTxId` helper to obtain the transaction ID of the transfer beforehand, without actually executing it.
+
+<<< @/../../docs-snippets/src/guide/predicates/send-and-spend-funds-from-predicates.test.ts#send-and-spend-funds-from-predicates-8{ts:line-numbers}
+
 ## Spending Entire Predicate Held Amount
 
 Trying to forward the entire amount held by the predicate results in an error because no funds are left to cover the transaction fees. Attempting this will result in an error message like:

--- a/packages/predicate/package.json
+++ b/packages/predicate/package.json
@@ -28,6 +28,7 @@
     "@fuel-ts/abi-coder": "workspace:*",
     "@fuel-ts/address": "workspace:*",
     "@fuel-ts/interfaces": "workspace:*",
+    "@fuel-ts/math": "workspace:*",
     "@fuel-ts/merkle": "workspace:*",
     "@fuel-ts/providers": "workspace:*",
     "@fuel-ts/transactions": "workspace:*",

--- a/packages/predicate/src/predicate.ts
+++ b/packages/predicate/src/predicate.ts
@@ -115,12 +115,7 @@ export class Predicate<ARGS extends InputValue[]> extends Account implements Abs
     /** Tx Params */
     txParams: TxParamsType = {}
   ): Promise<string> {
-    const request = await super.prepareTransferTxRequestForIdCalculation(
-      destination,
-      amount,
-      assetId,
-      txParams
-    );
+    const request = await super.prepareTransferTxRequest(destination, amount, assetId, txParams);
     const populatedRequest = this.populateTransactionPredicateData(request);
     return hashTransaction(populatedRequest, this.provider.getChainId());
   }

--- a/packages/predicate/src/predicate.ts
+++ b/packages/predicate/src/predicate.ts
@@ -18,7 +18,7 @@ import type {
   TransactionRequestLike,
   TransactionResponse,
 } from '@fuel-ts/providers';
-import { ScriptTransactionRequest, transactionRequestify } from '@fuel-ts/providers';
+import { transactionRequestify } from '@fuel-ts/providers';
 import { ByteArrayCoder, InputType } from '@fuel-ts/transactions';
 import type { TxParamsType } from '@fuel-ts/wallet';
 import { Account } from '@fuel-ts/wallet';
@@ -105,7 +105,7 @@ export class Predicate<ARGS extends InputValue[]> extends Account implements Abs
    * @param txParams - The transaction parameters (gasLimit, gasPrice, maturity).
    * @returns A promise that resolves to the transaction ID.
    */
-  async getTransferTransactionId(
+  async getTransferTxId(
     /** Address of the destination */
     destination: AbstractAddress,
     /** Amount of coins */
@@ -115,7 +115,7 @@ export class Predicate<ARGS extends InputValue[]> extends Account implements Abs
     /** Tx Params */
     txParams: TxParamsType = {}
   ): Promise<string> {
-    const request = await super.prepareTxRequestForIdCalculation(
+    const request = await super.prepareTransferTxRequestForIdCalculation(
       destination,
       amount,
       assetId,

--- a/packages/wallet/src/account.test.ts
+++ b/packages/wallet/src/account.test.ts
@@ -458,4 +458,23 @@ describe('Account', () => {
     expect(simulate.mock.calls.length).toBe(1);
     expect(simulate.mock.calls[0][0]).toEqual(transactionRequest);
   });
+
+  it('getTransferTransactionId should return the transaction id', async () => {
+    const amount = bn(1);
+    const assetId = '0x0101010101010101010101010101010101010101010101010101010101010101';
+    const destination = Address.fromAddressOrString(
+      '0x0101010101010101010101010101010101010101000000000000000000000000'
+    );
+    const txParam: Pick<TransactionRequestLike, 'gasLimit' | 'gasPrice' | 'maturity'> = {
+      gasLimit: bn(1),
+      gasPrice: bn(1),
+      maturity: 1,
+    };
+    const account = new Account(
+      '0x09c0b2d1a486c439a87bcba6b46a7a1a23f3897cc83a94521a96da5c23bc58db',
+      provider
+    );
+    const txId = await account.getTransferTransactionId(destination, amount, assetId, txParam);
+    expect(txId.length).toEqual(66);
+  });
 });

--- a/packages/wallet/src/account.test.ts
+++ b/packages/wallet/src/account.test.ts
@@ -458,23 +458,4 @@ describe('Account', () => {
     expect(simulate.mock.calls.length).toBe(1);
     expect(simulate.mock.calls[0][0]).toEqual(transactionRequest);
   });
-
-  it('getTransferTransactionId should return the transaction id', async () => {
-    const amount = bn(1);
-    const assetId = '0x0101010101010101010101010101010101010101010101010101010101010101';
-    const destination = Address.fromAddressOrString(
-      '0x0101010101010101010101010101010101010101000000000000000000000000'
-    );
-    const txParam: Pick<TransactionRequestLike, 'gasLimit' | 'gasPrice' | 'maturity'> = {
-      gasLimit: bn(1),
-      gasPrice: bn(1),
-      maturity: 1,
-    };
-    const account = new Account(
-      '0x09c0b2d1a486c439a87bcba6b46a7a1a23f3897cc83a94521a96da5c23bc58db',
-      provider
-    );
-    const txId = await account.getTransferTransactionId(destination, amount, assetId, txParam);
-    expect(txId.length).toEqual(66);
-  });
 });

--- a/packages/wallet/src/account.ts
+++ b/packages/wallet/src/account.ts
@@ -239,14 +239,7 @@ export class Account extends AbstractAccount {
     /** Tx Params */
     txParams: TxParamsType = {}
   ): Promise<TransactionResponse> {
-    const { maxGasPerTx } = this.provider.getGasConfig();
-    const params: TxParamsType = { gasLimit: maxGasPerTx, ...txParams };
-    const request = new ScriptTransactionRequest(params);
-    request.addCoinOutput(destination, amount, assetId);
-    const { maxFee, requiredQuantities } = await this.provider.getTransactionCost(request);
-
-    await this.fund(request, requiredQuantities, maxFee);
-
+    const request = await this.prepareTransferTxRequest(destination, amount, assetId, txParams);
     return this.sendTransaction(request);
   }
 
@@ -259,7 +252,7 @@ export class Account extends AbstractAccount {
    * @param txParams - The transaction parameters (gasLimit, gasPrice, maturity).
    * @returns A promise that resolves to the prepared transaction request.
    */
-  protected async prepareTransferTxRequestForIdCalculation(
+  protected async prepareTransferTxRequest(
     /** Address of the destination */
     destination: AbstractAddress,
     /** Amount of coins */

--- a/packages/wallet/src/account.ts
+++ b/packages/wallet/src/account.ts
@@ -1,7 +1,6 @@
 import { Address } from '@fuel-ts/address';
 import { BaseAssetId } from '@fuel-ts/address/configs';
 import { ErrorCode, FuelError } from '@fuel-ts/errors';
-import { hashTransaction } from '@fuel-ts/hasher';
 import { AbstractAccount } from '@fuel-ts/interfaces';
 import type { AbstractAddress } from '@fuel-ts/interfaces';
 import type { BigNumberish, BN } from '@fuel-ts/math';
@@ -244,31 +243,23 @@ export class Account extends AbstractAccount {
     const params: TxParamsType = { gasLimit: maxGasPerTx, ...txParams };
     const request = new ScriptTransactionRequest(params);
     request.addCoinOutput(destination, amount, assetId);
-    console.log({
-      inputs1: JSON.stringify(request.inputs),
-      length: request.inputs.length,
-    });
     const { maxFee, requiredQuantities } = await this.provider.getTransactionCost(request);
 
     await this.fund(request, requiredQuantities, maxFee);
-    console.log({
-      inputs2: JSON.stringify(request.inputs),
-      length: request.inputs.length,
-    });
 
     return this.sendTransaction(request);
   }
 
   /**
-   * Returns the transaction ID for a transfer transaction, without sending it.
+   * A helper that prepares a transaction request for calculating the transaction ID.
    *
    * @param destination - The address of the destination.
    * @param amount - The amount of coins to transfer.
    * @param assetId - The asset ID of the coins to transfer.
    * @param txParams - The transaction parameters (gasLimit, gasPrice, maturity).
-   * @returns A promise that resolves to the transaction ID.
+   * @returns A promise that resolves to the prepared transaction request.
    */
-  protected async prepareTxRequestForIdCalculation(
+  protected async prepareTransferTxRequestForIdCalculation(
     /** Address of the destination */
     destination: AbstractAddress,
     /** Amount of coins */
@@ -282,16 +273,8 @@ export class Account extends AbstractAccount {
     const params: TxParamsType = { gasLimit: maxGasPerTx, ...txParams };
     const request = new ScriptTransactionRequest(params);
     request.addCoinOutput(destination, amount, assetId);
-    console.log({
-      inputs3: JSON.stringify(request.inputs),
-      length: request.inputs.length,
-    });
     const { maxFee, requiredQuantities } = await this.provider.getTransactionCost(request);
     await this.fund(request, requiredQuantities, maxFee);
-    console.log({
-      inputs4: JSON.stringify(request.inputs),
-      length: request.inputs.length,
-    });
     return request;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -867,6 +867,9 @@ importers:
       '@fuel-ts/interfaces':
         specifier: workspace:*
         version: link:../interfaces
+      '@fuel-ts/math':
+        specifier: workspace:*
+        version: link:../math
       '@fuel-ts/merkle':
         specifier: workspace:*
         version: link:../merkle
@@ -888,10 +891,6 @@ importers:
       ethers:
         specifier: ^6.7.1
         version: 6.7.1
-    devDependencies:
-      '@fuel-ts/math':
-        specifier: workspace:*
-        version: link:../math
 
   packages/program:
     dependencies:


### PR DESCRIPTION
As a part of #1451, this PR adds a new helper `getTransferTxId` for predicates which lets you calculate the transaction ID for a `Predicate.transfer` transaction, before actually sending it.