### PR TITLE
fix: changelogs not showing up on changesets PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Prettify changelog
         run: |
+          git checkout master
           pnpm changeset:update-changelog
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -120,25 +120,25 @@ jobs:
           name: coverage-master
           path: coverage/report
 
-#      - name: Download Master Coverage Artifact
-#        uses: dawidd6/action-download-artifact@v2
-#        if: ${{ steps.findPr.outputs.number }}
-#        with:
-#          workflow: test.yaml
-#          branch: master
-#          name: coverage-master
-#          path: coverage-master
-#
-#      - name: Generate Coverage Diff
-#        if: ${{ (steps.findPr.outputs.number) }}
-#        run: pnpm test:coverage-diff
-#
-#      - name: Report Coverage
-#        uses: thollander/actions-comment-pull-request@v2
-#        if: ${{ steps.findPr.outputs.number }}
-#        with:
-#          filePath: coverage/report/coverage-diff.txt
-#          pr_number: ${{ (steps.findPr.outputs.number) }}
-#          comment_tag: diff
-#          mode: recreate
-#          create_if_not_exists: true
+      - name: Download Master Coverage Artifact
+        uses: dawidd6/action-download-artifact@v2
+        if: ${{ steps.findPr.outputs.number }}
+        with:
+          workflow: test.yaml
+          branch: master
+          name: coverage-master
+          path: coverage-master
+
+      - name: Generate Coverage Diff
+        if: ${{ (steps.findPr.outputs.number) }}
+        run: pnpm test:coverage-diff
+
+      - name: Report Coverage
+        uses: thollander/actions-comment-pull-request@v2
+        if: ${{ steps.findPr.outputs.number }}
+        with:
+          filePath: coverage/report/coverage-diff.txt
+          pr_number: ${{ (steps.findPr.outputs.number) }}
+          comment_tag: diff
+          mode: recreate
+          create_if_not_exists: true

--- a/scripts/changeset/update-changelog.mts
+++ b/scripts/changeset/update-changelog.mts
@@ -1,27 +1,29 @@
-import * as core from '@actions/core';
-import * as github from '@actions/github';
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import { getInfo } from "@changesets/get-github-info";
+import { execSync } from "child_process";
 
-// @ts-expect-error cant import ts in mts
-import {getFullChangelog} from './get-full-changelog.mts';
+import { getFullChangelog } from "./get-full-changelog.mts";
 
 await (async () => {
-  const { PUBLISHED, GITHUB_REPOSITORY, GITHUB_TOKEN, RELEASE_TAG } = process.env;
-  
+  const { PUBLISHED, GITHUB_REPOSITORY, GITHUB_TOKEN, RELEASE_TAG } =
+    process.env;
+
   if (!GITHUB_TOKEN) {
-    core.setFailed('Please add GITHUB_TOKEN to the environment');
+    core.setFailed("Please add GITHUB_TOKEN to the environment");
     return;
   }
 
-  if (['true', 'false'].indexOf(PUBLISHED ?? '') === -1) {
-    core.setFailed('Please add PUBLISHED to the environment. Valid values are: true, false');
+  if (["true", "false"].indexOf(PUBLISHED ?? "") === -1) {
+    core.setFailed(
+      "Please add PUBLISHED to the environment. Valid values are: true, false",
+    );
     return;
   }
 
   const octokit = github.getOctokit(GITHUB_TOKEN);
 
-  const changelog = await getFullChangelog(octokit);
-  
-  if (PUBLISHED === 'false') {
+  if (PUBLISHED === "false") {
     // update changesets PR body
     const searchQuery = `repo:${GITHUB_REPOSITORY}+state:open+head:changeset-release/master+base:master`;
     const searchResult = await octokit.rest.search.issuesAndPullRequests({
@@ -29,6 +31,8 @@ await (async () => {
     });
 
     const pr = searchResult.data.items[0];
+
+    const changelog = await getFullChangelog(octokit);
 
     await octokit.rest.pulls.update({
       ...github.context.repo,
@@ -38,10 +42,10 @@ await (async () => {
     return;
   }
 
-  if (PUBLISHED === 'true') {
+  if (PUBLISHED === "true") {
     // update release's body
     if (!RELEASE_TAG) {
-      core.setFailed('Please add RELEASE_TAG to the environment');
+      core.setFailed("Please add RELEASE_TAG to the environment");
       return;
     }
 
@@ -50,10 +54,24 @@ await (async () => {
       tag: RELEASE_TAG,
     });
 
+    const commit = execSync(`git rev-list --no-walk ${RELEASE_TAG}`)
+      .toString()
+      .trim();
+
+    const { pull } = await getInfo({
+      repo: GITHUB_REPOSITORY as string,
+      commit,
+    });
+
+    const pr = await octokit.rest.pulls.get({
+      ...github.context.repo,
+      pull_number: pull as number,
+    });
+
     await octokit.rest.repos.updateRelease({
       ...github.context.repo,
       release_id: release.data.id,
-      body: changelog,
+      body: pr.data.body as string,
     });
   }
 })();


### PR DESCRIPTION
The script ran on the `changesets-release/master` branch which _doesn't have_ any changesets on it because it deletes them. It should run on `master`, hence `git checkout master`.

I also fixed the logic for updating the release's body. It now finds its corresponding changeset PR and just copies its body.