### PR TITLE
docs: updated abi-typegen to typegen for links

### DIFF
--- a/.changeset/silver-phones-walk.md
+++ b/.changeset/silver-phones-walk.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: updated abi-typegen to typegen for links

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The [documentation](https://docs.fuel.network/docs/fuels-ts/) site is your main 
   - [Contracts](https://docs.fuel.network/docs/fuels-ts/contracts/)
   - [Scripts](https://docs.fuel.network/docs/fuels-ts/scripts/)
   - [Predicates](https://docs.fuel.network/docs/fuels-ts/predicates/)
-  - [ABI Typegen](https://docs.fuel.network/docs/fuels-ts/abi-typegen/)
+  - [ABI Typegen](https://docs.fuel.network/docs/fuels-ts/typegen/)
 - [Contributing](https://github.com/FuelLabs/fuels-ts/blob/master/CONTRIBUTING.md)
 - [The Fuel Forum](https://forum.fuel.network/)
 - [The Fuel Ecosystem](#the-fuel-ecosystem)

--- a/apps/docs/src/guide/fuels/commands.md
+++ b/apps/docs/src/guide/fuels/commands.md
@@ -104,7 +104,7 @@ Use it when instantiating your contracts:
 
 For a complete example, see:
 
-- [Using Generated Types](https://docs.fuel.network/docs/fuels-ts/abi-typegen/using-generated-types/)
+- [Using Generated Types](https://docs.fuel.network/docs/fuels-ts/typegen/using-generated-types/)
 
 ## `fuels dev`
 

--- a/packages/abi-typegen/README.md
+++ b/packages/abi-typegen/README.md
@@ -17,7 +17,7 @@ See the full ABI-spec [here](https://github.com/FuelLabs/fuel-specs/blob/master/
 
 ## Documentation
 
-See [Fuels-ts Documentation](https://docs.fuel.network/docs/fuels-ts/abi-typegen/)
+See [Fuels-ts Documentation](https://docs.fuel.network/docs/fuels-ts/typegen/)
 
 ## Installation
 


### PR DESCRIPTION
Fixes dead links for `abi-typegen`

https://github.com/FuelLabs/fuels-ts/actions/runs/8517995686/job/23329401712?pr=1980#step:4:265