### PR TITLE
fix: auto-load storage slots in `fuels deploy`

### DIFF
--- a/.changeset/kind-doors-grow.md
+++ b/.changeset/kind-doors-grow.md
@@ -1,0 +1,5 @@
+---
+"fuels": patch
+---
+
+The fuels CLI's deploy now auto-loads storage slots for contracts, just like typegen.

--- a/packages/fuels/src/cli/commands/deploy/deployContract.ts
+++ b/packages/fuels/src/cli/commands/deploy/deployContract.ts
@@ -1,7 +1,7 @@
 import { ContractFactory } from '@fuel-ts/contract';
 import type { DeployContractOptions } from '@fuel-ts/contract';
 import type { WalletUnlocked } from '@fuel-ts/wallet';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 
 import { debug } from '../../utils/logger';
 
@@ -9,11 +9,19 @@ export async function deployContract(
   wallet: WalletUnlocked,
   binaryPath: string,
   abiPath: string,
+  storageSlotsPath: string,
   deployConfig: DeployContractOptions
 ) {
   debug(`Deploying contract for ABI: ${abiPath}`);
 
   const bytecode = readFileSync(binaryPath);
+
+  if (existsSync(storageSlotsPath)) {
+    const storageSlots = JSON.parse(readFileSync(storageSlotsPath, 'utf-8'));
+    // eslint-disable-next-line no-param-reassign
+    deployConfig.storageSlots = storageSlots;
+  }
+
   const { minGasPrice: gasPrice } = wallet.provider.getGasConfig();
 
   const abi = JSON.parse(readFileSync(abiPath, 'utf-8'));

--- a/packages/fuels/src/cli/commands/deploy/index.ts
+++ b/packages/fuels/src/cli/commands/deploy/index.ts
@@ -3,6 +3,7 @@ import {
   getABIPath,
   getContractName,
   getContractCamelCase,
+  getStorageSlotsPath,
 } from '../../config/forcUtils';
 import type { FuelsConfig, DeployedContract } from '../../types';
 import { debug, log } from '../../utils/logger';
@@ -25,6 +26,7 @@ export async function deploy(config: FuelsConfig) {
     const contractPath = config.contracts[i];
     const binaryPath = getBinaryPath(contractPath);
     const abiPath = getABIPath(contractPath);
+    const storageSlotsPath = getStorageSlotsPath(contractPath);
     const projectName = getContractName(contractPath);
     const contractName = getContractCamelCase(contractPath);
     const deployConfig = await getDeployConfig(config.deployConfig, {
@@ -33,7 +35,13 @@ export async function deploy(config: FuelsConfig) {
       contractPath,
     });
 
-    const contractId = await deployContract(wallet, binaryPath, abiPath, deployConfig);
+    const contractId = await deployContract(
+      wallet,
+      binaryPath,
+      abiPath,
+      storageSlotsPath,
+      deployConfig
+    );
 
     debug(`Contract deployed: ${projectName} - ${contractId}`);
 

--- a/packages/fuels/src/cli/config/forcUtils.ts
+++ b/packages/fuels/src/cli/config/forcUtils.ts
@@ -83,3 +83,8 @@ export function getABIPath(contractPath: string) {
 export function getABIPaths(paths: string[]) {
   return Promise.all(paths.map((path) => getABIPath(path)));
 }
+
+export const getStorageSlotsPath = (contractPath: string) => {
+  const projectName = getContractName(contractPath);
+  return join(contractPath, `/out/debug/${projectName}-storage_slots.json`);
+};


### PR DESCRIPTION
Closes #1472 

If we don't auto-load these storage slots, some contracts will revert because of improper/missing initialization of storage slots.