### PR TITLE
feat: support generic enums in `typegen`

### DIFF
--- a/.changeset/breezy-owls-sing.md
+++ b/.changeset/breezy-owls-sing.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-typegen": patch
+---
+
+feat: support generic enums in `typegen`

--- a/packages/abi-typegen/src/abi/types/EnumType.ts
+++ b/packages/abi-typegen/src/abi/types/EnumType.ts
@@ -87,4 +87,19 @@ export class EnumType extends AType implements IType {
 
     return contents.join(', ');
   }
+
+  public getStructDeclaration(params: { types: IType[] }) {
+    const { types } = params;
+    const { typeParameters } = this.rawAbiType;
+
+    if (typeParameters) {
+      const structs = typeParameters.map((typeId) => findType({ types, typeId }));
+
+      const labels = structs.map(({ attributes: { inputLabel } }) => inputLabel);
+
+      return `<${labels.join(', ')}>`;
+    }
+
+    return '';
+  }
 }

--- a/packages/abi-typegen/src/templates/contract/dts.hbs
+++ b/packages/abi-typegen/src/templates/contract/dts.hbs
@@ -17,15 +17,15 @@ import type { {{commonTypesInUse}} } from "./common";
 {{#if inputNativeValues}}
 export enum {{structName}}Input { {{inputNativeValues}} };
 {{else}}
-export type {{structName}}Input = Enum<{ {{inputValues}} }>;
+export type {{structName}}Input{{typeAnnotations}} = Enum<{ {{inputValues}} }>;
 {{/if}}
 {{#if outputNativeValues}}
 export enum {{structName}}Output { {{outputNativeValues}} };
 {{else}}
   {{#if recycleRef}}
-export type {{structName}}Output = {{structName}}Input;
+export type {{structName}}Output{{typeAnnotations}} = {{structName}}Input{{typeAnnotations}};
   {{else}}
-export type {{structName}}Output = Enum<{ {{outputValues}} }>;
+export type {{structName}}Output{{typeAnnotations}} = Enum<{ {{outputValues}} }>;
   {{/if}}
 {{/if}}
 {{/each}}

--- a/packages/abi-typegen/src/templates/utils/formatEnums.test.ts
+++ b/packages/abi-typegen/src/templates/utils/formatEnums.test.ts
@@ -32,6 +32,7 @@ describe('formatEnums.ts', () => {
         outputNativeValues: "a = 'a', b = 'b', c = 'c'",
         outputValues: 'a: [], b: [], c: []',
         recycleRef: true,
+        typeAnnotations: '',
       },
       {
         structName: 'MyEnum',
@@ -40,6 +41,7 @@ describe('formatEnums.ts', () => {
         outputNativeValues: undefined,
         outputValues: 'letter: LetterEnumOutput',
         recycleRef: false,
+        typeAnnotations: '',
       },
     ]);
   });

--- a/packages/abi-typegen/src/templates/utils/formatEnums.ts
+++ b/packages/abi-typegen/src/templates/utils/formatEnums.ts
@@ -14,6 +14,7 @@ export function formatEnums(params: { types: IType[] }) {
       const outputValues = et.getStructContents({ types, target: TargetEnum.OUTPUT });
       const inputNativeValues = et.getNativeEnum({ types });
       const outputNativeValues = et.getNativeEnum({ types });
+      const typeAnnotations = et.getStructDeclaration({ types });
 
       return {
         structName,
@@ -22,6 +23,7 @@ export function formatEnums(params: { types: IType[] }) {
         recycleRef: inputValues === outputValues, // reduces duplication
         inputNativeValues,
         outputNativeValues,
+        typeAnnotations,
       };
     });
 

--- a/packages/abi-typegen/test/fixtures/forc-projects/full/src/main.sw
+++ b/packages/abi-typegen/test/fixtures/forc-projects/full/src/main.sw
@@ -10,6 +10,16 @@ enum MyEnum {
     Pending: (),
 }
 
+enum GenericEnum<T1, T2> {
+    a: T1,
+    b: T2,
+}
+
+struct GenericStructWithEnum<T1, T2> {
+    a: T1,
+    b: GenericEnum<T1, T2>,
+}
+
 struct MyStruct {
     x: u8,
     y: u8,
@@ -65,6 +75,8 @@ abi MyContract {
     fn types_raw_slice(x: raw_slice) -> raw_slice;
     fn types_std_string(x: String) -> String;
     fn types_result(x: Result<u64, u32>) -> Result<u64, str[10]>;
+    fn types_generic_enum(x: GenericEnum<u8, u16>) -> GenericEnum<u8, u16>;
+    fn types_generic_struct(x: GenericStructWithEnum<u8, u16>) -> GenericStructWithEnum<u8, u16>;
 }
 
 impl MyContract for Contract {
@@ -160,5 +172,11 @@ impl MyContract for Contract {
             Ok(value) => Ok(value),
             Err(MyContractError::DivisionByZero) => Err(__to_str_array("DivisError")),
         }
+    }
+    fn types_generic_enum(x: GenericEnum<u8, u16>) -> GenericEnum<u8, u16> {
+        x
+    }
+    fn types_generic_struct(x: GenericStructWithEnum<u8, u16>) -> GenericStructWithEnum<u8, u16> {
+        x
     }
 }

--- a/packages/abi-typegen/test/fixtures/templates/contract/dts.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/contract/dts.hbs
@@ -26,11 +26,15 @@ import type {
 
 import type { Option, Enum, Vec, Result } from "./common";
 
+export type GenericEnumInput<T1, T2> = Enum<{ a: T1, b: T2 }>;
+export type GenericEnumOutput<T1, T2> = GenericEnumInput<T1, T2>;
 export enum MyEnumInput { Checked = 'Checked', Pending = 'Pending' };
 export enum MyEnumOutput { Checked = 'Checked', Pending = 'Pending' };
 
 export type AssetIdInput = { bits: string };
 export type AssetIdOutput = AssetIdInput;
+export type GenericStructWithEnumInput<T1, T2> = { a: T1, b: GenericEnumInput<T1, T2> };
+export type GenericStructWithEnumOutput<T1, T2> = { a: T1, b: GenericEnumOutput<T1, T2> };
 export type MyStructInput = { x: BigNumberish, y: BigNumberish, state: MyEnumInput };
 export type MyStructOutput = { x: number, y: number, state: MyEnumOutput };
 export type RawBytesInput = { ptr: BigNumberish, cap: BigNumberish };
@@ -50,6 +54,8 @@ interface MyContractAbiInterface extends Interface {
     types_empty_then_value: FunctionFragment;
     types_enum: FunctionFragment;
     types_evm_address: FunctionFragment;
+    types_generic_enum: FunctionFragment;
+    types_generic_struct: FunctionFragment;
     types_option: FunctionFragment;
     types_option_geo: FunctionFragment;
     types_raw_slice: FunctionFragment;
@@ -80,6 +86,8 @@ interface MyContractAbiInterface extends Interface {
   encodeFunctionData(functionFragment: 'types_empty_then_value', values: [BigNumberish]): Uint8Array;
   encodeFunctionData(functionFragment: 'types_enum', values: [MyEnumInput]): Uint8Array;
   encodeFunctionData(functionFragment: 'types_evm_address', values: [EvmAddress]): Uint8Array;
+  encodeFunctionData(functionFragment: 'types_generic_enum', values: [GenericEnumInput<BigNumberish, BigNumberish>]): Uint8Array;
+  encodeFunctionData(functionFragment: 'types_generic_struct', values: [GenericStructWithEnumInput<BigNumberish, BigNumberish>]): Uint8Array;
   encodeFunctionData(functionFragment: 'types_option', values: [Option<BigNumberish>]): Uint8Array;
   encodeFunctionData(functionFragment: 'types_option_geo', values: [Option<MyStructInput>]): Uint8Array;
   encodeFunctionData(functionFragment: 'types_raw_slice', values: [RawSlice]): Uint8Array;
@@ -109,6 +117,8 @@ interface MyContractAbiInterface extends Interface {
   decodeFunctionData(functionFragment: 'types_empty_then_value', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'types_enum', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'types_evm_address', data: BytesLike): DecodedValue;
+  decodeFunctionData(functionFragment: 'types_generic_enum', data: BytesLike): DecodedValue;
+  decodeFunctionData(functionFragment: 'types_generic_struct', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'types_option', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'types_option_geo', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'types_raw_slice', data: BytesLike): DecodedValue;
@@ -142,6 +152,8 @@ export class MyContractAbi extends Contract {
     types_empty_then_value: InvokeFunction<[y: BigNumberish], void>;
     types_enum: InvokeFunction<[x: MyEnumInput], MyEnumOutput>;
     types_evm_address: InvokeFunction<[x: EvmAddress], EvmAddress>;
+    types_generic_enum: InvokeFunction<[x: GenericEnumInput<BigNumberish, BigNumberish>], GenericEnumOutput<number, number>>;
+    types_generic_struct: InvokeFunction<[x: GenericStructWithEnumInput<BigNumberish, BigNumberish>], GenericStructWithEnumOutput<number, number>>;
     types_option: InvokeFunction<[x: Option<BigNumberish>], Option<number>>;
     types_option_geo: InvokeFunction<[x: Option<MyStructInput>], Option<MyStructOutput>>;
     types_raw_slice: InvokeFunction<[x: RawSlice], RawSlice>;


### PR DESCRIPTION
 I found this issue after running `pnpm tsc --noEmit` on typegen outputs of our `fuel-gauge` test suite.