### PR TITLE
fix: bin path for `fuels-forc` in fuels CLI, add support bun's structure

### DIFF
--- a/.changeset/mean-phones-tickle.md
+++ b/.changeset/mean-phones-tickle.md
@@ -1,0 +1,5 @@
+---
+"fuels": patch
+---
+
+fix: bin path for `fuels-forc`, add support bun's structure

--- a/packages/fuels/src/cli.ts
+++ b/packages/fuels/src/cli.ts
@@ -2,7 +2,6 @@ import { configureCliOptions as configureTypegenCliOptions } from '@fuel-ts/abi-
 import { versions } from '@fuel-ts/versions';
 import { runVersions } from '@fuel-ts/versions/cli';
 import { Command, Option } from 'commander';
-import { join } from 'path';
 
 import { build } from './cli/commands/build';
 import { deploy } from './cli/commands/deploy';
@@ -11,7 +10,7 @@ import { init } from './cli/commands/init';
 import { withConfig } from './cli/commands/withConfig';
 import { withProgram } from './cli/commands/withProgram';
 import { Commands } from './cli/types';
-import { findPackageRoot } from './cli/utils/findPackageRoot';
+import { findBinPath } from './cli/utils/findBinPath';
 import { configureLogging } from './cli/utils/logger';
 
 export const onPreAction = (command: Command) => {
@@ -100,14 +99,12 @@ export const configureCli = () => {
    * Binary wrappers
    */
 
-  const binDir = join(findPackageRoot(), 'node_modules', '.bin');
-
   program.command('core', 'Wrapper around Fuel Core binary', {
-    executableFile: join(binDir, 'fuels-core'),
+    executableFile: findBinPath('fuels-core'),
   });
 
   program.command('forc', 'Wrapper around Forc binary', {
-    executableFile: join(binDir, 'fuels-forc'),
+    executableFile: findBinPath('fuels-forc'),
   });
 
   return program;

--- a/packages/fuels/src/cli/commands/build/buildSwayPrograms.ts
+++ b/packages/fuels/src/cli/commands/build/buildSwayPrograms.ts
@@ -1,8 +1,7 @@
 import { spawn } from 'child_process';
-import { join } from 'path';
 
 import type { FuelsConfig } from '../../types';
-import { findPackageRoot } from '../../utils/findPackageRoot';
+import { findBinPath } from '../../utils/findBinPath';
 import { getBinarySource } from '../../utils/getBinarySource';
 import { debug, error, log, loggingConfig } from '../../utils/logger';
 
@@ -28,8 +27,7 @@ export const buildSwayProgram = async (config: FuelsConfig, path: string) => {
   debug('Building Sway program', path);
 
   return new Promise<void>((resolve, reject) => {
-    const pkgRootDir = findPackageRoot();
-    const builtInForcPath = join(pkgRootDir, 'node_modules', '.bin', 'fuels-forc');
+    const builtInForcPath = findBinPath('fuels-forc');
 
     const command = config.useBuiltinForc ? builtInForcPath : 'forc';
     const forc = spawn(command, ['build', '-p', path], { stdio: 'pipe' });

--- a/packages/fuels/src/cli/commands/dev/startFuelCore.ts
+++ b/packages/fuels/src/cli/commands/dev/startFuelCore.ts
@@ -6,13 +6,11 @@ import { getPortPromise } from 'portfinder';
 import treeKill from 'tree-kill';
 
 import type { FuelsConfig } from '../../types';
+import { findBinPath } from '../../utils/findBinPath';
 import { getBinarySource } from '../../utils/getBinarySource';
 import { error, log, loggingConfig } from '../../utils/logger';
 
 import { defaultChainConfig, defaultConsensusKey } from './defaultChainConfig';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const npmWhich = require('npm-which')(__dirname);
 
 export type FuelCoreNode = {
   bindIp: string;
@@ -75,8 +73,7 @@ export const startFuelCore = async (config: FuelsConfig): Promise<FuelCoreNode> 
   ].flat();
 
   return new Promise((resolve, reject) => {
-    // This line finds the path to the built-in fuels-core binary
-    const builtInFuelsCorePath = npmWhich.sync('fuels-core');
+    const builtInFuelsCorePath = findBinPath('fuels-core');
 
     const command = config.useBuiltinFuelCore ? builtInFuelsCorePath : 'fuel-core';
     const core = spawn(command, flags, { stdio: 'pipe' });

--- a/packages/fuels/src/cli/utils/findBinPath.ts
+++ b/packages/fuels/src/cli/utils/findBinPath.ts
@@ -1,0 +1,16 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const npmWhich = require('npm-which')(__dirname);
+
+export function findBinPath(binCommandName: string) {
+  let binPath = npmWhich.sync(binCommandName);
+
+  if (!existsSync(binPath)) {
+    // The user might be using bun, which has a different structure for binaries inside node_modules
+    binPath = join('node_modules', '.bin', binCommandName);
+  }
+
+  return binPath;
+}

--- a/packages/fuels/src/cli/utils/findPackageRoot.ts
+++ b/packages/fuels/src/cli/utils/findPackageRoot.ts
@@ -1,9 +1,0 @@
-import { existsSync } from 'fs';
-import { join } from 'path';
-
-export function findPackageRoot(currentDir: string = __dirname) {
-  if (existsSync(join(currentDir, 'package.json'))) {
-    return currentDir;
-  }
-  return findPackageRoot(join(currentDir, '..'));
-}


### PR DESCRIPTION
Similar to #1477, but also adds (possible) support for [bun](https://bun.sh]), which has a different way of structuring binaries inside of `node_modules`.