### PR TITLE
feat!: remove nested option size validation

### DIFF
--- a/.changeset/olive-meals-love.md
+++ b/.changeset/olive-meals-love.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-coder": minor
+---
+
+feat!: remove nested option size validation

--- a/packages/abi-coder/src/encoding/coders/ArrayCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/ArrayCoder.ts
@@ -1,7 +1,7 @@
 import { ErrorCode, FuelError } from '@fuel-ts/errors';
 import { concat } from '@fuel-ts/utils';
 
-import { MAX_BYTES } from '../../utils/constants';
+import { MAX_BYTES, OPTION_CODER_TYPE } from '../../utils/constants';
 
 import type { TypesOfCoder } from './AbstractCoder';
 import { Coder } from './AbstractCoder';
@@ -15,11 +15,14 @@ export class ArrayCoder<TCoder extends Coder> extends Coder<
 > {
   coder: TCoder;
   length: number;
+  #hasNestedOption: boolean;
 
   constructor(coder: TCoder, length: number) {
+    const hasNestedOption = coder.type === OPTION_CODER_TYPE;
     super('array', `[${coder.type}; ${length}]`, length * coder.encodedLength);
     this.coder = coder;
     this.length = length;
+    this.#hasNestedOption = hasNestedOption;
   }
 
   encode(value: InputValueOf<TCoder>): Uint8Array {
@@ -35,7 +38,7 @@ export class ArrayCoder<TCoder extends Coder> extends Coder<
   }
 
   decode(data: Uint8Array, offset: number): [DecodedValueOf<TCoder>, number] {
-    if (data.length < this.encodedLength || data.length > MAX_BYTES) {
+    if ((!this.#hasNestedOption && data.length < this.encodedLength) || data.length > MAX_BYTES) {
       throw new FuelError(ErrorCode.DECODE_ERROR, `Invalid array data size.`);
     }
 

--- a/packages/abi-coder/src/encoding/coders/TupleCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/TupleCoder.ts
@@ -1,6 +1,8 @@
 import { ErrorCode, FuelError } from '@fuel-ts/errors';
 import { concatBytes } from '@fuel-ts/utils';
 
+import { OPTION_CODER_TYPE } from '../../utils/constants';
+
 import type { TypesOfCoder } from './AbstractCoder';
 import { Coder } from './AbstractCoder';
 
@@ -16,11 +18,14 @@ export class TupleCoder<TCoders extends Coder[]> extends Coder<
   DecodedValueOf<TCoders>
 > {
   coders: TCoders;
+  #hasNestedOption: boolean;
 
   constructor(coders: TCoders) {
+    const hasNestedOption = coders.some((coder) => coder.type === OPTION_CODER_TYPE);
     const encodedLength = coders.reduce((acc, coder) => acc + coder.encodedLength, 0);
     super('tuple', `(${coders.map((coder) => coder.type).join(', ')})`, encodedLength);
     this.coders = coders;
+    this.#hasNestedOption = hasNestedOption;
   }
 
   encode(value: InputValueOf<TCoders>): Uint8Array {
@@ -32,7 +37,7 @@ export class TupleCoder<TCoders extends Coder[]> extends Coder<
   }
 
   decode(data: Uint8Array, offset: number): [DecodedValueOf<TCoders>, number] {
-    if (data.length < this.encodedLength) {
+    if (!this.#hasNestedOption && data.length < this.encodedLength) {
       throw new FuelError(ErrorCode.DECODE_ERROR, `Invalid tuple data size.`);
     }
 

--- a/packages/abi-coder/src/encoding/coders/VecCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/VecCoder.ts
@@ -46,7 +46,7 @@ export class VecCoder<TCoder extends Coder> extends Coder<
   }
 
   decode(data: Uint8Array, offset: number): [DecodedValueOf<TCoder>, number] {
-    if (!this.#hasNestedOption && (data.length < this.encodedLength || data.length > MAX_BYTES)) {
+    if ((!this.#hasNestedOption && data.length < this.encodedLength) || data.length > MAX_BYTES) {
       throw new FuelError(ErrorCode.DECODE_ERROR, `Invalid vec data size.`);
     }
 

--- a/packages/abi-coder/src/encoding/coders/VecCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/VecCoder.ts
@@ -2,13 +2,12 @@ import { ErrorCode, FuelError } from '@fuel-ts/errors';
 import { bn } from '@fuel-ts/math';
 import { concatBytes } from '@fuel-ts/utils';
 
-import { MAX_BYTES, WORD_SIZE } from '../../utils/constants';
+import { MAX_BYTES, OPTION_CODER_TYPE, WORD_SIZE } from '../../utils/constants';
 import { isUint8Array } from '../../utils/utilities';
 
 import { Coder } from './AbstractCoder';
 import type { TypesOfCoder } from './AbstractCoder';
 import { BigNumberCoder } from './BigNumberCoder';
-import { OptionCoder } from './OptionCoder';
 
 type InputValueOf<TCoder extends Coder> = Array<TypesOfCoder<TCoder>['Input']> | Uint8Array;
 type DecodedValueOf<TCoder extends Coder> = Array<TypesOfCoder<TCoder>['Decoded']>;
@@ -18,12 +17,12 @@ export class VecCoder<TCoder extends Coder> extends Coder<
   DecodedValueOf<TCoder>
 > {
   coder: TCoder;
-  #isOptionVec: boolean;
+  #hasNestedOption: boolean;
 
   constructor(coder: TCoder) {
     super('struct', `struct Vec`, coder.encodedLength + WORD_SIZE);
     this.coder = coder;
-    this.#isOptionVec = this.coder instanceof OptionCoder;
+    this.#hasNestedOption = coder.type === OPTION_CODER_TYPE;
   }
 
   encode(value: InputValueOf<TCoder>): Uint8Array {
@@ -47,7 +46,7 @@ export class VecCoder<TCoder extends Coder> extends Coder<
   }
 
   decode(data: Uint8Array, offset: number): [DecodedValueOf<TCoder>, number] {
-    if (!this.#isOptionVec && (data.length < this.encodedLength || data.length > MAX_BYTES)) {
+    if (!this.#hasNestedOption && (data.length < this.encodedLength || data.length > MAX_BYTES)) {
       throw new FuelError(ErrorCode.DECODE_ERROR, `Invalid vec data size.`);
     }
 
@@ -57,7 +56,7 @@ export class VecCoder<TCoder extends Coder> extends Coder<
     const dataLength = length * this.coder.encodedLength;
     const dataBytes = data.slice(offsetAndLength, offsetAndLength + dataLength);
 
-    if (!this.#isOptionVec && dataBytes.length !== dataLength) {
+    if (!this.#hasNestedOption && dataBytes.length !== dataLength) {
       throw new FuelError(ErrorCode.DECODE_ERROR, `Invalid vec byte data size.`);
     }
 

--- a/packages/fuel-gauge/src/options.test.ts
+++ b/packages/fuel-gauge/src/options.test.ts
@@ -1,0 +1,151 @@
+import type { Contract } from 'fuels';
+
+import { getSetupContract } from './utils';
+
+const U8_MAX = 255;
+const U16_MAX = 65535;
+const U32_MAX = 4294967295;
+
+const setupContract = getSetupContract('options');
+let contractInstance: Contract;
+beforeAll(async () => {
+  contractInstance = await setupContract();
+});
+
+/**
+ * @group node
+ */
+describe('Options Tests', () => {
+  it('echos u8 option', async () => {
+    const someInput = U8_MAX;
+    const noneInput = undefined;
+
+    const { value: someValue } = await contractInstance.functions.echo_option(someInput).call();
+
+    expect(someValue).toBe(someInput);
+
+    const { value: noneValue } = await contractInstance.functions.echo_option(noneInput).call();
+
+    expect(noneValue).toBe(noneInput);
+  });
+
+  it('echos struct enum option', async () => {
+    const someInput = {
+      one: {
+        a: U8_MAX,
+      },
+      two: U32_MAX,
+    };
+
+    const { value: someValue } = await contractInstance.functions
+      .echo_struct_enum_option(someInput)
+      .call();
+
+    expect(someValue).toStrictEqual(someInput);
+
+    const noneInput = {
+      one: {
+        a: undefined,
+      },
+      two: undefined,
+    };
+
+    const { value: noneValue } = await contractInstance.functions
+      .echo_struct_enum_option(noneInput)
+      .call();
+
+    expect(noneValue).toStrictEqual(noneInput);
+  });
+
+  it('echos vec option', async () => {
+    const someInput = [U8_MAX, U16_MAX, U32_MAX];
+
+    const { value: someValue } = await contractInstance.functions.echo_vec_option(someInput).call();
+
+    expect(someValue).toStrictEqual(someInput);
+
+    const noneInput = [undefined, undefined, undefined];
+
+    const { value: noneValue } = await contractInstance.functions.echo_vec_option(noneInput).call();
+
+    expect(noneValue).toStrictEqual(noneInput);
+
+    const mixedInput = [U8_MAX, undefined, U32_MAX];
+
+    const { value: mixedValue } = await contractInstance.functions
+      .echo_vec_option(mixedInput)
+      .call();
+
+    expect(mixedValue).toStrictEqual(mixedInput);
+  });
+
+  it('echos tuple option', async () => {
+    const someInput = [U8_MAX, U16_MAX];
+
+    const { value: someValue } = await contractInstance.functions
+      .echo_tuple_option(someInput)
+      .call();
+
+    expect(someValue).toStrictEqual(someInput);
+
+    const noneInput = [undefined, undefined];
+
+    const { value: noneValue } = await contractInstance.functions
+      .echo_tuple_option(noneInput)
+      .call();
+
+    expect(noneValue).toStrictEqual(noneInput);
+
+    const mixedInput = [U8_MAX, undefined];
+
+    const { value: mixedValue } = await contractInstance.functions
+      .echo_tuple_option(mixedInput)
+      .call();
+
+    expect(mixedValue).toStrictEqual(mixedInput);
+  });
+
+  it('echoes enum option', async () => {
+    const someInput = { a: U8_MAX };
+
+    const { value: someValue } = await contractInstance.functions
+      .echo_enum_option(someInput)
+      .call();
+
+    expect(someValue).toStrictEqual(someInput);
+
+    const noneInput = { b: undefined };
+
+    const { value: noneValue } = await contractInstance.functions
+      .echo_enum_option(noneInput)
+      .call();
+
+    expect(noneValue).toStrictEqual(noneInput);
+  });
+
+  it('echos array option', async () => {
+    const someInput = [U8_MAX, U16_MAX, 123];
+
+    const { value: someValue } = await contractInstance.functions
+      .echo_array_option(someInput)
+      .call();
+
+    expect(someValue).toStrictEqual(someInput);
+
+    const noneInput = [undefined, undefined, undefined];
+
+    const { value: noneValue } = await contractInstance.functions
+      .echo_array_option(noneInput)
+      .call();
+
+    expect(noneValue).toStrictEqual(noneInput);
+
+    const mixedInput = [U8_MAX, undefined, 123];
+
+    const { value: mixedValue } = await contractInstance.functions
+      .echo_array_option(mixedInput)
+      .call();
+
+    expect(mixedValue).toStrictEqual(mixedInput);
+  });
+});

--- a/packages/fuel-gauge/test/fixtures/forc-projects/Forc.toml
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/Forc.toml
@@ -62,4 +62,5 @@ members = [
   "vector-types-contract",
   "vector-types-script",
   "vectors",
+  "options",
 ]

--- a/packages/fuel-gauge/test/fixtures/forc-projects/options/Forc.toml
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/options/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "options"
+
+[dependencies]

--- a/packages/fuel-gauge/test/fixtures/forc-projects/options/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/options/src/main.sw
@@ -1,0 +1,46 @@
+contract;
+
+enum OptionEnum {
+    a: Option<u8>,
+    b: Option<u16>,
+}
+
+struct OptionStruct {
+    one: OptionEnum,
+    two: Option<u32>,
+}
+
+abi OptionContract {
+    fn echo_option(arg: Option<u8>) -> Option<u8>;
+    fn echo_struct_enum_option(arg: OptionStruct) -> OptionStruct;
+    fn echo_vec_option(arg: Vec<Option<u32>>) -> Vec<Option<u32>>;
+    fn echo_tuple_option(arg: (Option<u8>, Option<u16>)) -> (Option<u8>, Option<u16>);
+    fn echo_enum_option(arg: OptionEnum) -> OptionEnum;
+    fn echo_array_option(arg: [Option<u16>; 3]) -> [Option<u16>; 3];
+}
+
+impl OptionContract for Contract {
+    fn echo_option(arg: Option<u8>) -> Option<u8> {
+        arg
+    }
+
+    fn echo_struct_enum_option(arg: OptionStruct) -> OptionStruct {
+        arg
+    }
+
+    fn echo_vec_option(arg: Vec<Option<u32>>) -> Vec<Option<u32>> {
+        arg
+    }
+
+    fn echo_tuple_option(arg: (Option<u8>, Option<u16>)) -> (Option<u8>, Option<u16>) {
+        arg
+    }
+
+    fn echo_enum_option(arg: OptionEnum) -> OptionEnum {
+        arg
+    }
+
+    fn echo_array_option(arg: [Option<u16>; 3]) -> [Option<u16>; 3] {
+        arg
+    }
+}


### PR DESCRIPTION
Closes #2321 

For `v0` encoding, an option would contain a `WORD_SIZE` for the enum case key (`Some` or `None`) and the property space for the value (i.e `u64` would be another `WORD_SIZE`. Even if the value was `None`, we would still receive the expected value property space, meaning we could validate correct for both values. However in `v1`, `None` will now only return the case bytes, and no value bytes. Meaning we can no longer validate the expected byte length before checking the case value.

We are still validating at the option value level (i.e. `Option<u8>` will be validated in the `NumberCoder` so we should not be too concerned about underflow/overflow here, but there are definitely improvements that could be made, that I'll investigate [here](https://github.com/FuelLabs/fuels-ts/issues/2323). But for now, this PR will remove the invalid check for options.

### Breaking Changes: 

Any parent type that contains a nested `option` will no longer throw due to size validation.