### PR TITLE
chore!: exporting `Asset` types

### DIFF
--- a/.changeset/itchy-bulldogs-pay.md
+++ b/.changeset/itchy-bulldogs-pay.md
@@ -1,0 +1,7 @@
+---
+"@fuel-ts/account": minor
+---
+
+- Rename Asset type `Fuel` to `NetworkFuel`
+- Rename Asset type `Ethereum` to `NetworkEthereum`
+- Exporting Asset types

--- a/packages/account/src/providers/assets/index.ts
+++ b/packages/account/src/providers/assets/index.ts
@@ -35,3 +35,4 @@ export const assets: Assets = [
 ];
 
 export * from './utils';
+export * from './types';

--- a/packages/account/src/providers/assets/types.ts
+++ b/packages/account/src/providers/assets/types.ts
@@ -1,4 +1,4 @@
-export type Ethereum = {
+export type NetworkEthereum = {
   /** type of network */
   type: 'ethereum';
   /** chain id of the network */
@@ -9,7 +9,7 @@ export type Ethereum = {
   address?: string;
 };
 
-export type Fuel = {
+export type NetworkFuel = {
   /** type of network */
   type: 'fuel';
   /** chain id of the network */
@@ -30,10 +30,10 @@ export type Asset = {
   /** icon of the asset */
   icon: string;
   /** asset id on Fuel Network */
-  networks: Array<Ethereum | Fuel>;
+  networks: Array<NetworkEthereum | NetworkFuel>;
 };
 
 export type Assets = Array<Asset>;
 
-export type AssetEth = Omit<Asset, 'networks'> & Ethereum;
-export type AssetFuel = Omit<Asset, 'networks'> & Fuel;
+export type AssetEth = Omit<Asset, 'networks'> & NetworkEthereum;
+export type AssetFuel = Omit<Asset, 'networks'> & NetworkFuel;

--- a/packages/account/src/providers/assets/utils/network.ts
+++ b/packages/account/src/providers/assets/utils/network.ts
@@ -1,9 +1,9 @@
 import { CHAIN_IDS } from '../../chains';
-import type { Asset, AssetEth, AssetFuel, Ethereum, Fuel } from '../types';
+import type { Asset, AssetEth, AssetFuel, NetworkEthereum, NetworkFuel } from '../types';
 
-type Network = Ethereum | Fuel;
-export type NetworkTypes = Ethereum['type'] | Fuel['type'];
-type NetworkTypeToNetwork<T> = T extends 'ethereum' ? Ethereum : T extends 'fuel' ? Fuel : Network;
+type Network = NetworkEthereum | NetworkFuel;
+export type NetworkTypes = NetworkEthereum['type'] | NetworkFuel['type'];
+type NetworkTypeToNetwork<T> = T extends 'ethereum' ? NetworkEthereum : T extends 'fuel' ? NetworkFuel : Network;
 
 /**
  * Returns the default chainId for the given network


### PR DESCRIPTION
On this PR I've:
- Rename Asset type `Fuel` to `NetworkFuel`
- Rename Asset type `Ethereum` to `NetworkEthereum`
- Exporting Asset types