### PR TITLE
build: upgrade `pnpm` version

### DIFF
--- a/.changeset/sharp-pillows-film.md
+++ b/.changeset/sharp-pillows-film.md
@@ -1,0 +1,3 @@
+---
+---
+build: upgrade `pnpm` version

--- a/.github/actions/ci-setup/action.yaml
+++ b/.github/actions/ci-setup/action.yaml
@@ -5,7 +5,7 @@ inputs:
     default: 20.10.0
   pnpm-version:
     description: "PNPM version"
-    default: 8.9.0
+    default: 9.0.2
 runs:
   using: "composite"
   steps:

--- a/.github/actions/test-setup/action.yaml
+++ b/.github/actions/test-setup/action.yaml
@@ -5,7 +5,7 @@ inputs:
     default: 20.10.0
   pnpm-version:
     description: "PNPM version"
-    default: 8.9.0
+    default: 9.0.2
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/breaking-change-pr-release.yaml
+++ b/.github/workflows/breaking-change-pr-release.yaml
@@ -56,7 +56,7 @@ jobs:
       - uses: FuelLabs/github-actions/setups/node@master
         with:
           node-version: 20.10.0
-          pnpm-version: 8.9.0
+          pnpm-version: 9.0.2
       - uses: FuelLabs/github-actions/setups/npm@master
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "private": true,
   "engines": {
     "node": "^18.18.2 || ^20.0.0",
-    "pnpm": "^8.9.0"
+    "pnpm": "^9.0.2"
   },
-  "packageManager": "pnpm@8.9.0",
+  "packageManager": "pnpm@9.0.2",
   "scripts": {
     "dev": "nodemon --config nodemon.config.json -x 'pnpm build:packages'",
     "build": "turbo run build --cache-dir=.turbo",


### PR DESCRIPTION
The [lint step fails on CI](https://github.com/FuelLabs/fuels-ts/actions/runs/8757757991/job/24037100858?pr=2117) but this isn't happening for me locally. I am running `pnpm` `9.0.2` so figured I would upgrade it across the board.