### PR TITLE
ci: removed e2e dependance on other tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,6 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [environments]
     if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Checkout


### PR DESCRIPTION
We made the `e2e` test dependent on the `environments` tests (https://github.com/FuelLabs/fuels-ts/pull/2254), to reduce our coin consumption. Due to the [simplification](https://github.com/FuelLabs/fuels-ts/pull/2282) of our `e2e` test, we no longer consume as many coins.

This change removes that dependency to increase our pipeline throughput.