### PR TITLE
ci: added missing token for Report Coverage step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -144,11 +144,13 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         if: ${{ steps.findPr.outputs.number }}
         with:
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
           filePath: coverage/report/coverage-diff.txt
           pr_number: ${{ (steps.findPr.outputs.number) }}
           comment_tag: diff
           mode: recreate
           create_if_not_exists: true
+
   create-changeset:
     needs: [test]
     name: Create Changeset


### PR DESCRIPTION
- Potentially fixes the issue with dependabot from [reporting coverage](https://github.com/FuelLabs/fuels-ts/actions/runs/8983190744/job/24688699112?pr=2253#step:11:15).