### PR TITLE
fix: bin installation from git

### DIFF
--- a/.changeset/beige-actors-march.md
+++ b/.changeset/beige-actors-march.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/forc": patch
+"@fuel-ts/fuel-core": patch
+---
+
+Fixing installation from git branches

--- a/packages/forc/lib/bin.js
+++ b/packages/forc/lib/bin.js
@@ -3,7 +3,7 @@
 import { spawn } from 'child_process';
 
 // eslint-disable-next-line import/extensions
-import binPath from './index.js';
+import { binPath } from './shared.js';
 
 const args = process.argv.slice(2);
 spawn(binPath, args, { stdio: 'inherit' }).on('exit', process.exit);

--- a/packages/forc/lib/index.js
+++ b/packages/forc/lib/index.js
@@ -1,8 +1,0 @@
-import { join } from 'path';
-
-// eslint-disable-next-line import/extensions
-import { __dirname } from './shared.js';
-
-const binPath = join(__dirname, '../forc-binaries/forc');
-
-export default binPath;

--- a/packages/forc/lib/install.js
+++ b/packages/forc/lib/install.js
@@ -4,7 +4,6 @@ import { execSync } from 'child_process';
 import { existsSync, rmSync, writeFileSync } from 'fs';
 import fetch from 'node-fetch';
 import { join } from 'path';
-import tar from 'tar';
 
 import {
   __dirname,
@@ -53,10 +52,7 @@ import {
     writeFileSync(pkgPath, buf);
 
     // Extract
-    await tar.x({
-      file: pkgPath,
-      C: binDir,
-    });
+    execSync(`tar xzf "${pkgPath}" -C "${binDir}"`);
 
     // Cleanup
     rmSync(pkgPath);

--- a/packages/forc/lib/install.js
+++ b/packages/forc/lib/install.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from 'child_process';
+import { error } from 'console';
 import { existsSync, rmSync, writeFileSync } from 'fs';
 import fetch from 'node-fetch';
 import { join } from 'path';
@@ -57,4 +58,4 @@ import {
     // Cleanup
     rmSync(pkgPath);
   }
-})().catch((e) => console.error(e));
+})().catch((e) => error(e));

--- a/packages/forc/lib/shared.js
+++ b/packages/forc/lib/shared.js
@@ -6,6 +6,8 @@ import { fileURLToPath } from 'url';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const __dirname = dirname(fileURLToPath(import.meta.url));
 
+export const binPath = join(__dirname, '../forc-binaries/forc');
+
 const platforms = {
   darwin: {
     arm64: 'darwin_arm64',
@@ -16,10 +18,6 @@ const platforms = {
     x64: 'linux_amd64',
   },
 };
-
-const binPath = join(__dirname, '../forc-binaries/forc');
-
-export default binPath;
 
 export const getPkgPlatform = () => {
   if (process.platform !== 'darwin' && process.platform !== 'linux') {

--- a/packages/forc/lib/shared.js
+++ b/packages/forc/lib/shared.js
@@ -1,7 +1,6 @@
 import { execSync } from 'child_process';
-import { cpSync } from 'fs';
-import fs from 'fs/promises';
-import path, { join, dirname } from 'path';
+import { cpSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -36,16 +35,16 @@ export const getPkgPlatform = () => {
   return platforms[process.platform][process.arch];
 };
 
-const versionFilePath = path.join(__dirname, '../VERSION');
+const versionFilePath = join(__dirname, '../VERSION');
 
-export const getCurrentVersion = async () => {
-  const versionContents = await fs.readFile(versionFilePath, 'utf8');
+export const getCurrentVersion = () => {
+  const versionContents = readFileSync(versionFilePath, 'utf8');
   const forcVersion = versionContents.match(/^.+$/m)?.[0] || versionContents;
   return forcVersion;
 };
 
-export const setCurrentVersion = async (version) => {
-  await fs.writeFile(versionFilePath, version);
+export const setCurrentVersion = (version) => {
+  writeFileSync(versionFilePath, version);
 };
 
 export const isGitBranch = (versionFileContents) => versionFileContents.indexOf('git:') !== -1;
@@ -53,11 +52,11 @@ export const isGitBranch = (versionFileContents) => versionFileContents.indexOf(
 const swayRepoUrl = 'https://github.com/fuellabs/sway.git';
 
 export const buildFromGitBranch = (branchName) => {
-  fs.rmSync('sway-repo', { recursive: true, force: true });
-  fs.rmSync('forc-binaries', { recursive: true, force: true });
+  rmSync('sway-repo', { recursive: true, force: true });
+  rmSync('forc-binaries', { recursive: true, force: true });
   execSync(`git clone --branch ${branchName} ${swayRepoUrl} sway-repo`);
   execSync(`cd sway-repo && cargo build`);
-  fs.mkdirSync('forc-binaries');
+  mkdirSync('forc-binaries');
   cpSync('sway-repo/target/debug/forc', 'forc-binaries');
   cpSync('sway-repo/target/debug/forc-deploy', 'forc-binaries');
   cpSync('sway-repo/target/debug/forc-doc', 'forc-binaries');
@@ -66,5 +65,5 @@ export const buildFromGitBranch = (branchName) => {
   cpSync('sway-repo/target/debug/forc-run', 'forc-binaries');
   cpSync('sway-repo/target/debug/forc-submit', 'forc-binaries');
   cpSync('sway-repo/target/debug/forc-tx', 'forc-binaries');
-  fs.rmSync('sway-repo', { recursive: true, force: true });
+  rmSync('sway-repo', { recursive: true, force: true });
 };

--- a/packages/forc/package.json
+++ b/packages/forc/package.json
@@ -17,10 +17,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "node-fetch": "^2.6.7",
-    "tar": "^6.2.0"
-  },
-  "devDependencies": {
-    "@types/tar": "^6.1.8"
+    "node-fetch": "^2.6.7"
   }
 }

--- a/packages/fuel-core/lib/bin.js
+++ b/packages/fuel-core/lib/bin.js
@@ -3,7 +3,7 @@
 import { spawn } from 'child_process';
 
 // eslint-disable-next-line import/extensions
-import binPath from './index.js';
+import { binPath } from './shared.js';
 
 const args = process.argv.slice(2);
 spawn(binPath, args, { stdio: 'inherit' }).on('exit', process.exit);

--- a/packages/fuel-core/lib/index.js
+++ b/packages/fuel-core/lib/index.js
@@ -1,8 +1,0 @@
-import { join } from 'path';
-
-// eslint-disable-next-line import/extensions
-import { __dirname } from './shared.js';
-
-const binPath = join(__dirname, '../fuel-core-binaries/fuel-core');
-
-export default binPath;

--- a/packages/fuel-core/lib/install.js
+++ b/packages/fuel-core/lib/install.js
@@ -4,7 +4,6 @@ import { execSync } from 'child_process';
 import { existsSync, rmSync, writeFileSync, mkdirSync, renameSync } from 'fs';
 import fetch from 'node-fetch';
 import { join } from 'path';
-import tar from 'tar';
 
 import {
   __dirname,
@@ -66,10 +65,7 @@ import {
     writeFileSync(pkgPath, buf);
 
     // Extract
-    await tar.x({
-      file: pkgPath,
-      C: rootDir,
-    });
+    execSync(`tar xzf "${pkgPath}" -C "${rootDir}"`);
 
     // Take the contents of the directory containing the extracted binaries and move them to the `fuel-core-binaries` directory
     renameSync(`${fileName}`, binDir);

--- a/packages/fuel-core/lib/install.js
+++ b/packages/fuel-core/lib/install.js
@@ -67,7 +67,8 @@ import {
     // Extract
     execSync(`tar xzf "${pkgPath}" -C "${rootDir}"`);
 
-    // Take the contents of the directory containing the extracted binaries and move them to the `fuel-core-binaries` directory
+    // Take the contents of the directory containing the extracted
+    // binaries and move them to the `fuel-core-binaries` directory
     renameSync(`${fileName}`, binDir);
 
     // Cleanup

--- a/packages/fuel-core/lib/install.js
+++ b/packages/fuel-core/lib/install.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from 'child_process';
+import { error } from 'console';
 import { existsSync, rmSync, writeFileSync, mkdirSync, renameSync } from 'fs';
 import fetch from 'node-fetch';
 import { join } from 'path';
@@ -78,4 +79,4 @@ import {
     });
     rmSync(pkgPath);
   }
-})().catch((e) => console.error(e));
+})().catch((e) => error(e));

--- a/packages/fuel-core/lib/shared.js
+++ b/packages/fuel-core/lib/shared.js
@@ -1,6 +1,5 @@
 import { execSync } from 'child_process';
-import { cpSync, rmSync } from 'fs';
-import fs from 'fs/promises';
+import { cpSync, mkdirSync, rmSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -34,13 +33,13 @@ export const getPkgPlatform = () => {
 
 const versionFilePath = join(__dirname, '../VERSION');
 
-export const getCurrentVersion = async () => {
-  const fuelCoreVersion = await fs.readFile(versionFilePath, 'utf8');
+export const getCurrentVersion = () => {
+  const fuelCoreVersion = readFileSync(versionFilePath, 'utf8');
   return fuelCoreVersion.trim();
 };
 
-export const setCurrentVersion = async (version) => {
-  await fs.writeFile(versionFilePath, version);
+export const setCurrentVersion = (version) => {
+  writeFileSync(versionFilePath, version);
 };
 
 export const isGitBranch = (versionFileContents) => versionFileContents.indexOf('git:') !== -1;
@@ -52,7 +51,7 @@ export const buildFromGitBranch = (branchName) => {
   rmSync('fuel-core-binaries', { recursive: true, force: true });
   execSync(`git clone --branch ${branchName} ${fuelCoreRepoUrl} fuel-core-repo`, { silent: true });
   execSync(`cd fuel-core-repo && cargo build`, { silent: true });
-  fs.mkdirSync('fuel-core-binaries');
+  mkdirSync('fuel-core-binaries');
   cpSync('fuel-core-repo/target/debug/fuel-core', 'fuel-core-binaries/fuel-core');
   rmSync('fuel-core-repo', { recursive: true, force: true });
 };

--- a/packages/fuel-core/lib/shared.js
+++ b/packages/fuel-core/lib/shared.js
@@ -6,6 +6,8 @@ import { fileURLToPath } from 'url';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const __dirname = dirname(fileURLToPath(import.meta.url));
 
+export const binPath = join(__dirname, '../fuel-core-binaries/fuel-core');
+
 const platforms = {
   darwin: {
     arm64: 'aarch64-apple-darwin',

--- a/packages/fuel-core/package.json
+++ b/packages/fuel-core/package.json
@@ -17,10 +17,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "node-fetch": "^2.7.0",
-    "tar": "^6.2.0"
-  },
-  "devDependencies": {
-    "@types/tar": "^6.1.8"
+    "node-fetch": "^2.7.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,26 +631,12 @@ importers:
       node-fetch:
         specifier: ^2.6.7
         version: 2.6.7
-      tar:
-        specifier: ^6.2.0
-        version: 6.2.0
-    devDependencies:
-      '@types/tar':
-        specifier: ^6.1.8
-        version: 6.1.10
 
   packages/fuel-core:
     dependencies:
       node-fetch:
         specifier: ^2.7.0
         version: 2.7.0
-      tar:
-        specifier: ^6.2.0
-        version: 6.2.0
-    devDependencies:
-      '@types/tar':
-        specifier: ^6.1.8
-        version: 6.1.10
 
   packages/fuel-gauge:
     dependencies:
@@ -8760,13 +8746,6 @@ packages:
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
 
-  /@types/tar@6.1.10:
-    resolution: {integrity: sha512-60ZO+W0tRKJ3ggdzJKp75xKVlNogKYMqGvr2bMH/+k3T0BagfYTnbmVDFMJB1BFttz6yRgP5MDGP27eh7brrqw==}
-    dependencies:
-      '@types/node': 20.10.5
-      minipass: 4.2.8
-    dev: true
-
   /@types/testing-library__jest-dom@5.14.6:
     resolution: {integrity: sha512-FkHXCb+ikSoUP4Y4rOslzTdX5sqYwMxfefKh1GmZ8ce1GOkEHntSp6b5cGadmNfp5e4BMEWOMx+WSKd5/MqlDA==}
     dependencies:
@@ -10747,11 +10726,6 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  /chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-    dev: false
 
   /chroma-js@2.4.2:
     resolution: {integrity: sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==}
@@ -13693,13 +13667,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: false
-
-  /fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
     dev: false
 
   /fs-monkey@1.0.4:
@@ -16871,34 +16838,9 @@ packages:
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  /minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-    dependencies:
-      yallist: 4.0.0
-    dev: false
-
-  /minipass@4.2.8:
-    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
-    engines: {node: '>=8'}
-    dev: true
-
-  /minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-    dev: false
-
   /minipass@6.0.2:
     resolution: {integrity: sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  /minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-    dev: false
 
   /mixme@0.5.9:
     resolution: {integrity: sha512-VC5fg6ySUscaWUpI4gxCBTQMH2RdUpNrk+MsbpCYtIvf9SBJdiUey4qE7BXviJsJR4nDQxCZ+3yaYNW3guz/Pw==}
@@ -20557,18 +20499,6 @@ packages:
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
-
-  /tar@6.2.0:
-    resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-    dev: false
 
   /temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}


### PR DESCRIPTION
# 1) Boken Commands

A couple of commands were broken, like:

```ts
import fs from 'fs/promises';

fs.rmSync(...);
```

But there's no `<cmd>Sync()` methods in `fs/promises`.

I also used the opportunity to standardize a couple of things.

# 2) Problematic `tar` package

I had problems with the TAR package, saying the `tar` files were invalid.

Since we won't support Windows soon, I removed them and rolled back the original commands.