### PR TITLE
fix: improper update of `getBuiltinVersions`

### DIFF
--- a/scripts/changeset/changeset-version-with-docs.ts
+++ b/scripts/changeset/changeset-version-with-docs.ts
@@ -15,10 +15,14 @@ import { error } from 'console';
     // Invoke versions' prebuild script (will rewrite version files if needed)
     execSync(`pnpm -C packages/versions prebuild`);
 
-    const versionsChanged = !!execSync(`git status --porcelain`).toString().trim();
+    const versionsFilePath = `packages/versions/src/lib/getBuiltinVersions.ts`;
+
+    const versionsChanged = !!execSync(`git status --porcelain ${versionsFilePath}`)
+      .toString()
+      .trim();
 
     if (versionsChanged) {
-      execSync(`git add packages/versions/src/lib/getBuiltinVersions.ts`);
+      execSync(`git add ${versionsFilePath}`);
       execSync(`git commit -m"ci(scripts): update versions"`);
     }
   } catch (err) {

--- a/scripts/changeset/changeset-version-with-docs.ts
+++ b/scripts/changeset/changeset-version-with-docs.ts
@@ -5,6 +5,13 @@ import { error } from 'console';
 
 (() => {
   try {
+    /**
+     * This is the base command that has to run always.
+     * Release CIs were failing when there were only empty changesets because we weren't running this command.
+     * See more here: https://github.com/FuelLabs/fuels-ts/pull/1847
+     */
+    execSync(`changeset version`);
+
     // Invoke versions' prebuild script (will rewrite version files if needed)
     execSync(`pnpm -C packages/versions prebuild`);
 
@@ -14,13 +21,6 @@ import { error } from 'console';
       execSync(`git add packages/versions/src/lib/getBuiltinVersions.ts`);
       execSync(`git commit -m"ci(scripts): update versions"`);
     }
-
-    /**
-     * This is the base command that has to run always.
-     * Release CIs were failing when there were only empty changesets because we weren't running this command.
-     * See more here: https://github.com/FuelLabs/fuels-ts/pull/1847
-     */
-    execSync(`changeset version`);
   } catch (err) {
     error(err.toString());
   }


### PR DESCRIPTION
Fixes how `getBuiltinVersions` is updated. This will update [`getBuiltinVersions` on the current changesets PR](https://github.com/FuelLabs/fuels-ts/pull/2072/files#diff-f34e8f56f6328b8b21d0b488f36cc3d07fd8125615629b65d01295009ff02266R5) to the proper value on the changeset PR.

If you want to test the fix locally, run the following on `master`:
- `pnpm tsx packages/versions/scripts/rewriteVersions.ts`
    - Notice that it changes to `0.80.0`. This is because we have a version mismatch between our `master`'s [`packages/fuels/package.json`](https://github.com/FuelLabs/fuels-ts/blob/764b37eac34647d653aceb3f681edccebc550095/packages/fuels/package.json#L3) and [`getBuiltinVersions`](https://github.com/FuelLabs/fuels-ts/blob/764b37eac34647d653aceb3f681edccebc550095/packages/versions/src/lib/getBuiltinVersions.ts#L5) which led to this investigation and fix. If those two versions were the same, `getBuiltinVersions.ts` wouldn't have changed.
- `pnpm changeset && pnpm tsx/packages/versions/scripts/rewriteVersions.ts`
    - Notice that it changes to `0.81.0` - this is correct and what the changeset PR should update to because `pnpm changeset` updates `packages/fuels/package.json` to that version which `rewriteVersions.ts` copies over.