### PR TITLE
chore: handling `EADDRNOTAVAIL` errors on top of `ECONNREFUSED`

### DIFF
--- a/.changeset/nasty-clocks-share.md
+++ b/.changeset/nasty-clocks-share.md
@@ -1,0 +1,5 @@
+---
+"fuels": patch
+---
+
+chore: handling `EADDRNOTAVAIL` errors on top of `ECONNREFUSED`

--- a/packages/fuels/src/cli/commands/deploy/createWallet.ts
+++ b/packages/fuels/src/cli/commands/deploy/createWallet.ts
@@ -18,8 +18,7 @@ export async function createWallet(providerUrl: string, privateKey?: string) {
     return Wallet.fromPrivateKey(pvtKey, provider);
   } catch (e) {
     const error = e as Error & { cause?: { code: string } };
-
-    if (error.cause?.code === 'ECONNREFUSED') {
+    if (/EADDRNOTAVAIL|ECONNREFUSED/.test(error.cause?.code ?? '')) {
       throw new FuelError(
         FuelError.CODES.CONNECTION_REFUSED,
         `Couldn't connect to the node at "${providerUrl}". Check that you've got a node running at the config's providerUrl or set autoStartFuelCore to true.`


### PR DESCRIPTION
This was failing locally for those not using Linux (hence why it works in CI).

![image](https://github.com/FuelLabs/fuels-ts/assets/26660/bcbc95f0-58ca-40c4-9e93-7d7184ce0537)


I tracked it down to this cause.