### PR TITLE
fix: `create-fuels` crashes when run

### DIFF
--- a/.changeset/old-garlics-warn.md
+++ b/.changeset/old-garlics-warn.md
@@ -1,0 +1,5 @@
+---
+"create-fuels": patch
+---
+
+fix `create-fuels` crashing when being run

--- a/packages/create-fuels/src/bin.ts
+++ b/packages/create-fuels/src/bin.ts
@@ -2,9 +2,12 @@
 import chalk from 'chalk';
 import { log } from 'console';
 
-import { runScaffoldCli } from './cli';
+import { runScaffoldCli, setupProgram } from './cli';
 
-runScaffoldCli()
+runScaffoldCli({
+  program: setupProgram(),
+  args: process.argv,
+})
   .then(() => process.exit(0))
   .catch((e) => {
     log(chalk.red(e));


### PR DESCRIPTION
Quick fix