### PR TITLE
fix: fetch just-published tag

### DIFF
--- a/scripts/changeset/update-changelog.mts
+++ b/scripts/changeset/update-changelog.mts
@@ -48,6 +48,8 @@ await (async () => {
       core.setFailed("Please add RELEASE_TAG to the environment");
       return;
     }
+    
+    execSync("git fetch --tags");
 
     const release = await octokit.rest.repos.getReleaseByTag({
       ...github.context.repo,


### PR DESCRIPTION
The changelog prettifying step [failed](https://github.com/FuelLabs/fuels-ts/actions/runs/8421458063/job/23058461552#step:9:20) because of the tag missing from local git.

closes #1938.