### PR TITLE
chore: disabling PR auto-release

### DIFF
--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    # if: false
+    if: false
     permissions: write-all
     steps:
       - name: Checkout


### PR DESCRIPTION
It was committed by mistake; one needs to uncomment it before merging:

https://github.com/FuelLabs/fuels-ts/blob/5daeea42b83944e9fc758012f235e41e7aa7bdff/.github/workflows/pr-release.yaml#L11

We could have a routine for automating this.

**EDIT**: _Created an [issue](https://github.com/FuelLabs/fuels-ts/issues/2119) for it._