### PR TITLE
fix: make `startFuelCore` package manager agnostic

### DIFF
--- a/.changeset/many-carrots-draw.md
+++ b/.changeset/many-carrots-draw.md
@@ -1,0 +1,5 @@
+---
+"fuels": patch
+---
+
+fix: make `startFuelCore` package manager agnostic

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -76,6 +76,7 @@
     "handlebars": "^4.7.7",
     "joycon": "^3.1.1",
     "lodash.camelcase": "^4.3.0",
+    "npm-which": "^3.0.1",
     "portfinder": "^1.0.32",
     "rimraf": "^3.0.2",
     "toml": "^3.0.0",

--- a/packages/fuels/src/cli/commands/dev/startFuelCore.ts
+++ b/packages/fuels/src/cli/commands/dev/startFuelCore.ts
@@ -6,11 +6,13 @@ import { getPortPromise } from 'portfinder';
 import treeKill from 'tree-kill';
 
 import type { FuelsConfig } from '../../types';
-import { findPackageRoot } from '../../utils/findPackageRoot';
 import { getBinarySource } from '../../utils/getBinarySource';
 import { error, log, loggingConfig } from '../../utils/logger';
 
 import { defaultChainConfig, defaultConsensusKey } from './defaultChainConfig';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const npmWhich = require('npm-which')(__dirname);
 
 export type FuelCoreNode = {
   bindIp: string;
@@ -73,8 +75,8 @@ export const startFuelCore = async (config: FuelsConfig): Promise<FuelCoreNode> 
   ].flat();
 
   return new Promise((resolve, reject) => {
-    const pkgRootDir = findPackageRoot();
-    const builtInFuelsCorePath = join(pkgRootDir, 'node_modules', '.bin', 'fuels-core');
+    // This line finds the path to the built-in fuels-core binary
+    const builtInFuelsCorePath = npmWhich.sync('fuels-core');
 
     const command = config.useBuiltinFuelCore ? builtInFuelsCorePath : 'fuel-core';
     const core = spawn(command, flags, { stdio: 'pipe' });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -737,6 +737,9 @@ importers:
       lodash.camelcase:
         specifier: ^4.3.0
         version: 4.3.0
+      npm-which:
+        specifier: ^3.0.1
+        version: 3.0.1
       portfinder:
         specifier: ^1.0.32
         version: 1.0.32
@@ -13908,6 +13911,14 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /npm-path@2.0.4:
+    resolution: {integrity: sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+    dependencies:
+      which: 1.3.1
+    dev: false
+
   /npm-run-all@4.1.5:
     resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
     engines: {node: '>= 4'}
@@ -13936,6 +13947,16 @@ packages:
     dependencies:
       path-key: 4.0.0
     dev: true
+
+  /npm-which@3.0.1:
+    resolution: {integrity: sha512-CM8vMpeFQ7MAPin0U3wzDhSGV0hMHNwHU0wjo402IVizPDrs45jSfSuoC+wThevY88LQti8VvaAnqYAeVy3I1A==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      npm-path: 2.0.4
+      which: 1.3.1
+    dev: false
 
   /nth-check@1.0.2:
     resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}


### PR DESCRIPTION
This PR fixes a bug where the initial approach used by `startFuelCore` to locate the `fuels-core` binaries was only working for `pnpm`. This is now package manger agnostic with this PR.