### PR TITLE
feat!: deprecate multiple encoding version support for configurable constants

### DIFF
--- a/.changeset/brave-rice-march.md
+++ b/.changeset/brave-rice-march.md
@@ -2,4 +2,4 @@
 "@fuel-ts/abi-coder": minor
 ---
 
-Deprecate multiple encoding version support for configurables
+feat!: deprecate multiple encoding version support for configurable constants

--- a/.changeset/brave-rice-march.md
+++ b/.changeset/brave-rice-march.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-coder": minor
+---
+
+Deprecate multiple encoding version support for configurables

--- a/packages/abi-coder/src/Interface.ts
+++ b/packages/abi-coder/src/Interface.ts
@@ -99,7 +99,6 @@ export class Interface<TAbi extends JsonAbi = JsonAbi> {
 
     return AbiCoder.encode(this.jsonAbi, configurable.configurableType, value, {
       isRightPadded: true,
-      encoding: this.jsonAbi.encoding,
     });
   }
 

--- a/packages/abi-coder/src/Interface.ts
+++ b/packages/abi-coder/src/Interface.ts
@@ -7,6 +7,7 @@ import { AbiCoder } from './AbiCoder';
 import { FunctionFragment } from './FunctionFragment';
 import type { InputValue } from './encoding/coders/AbstractCoder';
 import type { JsonAbi, JsonAbiConfigurable } from './types/JsonAbi';
+import { ENCODING_V0 } from './utils/constants';
 import { findTypeById } from './utils/json-abi';
 
 export class Interface<TAbi extends JsonAbi = JsonAbi> {
@@ -99,6 +100,7 @@ export class Interface<TAbi extends JsonAbi = JsonAbi> {
 
     return AbiCoder.encode(this.jsonAbi, configurable.configurableType, value, {
       isRightPadded: true,
+      encoding: ENCODING_V0,
     });
   }
 

--- a/packages/fuel-gauge/src/experimental-contract.test.ts
+++ b/packages/fuel-gauge/src/experimental-contract.test.ts
@@ -1,11 +1,12 @@
 import { readFileSync } from 'fs';
-import type { Contract } from 'fuels';
+import type { Contract, ContractFactory } from 'fuels';
 import { bn } from 'fuels';
 import { join } from 'path';
 
-import { setup } from './utils';
+import { setup, setupFactory } from './utils';
 
 let contractInstance: Contract;
+let contractFactory: ContractFactory;
 
 const U8_MAX = 2 ** 8 - 1;
 const U16_MAX = 2 ** 16 - 1;
@@ -29,6 +30,7 @@ describe('Experimental Contract', () => {
     const abi = JSON.parse(readFileSync(`${path}-abi.json`, 'utf8'));
 
     contractInstance = await setup({ contractBytecode, abi });
+    contractFactory = await setupFactory({ contractBytecode, abi });
   });
 
   it('echos mixed struct with all types', async () => {
@@ -85,5 +87,25 @@ describe('Experimental Contract', () => {
     await expect(contractInstance.functions.test_revert().call()).rejects.toThrow(
       'The transaction reverted because a "require" statement has thrown "This is a revert error".'
     );
+  });
+
+  it('echos configurable (both encoding versions)', async () => {
+    const param = [1, 2, 3, 'four'];
+    const { value } = await contractInstance.functions.echo_configurable(param).call();
+
+    expect(value).toStrictEqual(param);
+
+    const configurableParam = [5, 6, 7, 'fuel'];
+    const configurableConstants = {
+      CONF: configurableParam,
+    };
+    const configurableContractInstance = await contractFactory.deployContract({
+      configurableConstants,
+    });
+    const { value: configurableValue } = await configurableContractInstance.functions
+      .echo_configurable(configurableParam)
+      .call();
+
+    expect(configurableValue).toStrictEqual(configurableParam);
   });
 });

--- a/packages/fuel-gauge/src/experimental-contract.test.ts
+++ b/packages/fuel-gauge/src/experimental-contract.test.ts
@@ -1,9 +1,9 @@
 import { readFileSync } from 'fs';
-import type { Contract, ContractFactory } from 'fuels';
-import { bn } from 'fuels';
+import type { Contract } from 'fuels';
+import { ContractFactory, bn } from 'fuels';
 import { join } from 'path';
 
-import { setup, setupFactory } from './utils';
+import { setup } from './utils';
 
 let contractInstance: Contract;
 let contractFactory: ContractFactory;
@@ -30,7 +30,7 @@ describe('Experimental Contract', () => {
     const abi = JSON.parse(readFileSync(`${path}-abi.json`, 'utf8'));
 
     contractInstance = await setup({ contractBytecode, abi });
-    contractFactory = await setupFactory({ contractBytecode, abi });
+    contractFactory = new ContractFactory(contractBytecode, abi, contractInstance.account);
   });
 
   it('echos mixed struct with all types', async () => {

--- a/packages/fuel-gauge/src/utils.ts
+++ b/packages/fuel-gauge/src/utils.ts
@@ -9,13 +9,14 @@ let contractInstance: Contract;
 const deployContract = async (
   factory: ContractFactory,
   provider: Provider,
-  useCache: boolean = true
+  useCache: boolean = true,
+  configurableConstants?: { [name: string]: unknown }
 ) => {
   if (contractInstance && useCache) {
     return contractInstance;
   }
   const { minGasPrice } = provider.getGasConfig();
-  contractInstance = await factory.deployContract({ gasPrice: minGasPrice });
+  contractInstance = await factory.deployContract({ configurableConstants, gasPrice: minGasPrice });
   return contractInstance;
 };
 
@@ -36,6 +37,7 @@ export type SetupConfig = {
   contractBytecode: BytesLike;
   abi: JsonAbi | Interface;
   cache?: boolean;
+  configurableConstants?: { [name: string]: unknown };
 };
 
 export const setup = async ({ contractBytecode, abi, cache }: SetupConfig) => {
@@ -44,6 +46,11 @@ export const setup = async ({ contractBytecode, abi, cache }: SetupConfig) => {
   const factory = new ContractFactory(contractBytecode, abi, wallet);
   const contract = await deployContract(factory, wallet.provider, cache);
   return contract;
+};
+
+export const setupFactory = async ({ contractBytecode, abi }: SetupConfig) => {
+  const wallet = await createWallet();
+  return new ContractFactory(contractBytecode, abi, wallet);
 };
 
 export const createSetupConfig =

--- a/packages/fuel-gauge/src/utils.ts
+++ b/packages/fuel-gauge/src/utils.ts
@@ -9,14 +9,13 @@ let contractInstance: Contract;
 const deployContract = async (
   factory: ContractFactory,
   provider: Provider,
-  useCache: boolean = true,
-  configurableConstants?: { [name: string]: unknown }
+  useCache: boolean = true
 ) => {
   if (contractInstance && useCache) {
     return contractInstance;
   }
   const { minGasPrice } = provider.getGasConfig();
-  contractInstance = await factory.deployContract({ configurableConstants, gasPrice: minGasPrice });
+  contractInstance = await factory.deployContract({ gasPrice: minGasPrice });
   return contractInstance;
 };
 
@@ -37,7 +36,6 @@ export type SetupConfig = {
   contractBytecode: BytesLike;
   abi: JsonAbi | Interface;
   cache?: boolean;
-  configurableConstants?: { [name: string]: unknown };
 };
 
 export const setup = async ({ contractBytecode, abi, cache }: SetupConfig) => {
@@ -46,11 +44,6 @@ export const setup = async ({ contractBytecode, abi, cache }: SetupConfig) => {
   const factory = new ContractFactory(contractBytecode, abi, wallet);
   const contract = await deployContract(factory, wallet.provider, cache);
   return contract;
-};
-
-export const setupFactory = async ({ contractBytecode, abi }: SetupConfig) => {
-  const wallet = await createWallet();
-  return new ContractFactory(contractBytecode, abi, wallet);
 };
 
 export const createSetupConfig =

--- a/packages/fuel-gauge/test/fixtures/forc-projects-experimental/contract-echo/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects-experimental/contract-echo/src/main.sw
@@ -94,7 +94,6 @@ impl MyContract for Contract {
         let param_str: str = from_str_array(param.3);
         let conf_str: str = from_str_array(CONF.3);
         assert_eq(param_str, conf_str);
-
         
         CONF
     }

--- a/packages/fuel-gauge/test/fixtures/forc-projects-experimental/contract-echo/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects-experimental/contract-echo/src/main.sw
@@ -6,7 +6,6 @@ use std::option::Option;
 use std::bytes::Bytes;
 use std::vec::Vec;
 
-
 enum NativeEnum {
     Checked: (),
     Pending: (),
@@ -94,7 +93,7 @@ impl MyContract for Contract {
         let param_str: str = from_str_array(param.3);
         let conf_str: str = from_str_array(CONF.3);
         assert_eq(param_str, conf_str);
-        
+
         CONF
     }
 }

--- a/packages/fuel-gauge/test/fixtures/forc-projects-experimental/contract-echo/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects-experimental/contract-echo/src/main.sw
@@ -6,6 +6,7 @@ use std::option::Option;
 use std::bytes::Bytes;
 use std::vec::Vec;
 
+
 enum NativeEnum {
     Checked: (),
     Pending: (),
@@ -65,9 +66,14 @@ struct MixedStruct {
     str_slice: str,
 }
 
+configurable {
+    CONF: (u8, u16, u32, str[4]) = (1, 2, 3, __to_str_array("four")),
+}
+
 abi MyContract {
     fn echo_struct(param: MixedStruct) -> MixedStruct;
     fn test_revert() -> bool;
+    fn echo_configurable(param: (u8, u16, u32, str[4])) -> (u8, u16, u32, str[4]);
 }
 
 impl MyContract for Contract {
@@ -78,5 +84,18 @@ impl MyContract for Contract {
     fn test_revert() -> bool {
         require(false, "This is a revert error");
         true
+    }
+
+    fn echo_configurable(param: (u8, u16, u32, str[4])) -> (u8, u16, u32, str[4]) {
+        assert_eq(param.0, CONF.0);
+        assert_eq(param.1, CONF.1);
+        assert_eq(param.2, CONF.2);
+
+        let param_str: str = from_str_array(param.3);
+        let conf_str: str = from_str_array(CONF.3);
+        assert_eq(param_str, conf_str);
+
+        
+        CONF
     }
 }


### PR DESCRIPTION
Relates to #1672.

I had incorrectly assumed that configurable constants were included for `v1` encoding. They are currently [unsupported](https://github.com/FuelLabs/sway/issues/5727).

This PR removes support at the encoding entry point for configurables, and introduces a test that includes both `v0` configurable encoding and `v1` param encoding.