### PR TITLE
fix: broken coverage report and changeset PR title

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,8 +51,7 @@ jobs:
 
       - name: Set branch name and changeset PR title
         run: |
-          echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_ENV
-          echo "CHANGESET_PR_TITLE=$(echo "ci(changesets): versioning packages for branch \`$BRANCH_NAME\`")" >> $GITHUB_ENV
+          echo "CHANGESET_PR_TITLE=$(echo "ci(changesets): versioning packages for branch \`${{ github.ref_name }}\`")" >> $GITHUB_ENV
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
@@ -78,7 +77,7 @@ jobs:
           PUBLISHED: ${{ steps.changesets.outputs.published }}
 
       - name: Release to @next tag on npm
-        if: env.BRANCH_NAME == 'master' && steps.changesets.outputs.published != 'true'
+        if: github.ref_name == 'master' && steps.changesets.outputs.published != 'true'
         run: |
           git checkout master
           pnpm changeset:next
@@ -94,7 +93,7 @@ jobs:
         run: echo LAST_COMMIT_MSG=$(git --no-pager log -1 --pretty=%B) >> $GITHUB_ENV
 
       - name: Decides if Docs should be deployed
-        if: env.BRANCH_NAME == 'master' && startsWith(env.LAST_COMMIT_MSG, 'ci(changesets):')
+        if: github.ref_name == 'master' && startsWith(env.LAST_COMMIT_MSG, 'ci(changesets):')
         run: echo SHOULD_DEPLOY_DOCS=true >> $GITHUB_ENV
 
       - name: Configure GitHub Pages

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -120,25 +120,25 @@ jobs:
           name: coverage-master
           path: coverage/report
 
-      - name: Download Master Coverage Artifact
-        uses: dawidd6/action-download-artifact@v2
-        if: ${{ steps.findPr.outputs.number }}
-        with:
-          workflow: test.yaml
-          branch: master
-          name: coverage-master
-          path: coverage-master
-
-      - name: Generate Coverage Diff
-        if: ${{ (steps.findPr.outputs.number) }}
-        run: pnpm test:coverage-diff
-
-      - name: Report Coverage
-        uses: thollander/actions-comment-pull-request@v2
-        if: ${{ steps.findPr.outputs.number }}
-        with:
-          filePath: coverage/report/coverage-diff.txt
-          pr_number: ${{ (steps.findPr.outputs.number) }}
-          comment_tag: diff
-          mode: recreate
-          create_if_not_exists: true
+#      - name: Download Master Coverage Artifact
+#        uses: dawidd6/action-download-artifact@v2
+#        if: ${{ steps.findPr.outputs.number }}
+#        with:
+#          workflow: test.yaml
+#          branch: master
+#          name: coverage-master
+#          path: coverage-master
+#
+#      - name: Generate Coverage Diff
+#        if: ${{ (steps.findPr.outputs.number) }}
+#        run: pnpm test:coverage-diff
+#
+#      - name: Report Coverage
+#        uses: thollander/actions-comment-pull-request@v2
+#        if: ${{ steps.findPr.outputs.number }}
+#        with:
+#          filePath: coverage/report/coverage-diff.txt
+#          pr_number: ${{ (steps.findPr.outputs.number) }}
+#          comment_tag: diff
+#          mode: recreate
+#          create_if_not_exists: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,7 +87,7 @@ jobs:
           TEST_WALLET_PVT_KEY: ${{ secrets.TEST_WALLET_PVT_KEY }}
 
   test:
-    if: github.base_ref == 'master'
+    if: github.base_ref == 'master' || github.ref_name == 'master'
     runs-on: ubuntu-latest
     needs: [environments, e2e]
     steps:


### PR DESCRIPTION
Fixes:
- Broken coverage report (e.g. [this](https://github.com/FuelLabs/fuels-ts/actions/runs/8362381017/job/22893369897?pr=1883#step:9:34))
- Title of changeset PR from "ci(changesets): versioning packages for branch ``" to :ci(changesets): versioning packages for branch `master`"

Note: I commented out the coverage part in https://github.com/FuelLabs/fuels-ts/pull/1908/commits/9ab6863573fa1fe899ecd751f91a71092f50e9eb to get `master` to upload its `coverage-artifact` and I'll do a subsequent PR to uncomment it.