### PR TITLE
fix: contract created operation with input message

### DIFF
--- a/.changeset/spotty-berries-cry.md
+++ b/.changeset/spotty-berries-cry.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/providers": patch
+---
+
+Fix operations contract created with input of type message

--- a/packages/providers/src/transaction-summary/input.ts
+++ b/packages/providers/src/transaction-summary/input.ts
@@ -3,6 +3,11 @@ import type { Input, InputCoin, InputContract, InputMessage } from '@fuel-ts/tra
 import { InputType } from '@fuel-ts/transactions';
 
 /** @hidden */
+export function getInputsByTypes<T = Input>(inputs: Input[], types: Array<InputType>) {
+  return inputs.filter((i) => types.includes(i.type)) as T[];
+}
+
+/** @hidden */
 export function getInputsByType<T = Input>(inputs: Input[], type: InputType) {
   return inputs.filter((i) => i.type === type) as T[];
 }
@@ -15,6 +20,11 @@ export function getInputsCoin(inputs: Input[]) {
 /** @hidden */
 export function getInputsMessage(inputs: Input[]) {
   return getInputsByType<InputMessage>(inputs, InputType.Message);
+}
+
+/** @hidden */
+export function getInputsCoinAndMessage(inputs: Input[]) {
+  return getInputsByTypes<InputCoin | InputMessage>(inputs, [InputType.Coin, InputType.Message]);
 }
 
 /** @hidden */

--- a/packages/providers/src/transaction-summary/operations.test.ts
+++ b/packages/providers/src/transaction-summary/operations.test.ts
@@ -692,7 +692,7 @@ describe('operations', () => {
     it('should getOperations return contract created operations with input type message', () => {
       const expected: Operation = {
         from: {
-          address: '0x3e7ddda4d0d3f8307ae5f1aed87623992c1c4decefec684936960775181b2302',
+          address: '0x06300e686a5511c7ba0399fc68dcbe0ca2d8f54f7e6afea73c505dd3bcacf33b',
           type: 1,
         },
         name: OperationName.contractCreated,

--- a/packages/providers/src/transaction-summary/operations.test.ts
+++ b/packages/providers/src/transaction-summary/operations.test.ts
@@ -688,6 +688,30 @@ describe('operations', () => {
       expect(operations.length).toEqual(1);
       expect(operations[0]).toStrictEqual(expected);
     });
+
+    it('should getOperations return contract created operations with input type message', () => {
+      const expected: Operation = {
+        from: {
+          address: '0x3e7ddda4d0d3f8307ae5f1aed87623992c1c4decefec684936960775181b2302',
+          type: 1,
+        },
+        name: OperationName.contractCreated,
+        to: {
+          address: '0xef066899413ef8dc7c3073a50868bafb3d039d9bad8006c2635b7f0efa992553',
+          type: 0,
+        },
+      };
+      const operations = getOperations({
+        transactionType: TransactionType.Create,
+        inputs: [MOCK_INPUT_MESSAGE],
+        outputs: [MOCK_OUTPUT_CONTRACT_CREATED, MOCK_OUTPUT_CHANGE],
+        receipts: [],
+        maxInputs: bn(255),
+      });
+
+      expect(operations.length).toEqual(1);
+      expect(operations[0]).toStrictEqual(expected);
+    });
   });
 
   describe('addOperation', () => {

--- a/packages/providers/src/transaction-summary/operations.ts
+++ b/packages/providers/src/transaction-summary/operations.ts
@@ -16,8 +16,8 @@ import {
   getInputFromAssetId,
   getInputAccountAddress,
   getInputContractFromIndex,
-  getInputsCoin,
   getInputsContract,
+  getInputsCoinAndMessage,
 } from './input';
 import {
   getOutputsChange,
@@ -427,7 +427,7 @@ export function getPayProducerOperations(outputs: Output[]): Operation[] {
 /** @hidden */
 export function getContractCreatedOperations({ inputs, outputs }: InputOutputParam): Operation[] {
   const contractCreatedOutputs = getOutputsContractCreated(outputs);
-  const input = getInputsCoin(inputs)[0];
+  const input = getInputsCoinAndMessage(inputs)[0];
   const fromAddress = getInputAccountAddress(input);
   const contractCreatedOperations = contractCreatedOutputs.reduce((prev, contractCreatedOutput) => {
     const operations = addOperation(prev, {


### PR DESCRIPTION
The current implementation of `getContractCreatedOperations` only checks by inputs of type `Coin` with the new implementation if accounts for coin and message.

This issue is affecting also beta-4 versions, would be good to have a patch for the older versions also. But maybe as we don't have this support for now we are going to get it only on beta-5. cc: @arboleya 

closes: #1634 