### PR TITLE
chore: update deprecated extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "ZixuanChen.vitest-explorer",
+    "vitest.explorer",
     "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint"
   ]


### PR DESCRIPTION
The extension `ZixuanChen.vitest-explorer` has been [deprecated](https://marketplace.visualstudio.com/items?itemName=ZixuanChen.vitest-explorer) in favor of [`vitest.explorer`](https://marketplace.visualstudio.com/items?itemName=vitest.explorer) and it's popping up in vscode.