### PR TITLE
remove data heavy unused parts of the receipts in gql queries

### DIFF
--- a/packages/providers/src/operations.graphql
+++ b/packages/providers/src/operations.graphql
@@ -44,15 +44,11 @@ fragment transactionFragment on Transaction {
 fragment receiptFragment on Receipt {
   contract {
     id
-    bytecode
-    salt
   }
   pc
   is
   to {
     id
-    bytecode
-    salt
   }
   toAddress
   amount


### PR DESCRIPTION
related: #1706 

remove fetching of contract bytecode when returning receipts