### PR TITLE
fix: missing class name fix for items utility class

### DIFF
--- a/.changeset/little-timers-melt.md
+++ b/.changeset/little-timers-melt.md
@@ -1,0 +1,5 @@
+---
+"create-fuels": patch
+---
+
+fix tailwind syntax error in create-fuels template

--- a/templates/nextjs/src/pages/index.tsx
+++ b/templates/nextjs/src/pages/index.tsx
@@ -48,7 +48,7 @@ export default function Home() {
 
   return (
     <div className={`min-h-screen items-center p-24 flex flex-col gap-6`}>
-      <div className="flex gap-4 items-">
+      <div className="flex gap-4 items-center">
         <FuelLogo />
         <h1 className="text-2xl font-semibold ali">Welcome to Fuel</h1>
       </div>


### PR DESCRIPTION
Added 'center' class name to 'items-' utility class.

the syntax error: https://github.com/FuelLabs/fuels-ts/blob/master/templates/nextjs/src/pages/index.tsx?plain=1#L51