### PR TITLE
feat: disable `option` length validation at `enum Option` level

### DIFF
--- a/.changeset/kind-flowers-chew.md
+++ b/.changeset/kind-flowers-chew.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-coder": patch
+---
+
+feat: disable option size validation

--- a/.changeset/kind-flowers-chew.md
+++ b/.changeset/kind-flowers-chew.md
@@ -2,4 +2,4 @@
 "@fuel-ts/abi-coder": patch
 ---
 
-feat: disable `option` length validation
+feat: disable `option` length validation at `enum Option` level

--- a/.changeset/kind-flowers-chew.md
+++ b/.changeset/kind-flowers-chew.md
@@ -2,4 +2,4 @@
 "@fuel-ts/abi-coder": patch
 ---
 
-feat: disable option size validation
+feat: disable `option` length validation

--- a/packages/fuel-gauge/src/options.test.ts
+++ b/packages/fuel-gauge/src/options.test.ts
@@ -1,4 +1,5 @@
-import type { Contract } from 'fuels';
+import { generateTestWallet } from '@fuel-ts/account/test-utils';
+import type { Contract, WalletUnlocked } from 'fuels';
 
 import { getSetupContract } from './utils';
 
@@ -8,8 +9,12 @@ const U32_MAX = 4294967295;
 
 const setupContract = getSetupContract('options');
 let contractInstance: Contract;
+let wallet: WalletUnlocked;
 beforeAll(async () => {
   contractInstance = await setupContract();
+  wallet = await generateTestWallet(contractInstance.provider, [
+    [200_000, contractInstance.provider.getBaseAssetId()],
+  ]);
 });
 
 /**
@@ -178,5 +183,13 @@ describe('Options Tests', () => {
     const { value } = await contractInstance.functions.echo_deeply_nested_option(input).call();
 
     expect(value).toStrictEqual(input);
+  });
+
+  it('prints struct option', async () => {
+    const { value } = await contractInstance.functions
+      .get_some_struct({ Address: { bits: wallet.address.toB256() } })
+      .call();
+
+    expect(value).toStrictEqual(undefined);
   });
 });

--- a/packages/fuel-gauge/test/fixtures/forc-projects/options/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/options/src/main.sw
@@ -1,5 +1,7 @@
 contract;
 
+use {std::{auth::msg_sender, hash::Hash,},};
+
 enum OptionEnum {
     a: Option<u8>,
     b: Option<u16>,
@@ -49,7 +51,18 @@ struct DeepStruct {
     DeepEnum: DeepEnum,
 }
 
+struct SomeStruct {
+    a: u64,
+    b: u64,
+}
+
+storage {
+    stuff: StorageMap<Identity, SomeStruct> = StorageMap {},
+}
+
 abi OptionContract {
+    #[storage(read)]
+    fn get_some_struct(id: Identity) -> Option<SomeStruct>;
     fn echo_option(arg: Option<u8>) -> Option<u8>;
     fn echo_struct_enum_option(arg: OptionStruct) -> OptionStruct;
     fn echo_vec_option(arg: Vec<Option<u32>>) -> Vec<Option<u32>>;
@@ -61,6 +74,11 @@ abi OptionContract {
 }
 
 impl OptionContract for Contract {
+    #[storage(read)]
+    fn get_some_struct(id: Identity) -> Option<SomeStruct> {
+        storage.stuff.get(id).try_read()
+    }
+
     fn echo_option(arg: Option<u8>) -> Option<u8> {
         arg
     }


### PR DESCRIPTION
Closes #2335 

#2322 and #2325 removed length validation for nested options. We should also disable the enum level length validation, where the coder itself is an `enum Option`.

 