### PR TITLE
docs: validation for code snippet import statements

### DIFF
--- a/.changeset/kind-hats-speak.md
+++ b/.changeset/kind-hats-speak.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: validation for code snippet import statements

--- a/apps/docs/.vitepress/plugins/snippetPlugin.ts
+++ b/apps/docs/.vitepress/plugins/snippetPlugin.ts
@@ -3,10 +3,11 @@ import path from 'path';
 import fs from 'fs';
 import { ErrorCode, FuelError } from '@fuel-ts/errors';
 import { RuleBlock } from 'markdown-it/lib/parser_block';
-import { extractImports } from './utils/extractImports';
+import { extractImports, validateSnippetContent } from './utils/extractImports';
 
 // Regex to match import comments
 export const IMPORT_REGEXP = /\/\/ #import \{(.+)\};$/;
+export const IMPORT_START_REGEXP = /\/\/ #import/;
 
 // Regex to match region start/end comments
 export const REGION_REGEXP = /^\/\/ ?#?((?:end)?region) ([\w*-]+)$/;
@@ -142,6 +143,7 @@ export const snippetPlugin = (md: MarkdownIt, srcDir: string) => {
       }
 
       const snippetContent = lines.slice(region.start, region.end);
+      validateSnippetContent(snippetContent, filepath);
 
       // Extract and add imports specified in the #import flag
       let importStatements = '';

--- a/apps/docs/.vitepress/plugins/utils/extractImports.ts
+++ b/apps/docs/.vitepress/plugins/utils/extractImports.ts
@@ -1,6 +1,6 @@
 import { FuelError, ErrorCode } from '@fuel-ts/errors';
 import fs from 'fs';
-import { IMPORT_REGEXP } from '../snippetPlugin';
+import { IMPORT_REGEXP, IMPORT_START_REGEXP } from '../snippetPlugin';
 
 /**
  * Combines import statements into a single string.
@@ -59,6 +59,36 @@ export const validateImports = (
     }
   }
 };
+
+/**
+ * Validates that the snippet content contains valid import statements.
+ * 
+ * @param snippetContent - the snippet content to validate
+ * @param filepath - file path of the snippet
+
+ * @throws {FuelError} - If there are malformed "#import" statements in the code snippet.
+ * ```ts
+ * // Valid
+ * // #import { AssetId };
+ * 
+ * // Not valid
+ * // Missing semicolon: "#import { AssetId }"
+ * // Plain wrong: "#import "
+ * ```
+ */
+export const validateSnippetContent = (snippetContent: string[], filepath: string) => {
+  const allImportStatements = snippetContent.filter((line) => IMPORT_START_REGEXP.test(line));
+  const validImportStatements = snippetContent.filter((line) => IMPORT_REGEXP.test(line));
+
+  // Validates that all the import statements have been picked up
+  if (allImportStatements.length !== validImportStatements.length) {
+    const invalidLines = allImportStatements.filter((line) => !validImportStatements.includes(line));
+    throw new FuelError(
+      ErrorCode.VITEPRESS_PLUGIN_ERROR,
+      `Found malformed "#import" statements in code snippet.\n\nPlease check "${filepath}".\n\n${invalidLines.map((line) => line.trim()).join('\n')}`
+    );
+  }
+}
 
 /**
  * Collects import statements from the given lines of code and extracts the imported items and their sources.


### PR DESCRIPTION
Closes: #1960

---

Adds validation to the code snippet script. Throwing an error when a malformed code snippet is detected.