### PR TITLE
fix: Remove UTXO flag 

### DIFF
--- a/scripts/run-node.sh
+++ b/scripts/run-node.sh
@@ -14,5 +14,4 @@ pnpm fuels-core run \
     --poa-instant true \
     --min-gas-price 1 \
     --vm-backtrace \
-    --utxo-validation \
     --debug


### PR DESCRIPTION
fuel-core binary's `--debug` flag conflicts with `--utxo-validation`