### PR TITLE
chore!: reset base `forc` version to `0.49.3` except for experimental builds

### DIFF
--- a/.changeset/tall-bees-move.md
+++ b/.changeset/tall-bees-move.md
@@ -3,4 +3,4 @@
 "@fuel-ts/versions": minor
 ---
 
-chore: reset base `forc` version to `0.49.3` except for experimental builds
+chore!: reset base `forc` version to `0.49.3` except for experimental builds


### PR DESCRIPTION
Original PR is #1963. This PR just changes its changeset to mark it as a breaking change.