### PR TITLE
feat: remove `uuid` dependency in favor of `crypto.randomUUID()`

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -62,10 +62,6 @@
     "@fuel-ts/errors": "workspace:*",
     "ethers": "^6.7.1",
     "portfinder": "^1.0.32",
-    "tree-kill": "^1.2.2",
-    "uuid": "^9.0.0"
-  },
-  "devDependencies": {
-    "@types/uuid": "^9.0.1"
+    "tree-kill": "^1.2.2"
   }
 }

--- a/packages/wallet/src/keystore-wallet.ts
+++ b/packages/wallet/src/keystore-wallet.ts
@@ -11,7 +11,6 @@ import {
 import { ErrorCode, FuelError } from '@fuel-ts/errors';
 import type { AbstractAddress } from '@fuel-ts/interfaces';
 import { hexlify } from 'ethers';
-import { v4 as uuidv4 } from 'uuid';
 
 export type KeystoreWallet = {
   id: string;
@@ -90,7 +89,7 @@ export async function encryptKeystoreWallet(
 
   // Construct keystore.
   const keystore: KeystoreWallet = {
-    id: uuidv4(),
+    id: crypto.randomUUID(),
     version: 3,
     address: removeHexPrefix(ownerAddress.toHexString()),
     crypto: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1227,13 +1227,6 @@ importers:
       tree-kill:
         specifier: ^1.2.2
         version: 1.2.2
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
-    devDependencies:
-      '@types/uuid':
-        specifier: ^9.0.1
-        version: 9.0.1
 
   packages/wallet-manager:
     dependencies:
@@ -9172,10 +9165,6 @@ packages:
 
   /@types/unist@2.0.6:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
-    dev: true
-
-  /@types/uuid@9.0.1:
-    resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
     dev: true
 
   /@types/web-bluetooth@0.0.16:
@@ -22288,11 +22277,6 @@ packages:
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
-
-  /uuid@9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
-    hasBin: true
-    dev: false
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}


### PR DESCRIPTION
This is a quick win that follows what the [`uuid` library](https://www.npmjs.com/package/uuid) suggests:

> Note Only interested in creating a version 4 UUID? You might be able to use [crypto.randomUUID()](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID), eliminating the need to install this library.