### PR TITLE
fix: re-enable auto-install of dependencies when `create-fuels` is run

### DIFF
--- a/.changeset/brown-dingos-grow.md
+++ b/.changeset/brown-dingos-grow.md
@@ -1,0 +1,5 @@
+---
+"create-fuels": patch
+---
+
+enable auto-install of dependencies in create-fuels

--- a/packages/create-fuels/src/bin.ts
+++ b/packages/create-fuels/src/bin.ts
@@ -7,6 +7,7 @@ import { runScaffoldCli, setupProgram } from './cli';
 runScaffoldCli({
   program: setupProgram(),
   args: process.argv,
+  shouldInstallDeps: true,
 })
   .then(() => process.exit(0))
   .catch((e) => {


### PR DESCRIPTION
This was disabled unintentionally when the internal API was changed recently.