### PR TITLE
feat: `VecCoder@v1` accepts `UInt8Array` as encode input

### DIFF
--- a/.changeset/tame-icons-film.md
+++ b/.changeset/tame-icons-film.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-coder": patch
+---
+
+feat: `VecCoder@v1` accepts `UInt8Array` as encode input

--- a/packages/abi-coder/src/encoding/coders/v1/VecCoder.test.ts
+++ b/packages/abi-coder/src/encoding/coders/v1/VecCoder.test.ts
@@ -1,5 +1,6 @@
 import { ErrorCode, FuelError } from '@fuel-ts/errors';
 import { expectToThrowFuelError } from '@fuel-ts/errors/test-utils';
+import { arrayify } from '@fuel-ts/utils';
 
 import { U32_MAX } from '../../../../test/utils/constants';
 
@@ -23,7 +24,10 @@ describe('VecCoder', () => {
     const coder = new VecCoder(new BooleanCoder());
     await expectToThrowFuelError(
       () => coder.encode('Nope' as never),
-      new FuelError(ErrorCode.ENCODE_ERROR, 'Expected array value.')
+      new FuelError(
+        ErrorCode.ENCODE_ERROR,
+        'Expected array value, or a Uint8Array. You can use arrayify to convert a value to a Uint8Array.'
+      )
     );
   });
 
@@ -35,6 +39,14 @@ describe('VecCoder', () => {
 
     expect(actual).toEqual(expected);
     expect(newOffset).toEqual(11);
+  });
+
+  it('should encode a u8 Vec (UInt8Array)', () => {
+    const coder = new VecCoder(new NumberCoder('u8'));
+    const expected = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 3, 8, 6, 7]);
+    const actual = coder.encode(arrayify(Uint8Array.from([8, 6, 7])));
+
+    expect(actual).toEqual(expected);
   });
 
   it('throws when decoding empty vec bytes', async () => {

--- a/packages/abi-coder/src/encoding/coders/v1/VecCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/v1/VecCoder.ts
@@ -3,13 +3,14 @@ import { bn } from '@fuel-ts/math';
 import { concatBytes } from '@fuel-ts/utils';
 
 import { MAX_BYTES, WORD_SIZE } from '../../../utils/constants';
+import { isUint8Array } from '../../../utils/utilities';
 import type { TypesOfCoder } from '../AbstractCoder';
 import { Coder } from '../AbstractCoder';
 import { BigNumberCoder } from '../v0/BigNumberCoder';
 
 import { OptionCoder } from './OptionCoder';
 
-type InputValueOf<TCoder extends Coder> = Array<TypesOfCoder<TCoder>['Input']>;
+type InputValueOf<TCoder extends Coder> = Array<TypesOfCoder<TCoder>['Input']> | Uint8Array;
 type DecodedValueOf<TCoder extends Coder> = Array<TypesOfCoder<TCoder>['Decoded']>;
 
 export class VecCoder<TCoder extends Coder> extends Coder<
@@ -26,12 +27,21 @@ export class VecCoder<TCoder extends Coder> extends Coder<
   }
 
   encode(value: InputValueOf<TCoder>): Uint8Array {
-    if (!Array.isArray(value)) {
-      throw new FuelError(ErrorCode.ENCODE_ERROR, `Expected array value.`);
+    if (!Array.isArray(value) && !isUint8Array(value)) {
+      throw new FuelError(
+        ErrorCode.ENCODE_ERROR,
+        `Expected array value, or a Uint8Array. You can use arrayify to convert a value to a Uint8Array.`
+      );
+    }
+
+    const lengthCoder = new BigNumberCoder('u64');
+
+    if (isUint8Array(value)) {
+      return new Uint8Array([...lengthCoder.encode(value.length), ...value]);
     }
 
     const bytes = value.map((v) => this.coder.encode(v));
-    const lengthBytes = new BigNumberCoder('u64').encode(value.length);
+    const lengthBytes = lengthCoder.encode(value.length);
 
     return new Uint8Array([...lengthBytes, ...concatBytes(bytes)]);
   }


### PR DESCRIPTION
The work in #2018 made a `UInt8Array` a valid input for for `VecCoder.encode`. This is useful for working with bytecode, where the function likely accepts a `Vec<u8>` and the input would be passed as _arrayified_ binary, so requiring a `number[]` is poor DX. 

This feature was not brought across to `V1`, it was probably missed due to the timing overlap. This PR introduces that change to `V1` encoding.