### PR TITLE
fix!: remove offset from `decodeLog` and `decodeFunctionResult` methods

### DIFF
--- a/.changeset/perfect-kings-camp.md
+++ b/.changeset/perfect-kings-camp.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-coder": minor
+---
+
+Changed decodeLog and decodeFunctionResult return types to have only decoded value without an offset

--- a/.changeset/perfect-kings-camp.md
+++ b/.changeset/perfect-kings-camp.md
@@ -2,4 +2,4 @@
 "@fuel-ts/abi-coder": minor
 ---
 
-Changed decodeLog and decodeFunctionResult return types to have only decoded value without an offset
+fix: Changed decodeLog and decodeFunctionResult return types to have only decoded value without an offset

--- a/packages/abi-coder/src/Interface.ts
+++ b/packages/abi-coder/src/Interface.ts
@@ -75,7 +75,7 @@ export class Interface<TAbi extends JsonAbi = JsonAbi> {
   }
 
   decodeLog(data: BytesLike, logId: string): any {
-    const loggedType = this.jsonAbi.loggedTypes.find((type) => type.logId === logId);
+    const loggedType = this.jsonAbi.loggedTypes.find((type) => type.logId.toString() === logId);
     if (!loggedType) {
       throw new FuelError(
         ErrorCode.LOG_TYPE_NOT_FOUND,

--- a/packages/abi-coder/src/Interface.ts
+++ b/packages/abi-coder/src/Interface.ts
@@ -71,7 +71,7 @@ export class Interface<TAbi extends JsonAbi = JsonAbi> {
     const fragment =
       typeof functionFragment === 'string' ? this.getFunction(functionFragment) : functionFragment;
 
-    return fragment.decodeOutput(data);
+    return fragment.decodeOutput(data)[0];
   }
 
   decodeLog(data: BytesLike, logId: string): any {
@@ -85,7 +85,7 @@ export class Interface<TAbi extends JsonAbi = JsonAbi> {
 
     return AbiCoder.decode(this.jsonAbi, loggedType.loggedType, arrayify(data), 0, {
       encoding: this.encoding,
-    });
+    })[0];
   }
 
   encodeConfigurable(name: string, value: InputValue) {

--- a/packages/abi-coder/src/Interface.ts
+++ b/packages/abi-coder/src/Interface.ts
@@ -45,7 +45,7 @@ export class Interface<TAbi extends JsonAbi = JsonAbi> {
 
     throw new FuelError(
       ErrorCode.FUNCTION_NOT_FOUND,
-      `function ${nameOrSignatureOrSelector} not found: ${JSON.stringify(fn)}.`
+      `Function ${nameOrSignatureOrSelector} not found.`
     );
   }
 

--- a/packages/abi-coder/src/Interface.ts
+++ b/packages/abi-coder/src/Interface.ts
@@ -75,7 +75,7 @@ export class Interface<TAbi extends JsonAbi = JsonAbi> {
   }
 
   decodeLog(data: BytesLike, logId: string): any {
-    const loggedType = this.jsonAbi.loggedTypes.find((type) => type.logId.toString() === logId);
+    const loggedType = this.jsonAbi.loggedTypes.find((type) => type.logId === logId);
     if (!loggedType) {
       throw new FuelError(
         ErrorCode.LOG_TYPE_NOT_FOUND,

--- a/packages/abi-coder/test/Interface.test.ts
+++ b/packages/abi-coder/test/Interface.test.ts
@@ -782,4 +782,26 @@ describe('Abi interface', () => {
       ).toThrowError(`Log type with logId '1' doesn't exist in the ABI.`);
     });
   });
+
+  describe('decodeFunctionResult', () => {
+    it('should return decoded function result', () => {
+      const data = exhaustiveExamplesInterface.decodeFunctionResult(
+        'struct_simple',
+        '0x01000000000000000000000000000020'
+      );
+      expect(data).toEqual({
+        a: true,
+        b: 32,
+      });
+    });
+
+    it('should throw an error when function does not exist', () => {
+      expect(() => {
+        exhaustiveExamplesInterface.decodeFunctionResult(
+          'doesnt_exist',
+          '0x01000000000000000000000000000020'
+        );
+      }).toThrowError(/^Function doesnt_exist not found\.$/);
+    });
+  });
 });

--- a/packages/abi-coder/test/Interface.test.ts
+++ b/packages/abi-coder/test/Interface.test.ts
@@ -766,4 +766,20 @@ describe('Abi interface', () => {
       );
     });
   });
+
+  describe('decodeLog', () => {
+    it('should return decoded log by id', () => {
+      const data = exhaustiveExamplesInterface.decodeLog('0x01000000000000000000000000000020', '0');
+      expect(data).toEqual({
+        a: true,
+        b: 32,
+      });
+    });
+
+    it('should throw an error when log does not exist', () => {
+      expect(() =>
+        exhaustiveExamplesInterface.decodeLog('0x01000000000000000000000000000020', '1')
+      ).toThrowError(`Log type with logId '1' doesn't exist in the ABI.`);
+    });
+  });
 });

--- a/packages/abi-coder/test/fixtures/forc-projects/exhaustive-examples/src/main.sw
+++ b/packages/abi-coder/test/fixtures/forc-projects/exhaustive-examples/src/main.sw
@@ -181,6 +181,8 @@ abi MyContract {
         arg3: (str[5], bool),
         arg4: MyOtherStruct,
     );
+
+    fn log();
 }
 
 impl MyContract for Contract {
@@ -338,5 +340,12 @@ impl MyContract for Contract {
     ) {}
     fn simple_vector(arg: Vec<u8>) -> Vec<u8> {
         arg
+    }
+
+    fn log() {
+        log(SimpleStruct {
+            a: true,
+            b: 32u32,
+        });
     }
 }

--- a/packages/account/src/providers/transaction-response/getDecodedLogs.ts
+++ b/packages/account/src/providers/transaction-response/getDecodedLogs.ts
@@ -35,7 +35,7 @@ export function getDecodedLogs<T = unknown>(
           ? new BigNumberCoder('u64').encode(receipt.val0)
           : receipt.data;
 
-      const [decodedLog] = interfaceToUse.decodeLog(data, receipt.val1.toString());
+      const decodedLog = interfaceToUse.decodeLog(data, receipt.val1.toString());
       logs.push(decodedLog);
     }
 


### PR DESCRIPTION
It feels like public `decode` functions should return the decoded value itself. Not a tuple with an internal offset.