### PR TITLE
docs: add a link to deployment guide in `create-fuels` readme

### DIFF
--- a/.changeset/famous-sheep-whisper.md
+++ b/.changeset/famous-sheep-whisper.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: add a link to deployment guide in `create-fuels` readme

--- a/apps/create-fuels-counter-guide/README.md
+++ b/apps/create-fuels-counter-guide/README.md
@@ -8,11 +8,15 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-fuel
 npm run fuels:dev
 ```
 
-1. Start the Next.js development server.
+2. Start the Next.js development server.
 
 ```bash
 npm run dev
 ```
+
+## Deploying to Testnet
+
+To learn how to deploy your Fuel dApp to the testnet, you can follow our [Deploying to Testnet](https://docs.fuel.network/docs/fuels-ts/creating-a-fuel-dapp/deploying-a-dapp-to-testnet/) guide.
 
 ## Learn More
 

--- a/packages/create-fuels/README.md
+++ b/packages/create-fuels/README.md
@@ -19,11 +19,15 @@ npm run fuels:dev
 npx fuels dev
 ```
 
-1. Start the Next.js development server.
+2. Start the Next.js development server.
 
 ```bash
 npm run dev
 ```
+
+## Deploying to Testnet
+
+To learn how to deploy your Fuel dApp to the testnet, you can follow our [Deploying to Testnet](https://docs.fuel.network/docs/fuels-ts/creating-a-fuel-dapp/deploying-a-dapp-to-testnet/) guide.
 
 ## Learn More
 

--- a/templates/nextjs/README.md
+++ b/templates/nextjs/README.md
@@ -8,11 +8,15 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-fuel
 npm run fuels:dev
 ```
 
-1. Start the Next.js development server.
+2. Start the Next.js development server.
 
 ```bash
 npm run dev
 ```
+
+## Deploying to Testnet
+
+To learn how to deploy your Fuel dApp to the testnet, you can follow our [Deploying to Testnet](https://docs.fuel.network/docs/fuels-ts/creating-a-fuel-dapp/deploying-a-dapp-to-testnet/) guide.
 
 ## Learn More
 


### PR DESCRIPTION
Closes #2069