### PR TITLE
docs: fix imports and reordered errors

### DIFF
--- a/.changeset/ten-geese-trade.md
+++ b/.changeset/ten-geese-trade.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: fix imports and reordered errors

--- a/apps/docs-snippets/src/guide/cookbook/custom-transactions-contract-calls.test.ts
+++ b/apps/docs-snippets/src/guide/cookbook/custom-transactions-contract-calls.test.ts
@@ -41,7 +41,7 @@ describe('Custom Transactions from Contract Calls', () => {
     expect(initialBalance.toNumber()).toBe(0);
 
     // #region custom-transactions-contract-calls
-    // #import { bn, Contract, ScriptTransactionRequest }
+    // #import { bn, Contract, ScriptTransactionRequest };
 
     const amountToRecipient = bn(10_000); // 0x2710
     // Connect to the contract

--- a/apps/docs-snippets/src/guide/cookbook/custom-transactions-contract-calls.test.ts
+++ b/apps/docs-snippets/src/guide/cookbook/custom-transactions-contract-calls.test.ts
@@ -41,7 +41,7 @@ describe('Custom Transactions from Contract Calls', () => {
     expect(initialBalance.toNumber()).toBe(0);
 
     // #region custom-transactions-contract-calls
-    // #import { bn, Contract, ScriptTransactionRequest };
+    // #import { bn, Contract, FunctionInvocationResult };
 
     const amountToRecipient = bn(10_000); // 0x2710
     // Connect to the contract

--- a/apps/docs-snippets/src/guide/scripts/script-custom-transaction.test.ts
+++ b/apps/docs-snippets/src/guide/scripts/script-custom-transaction.test.ts
@@ -46,7 +46,7 @@ describe(__filename, () => {
     expect(contractInitialBalanceAssetB).toStrictEqual(new BN(0));
 
     // #region custom-transactions-2
-    // #import { BN, CoinQuantityLike, ScriptTransactionRequest }
+    // #import { BN, CoinQuantityLike, ScriptTransactionRequest };
 
     // 1. Create a script transaction using the script binary
     const { minGasPrice } = contract.provider.getGasConfig();

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -62,6 +62,21 @@ export default defineConfig({
         collapsed: false,
         items: [
           {
+            text: 'Errors',
+            link: '/guide/errors/',
+            collapsed: true,
+            items: [
+              {
+                text: 'Error Codes',
+                link: '/guide/errors/error-codes',
+              },
+              {
+                text: 'Debugging Revert Errors',
+                link: '/guide/errors/debugging-revert-errors',
+              },
+            ],
+          },
+          {
             text: 'Wallets',
             link: '/guide/wallets/',
             collapsed: true,
@@ -432,21 +447,6 @@ export default defineConfig({
                     link: '/guide/fuels/binaries',
                   },
                 ],
-              },
-            ],
-          },
-          {
-            text: 'Errors',
-            link: '/guide/errors/',
-            collapsed: true,
-            items: [
-              {
-                text: 'Debugging Revert Errors',
-                link: '/guide/errors/debugging-revert-errors',
-              },
-              {
-                text: 'Error Codes',
-                link: '/guide/errors/error-codes',
               },
             ],
           },


### PR DESCRIPTION
- Added missing semi-colons to the imports.
- `Errors` documentation section, now nested under the `basics` parent.