### PR TITLE
chore: Enforce node v20 for our repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "private": true,
   "engines": {
-    "node": "^18.18.2 || ^20.0.0",
+    "node": "^20.0.0",
     "pnpm": "^8.9.0"
   },
   "packageManager": "pnpm@8.9.0",

--- a/scripts/lint-package-jsons.ts
+++ b/scripts/lint-package-jsons.ts
@@ -12,13 +12,21 @@ interface PackageJson {
 
 const {
   author,
-  engines: { node },
+  engines: { node: repoNodeVersion },
 } = JSON.parse(readFileSync('package.json', 'utf-8')) as PackageJson;
 
 const expectedAuthor = 'Fuel Labs <contact@fuel.sh> (https://fuel.network/)';
 
+const node20 = '^20.0.0';
+const expectedNode = `^18.18.2 || ${node20}`;
+
 if (author !== expectedAuthor) {
   error(`The package.json's author field should be '${expectedAuthor}'`);
+  process.exit(1);
+}
+
+if (repoNodeVersion !== node20) {
+  error(`The package.json's engines.node field should be '${expectedNode}'`);
   process.exit(1);
 }
 
@@ -26,13 +34,13 @@ const faultyPackageJsons = globSync(`{packages,apps}/*/package.json`)
   .filter((path) => !/\/forc|fuel-core\//.test(path))
   .filter((path) => {
     const json = JSON.parse(readFileSync(path, 'utf-8')) as PackageJson;
-    return json.private ? false : json.author !== author || json.engines.node !== node;
+    return json.private ? false : json.author !== author || json.engines.node !== expectedNode;
   });
 
 if (faultyPackageJsons.length) {
   const expectedConfigs = {
     author,
-    engines: { node },
+    engines: { node: expectedNode },
   };
 
   error(


### PR DESCRIPTION
This is only enforcing it for us when developing in our repo. The packages are still supporting v18 and v20.