### PR TITLE
chore: fix `backstick` error on breaking change workflow

### DIFF
--- a/.changeset/ten-games-lay.md
+++ b/.changeset/ten-games-lay.md
@@ -1,4 +1,0 @@
----
----
-
-chore: fix backstick error on breaking change workflow

--- a/.changeset/ten-games-lay.md
+++ b/.changeset/ten-games-lay.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: fix backstick error on breaking change workflow

--- a/.github/workflows/breaking-change-pr-release.yaml
+++ b/.github/workflows/breaking-change-pr-release.yaml
@@ -29,10 +29,8 @@ jobs:
           PR_TITLE=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
           echo "$PR_TITLE"
           if echo "$PR_TITLE" | grep -qE '^\w+!:'; then
-            echo "Is a breaking change"
             echo "isBreakingChange=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Is not a breaking change"
             echo "isBreakingChange=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/breaking-change-pr-release.yaml
+++ b/.github/workflows/breaking-change-pr-release.yaml
@@ -34,6 +34,8 @@ jobs:
             echo "isBreakingChange=false" >> "$GITHUB_OUTPUT"
           fi
 
+          echo "isBreakingChange=$isBreakingChange"
+
       - name: Check if PR is a draft
         id: check-draft
         run: |

--- a/.github/workflows/breaking-change-pr-release.yaml
+++ b/.github/workflows/breaking-change-pr-release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Check if PR title is a breaking change
         id: check-title
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_TITLE=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
           if echo "$PR_TITLE" | grep -qE '^\w+!:'; then
             echo "isBreakingChange=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/breaking-change-pr-release.yaml
+++ b/.github/workflows/breaking-change-pr-release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Check if PR title is a breaking change
         id: check-title
         run: |
-          PR_TITLE="ci(changesets): versioning packages for branch `master`"
+          PR_TITLE="${{ github.event.pull_request.title }}"
           if echo "$PR_TITLE" | grep -qE '^\w+!:'; then
             echo "isBreakingChange=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/breaking-change-pr-release.yaml
+++ b/.github/workflows/breaking-change-pr-release.yaml
@@ -29,12 +29,12 @@ jobs:
           PR_TITLE=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
           echo "$PR_TITLE"
           if echo "$PR_TITLE" | grep -qE '^\w+!:'; then
+            echo "Is a breaking change"
             echo "isBreakingChange=true" >> "$GITHUB_OUTPUT"
           else
+            echo "Is not a breaking change"
             echo "isBreakingChange=false" >> "$GITHUB_OUTPUT"
           fi
-
-          echo "isBreakingChange=$isBreakingChange"
 
       - name: Check if PR is a draft
         id: check-draft

--- a/.github/workflows/breaking-change-pr-release.yaml
+++ b/.github/workflows/breaking-change-pr-release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Check if PR title is a breaking change
         id: check-title
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_TITLE="test `command` test"
           if echo "$PR_TITLE" | grep -qE '^\w+!:'; then
             echo "isBreakingChange=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/breaking-change-pr-release.yaml
+++ b/.github/workflows/breaking-change-pr-release.yaml
@@ -27,6 +27,7 @@ jobs:
         id: check-title
         run: |
           PR_TITLE=$(jq -r .pull_request.title "$GITHUB_EVENT_PATH")
+          echo "$PR_TITLE"
           if echo "$PR_TITLE" | grep -qE '^\w+!:'; then
             echo "isBreakingChange=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/breaking-change-pr-release.yaml
+++ b/.github/workflows/breaking-change-pr-release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Check if PR title is a breaking change
         id: check-title
         run: |
-          PR_TITLE="test `command` test"
+          PR_TITLE="ci(changesets): versioning packages for branch `master`"
           if echo "$PR_TITLE" | grep -qE '^\w+!:'; then
             echo "isBreakingChange=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
Fix this: https://github.com/FuelLabs/fuels-ts/actions/runs/8394068112/job/22990387566?pr=1892