### PR TITLE
fix: `typegen` generic enums and `./common` import (predicates, scripts)

### DIFF
--- a/.changeset/fast-deers-turn.md
+++ b/.changeset/fast-deers-turn.md
@@ -2,4 +2,4 @@
 "@fuel-ts/abi-typegen": patch
 ---
 
-fix: `typegen` generic enums and `./common` import for predicates and scripts
+fix: `typegen` generic enums and `./common` import (predicates, scripts)

--- a/.changeset/fast-deers-turn.md
+++ b/.changeset/fast-deers-turn.md
@@ -2,4 +2,4 @@
 "@fuel-ts/abi-typegen": patch
 ---
 
-fix: `typegen` predicates and scripts not importing from `./common`
+fix: `typegen` generic enums and `./common` import for predicates and scripts

--- a/.changeset/fast-deers-turn.md
+++ b/.changeset/fast-deers-turn.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-typegen": patch
+---
+
+fix: `typegen` predicates and scripts not importing from `./common`

--- a/packages/abi-typegen/src/runTypegen.test.ts
+++ b/packages/abi-typegen/src/runTypegen.test.ts
@@ -189,7 +189,7 @@ describe('runTypegen.js', () => {
     // validates execution was ok
     expect(error).toBeFalsy();
 
-    expect(stdoutWrite).toHaveBeenCalledTimes(4);
+    expect(stdoutWrite).toHaveBeenCalledTimes(5);
   });
 
   test('should raise error for non-existent Script BIN file', async () => {

--- a/packages/abi-typegen/src/templates/predicate/factory.hbs
+++ b/packages/abi-typegen/src/templates/predicate/factory.hbs
@@ -17,15 +17,15 @@ import type { {{commonTypesInUse}} } from "./common";
 {{#if inputNativeValues}}
 export enum {{structName}}Input { {{inputNativeValues}} };
 {{else}}
-export type {{structName}}Input = Enum<{ {{inputValues}} }>;
+export type {{structName}}Input{{typeAnnotations}} = Enum<{ {{inputValues}} }>;
 {{/if}}
 {{#if outputNativeValues}}
 export enum {{structName}}Output { {{outputNativeValues}} };
 {{else}}
   {{#if recycleRef}}
-export type {{structName}}Output = {{structName}}Input;
+export type {{structName}}Output{{typeAnnotations}} = {{structName}}Input{{typeAnnotations}};
   {{else}}
-export type {{structName}}Output = Enum<{ {{outputValues}} }>;
+export type {{structName}}Output{{typeAnnotations}} = Enum<{ {{outputValues}} }>;
   {{/if}}
 {{/if}}
 {{/each}}

--- a/packages/abi-typegen/src/templates/predicate/factory.hbs
+++ b/packages/abi-typegen/src/templates/predicate/factory.hbs
@@ -9,7 +9,7 @@ import {
 {{/if}}
 
 {{#if commonTypesInUse}}
-import type { {{commonTypesInUse}} } from "./common";
+import type { {{commonTypesInUse}} } from "../common";
 {{/if}}
 
 

--- a/packages/abi-typegen/src/templates/predicate/factory.ts
+++ b/packages/abi-typegen/src/templates/predicate/factory.ts
@@ -18,6 +18,7 @@ export function renderFactoryTemplate(params: { abi: Abi }) {
     rawContents,
     name: capitalizedName,
     hexlifiedBinContents: hexlifiedBinString,
+    commonTypesInUse,
   } = params.abi;
 
   const abiJsonString = JSON.stringify(rawContents, null, 2);
@@ -50,6 +51,7 @@ export function renderFactoryTemplate(params: { abi: Abi }) {
       capitalizedName,
       imports,
       formattedConfigurables,
+      commonTypesInUse: commonTypesInUse.join(', '),
     },
   });
 

--- a/packages/abi-typegen/src/templates/script/factory.hbs
+++ b/packages/abi-typegen/src/templates/script/factory.hbs
@@ -17,15 +17,15 @@ import type { {{commonTypesInUse}} } from "./common";
 {{#if inputNativeValues}}
 export enum {{structName}}Input { {{inputNativeValues}} };
 {{else}}
-export type {{structName}}Input = Enum<{ {{inputValues}} }>;
+export type {{structName}}Input{{typeAnnotations}} = Enum<{ {{inputValues}} }>;
 {{/if}}
 {{#if outputNativeValues}}
 export enum {{structName}}Output { {{outputNativeValues}} };
 {{else}}
   {{#if recycleRef}}
-export type {{structName}}Output = {{structName}}Input;
+export type {{structName}}Output{{typeAnnotations}} = {{structName}}Input{{typeAnnotations}};
   {{else}}
-export type {{structName}}Output = Enum<{ {{outputValues}} }>;
+export type {{structName}}Output{{typeAnnotations}} = Enum<{ {{outputValues}} }>;
   {{/if}}
 {{/if}}
 {{/each}}

--- a/packages/abi-typegen/src/templates/script/factory.hbs
+++ b/packages/abi-typegen/src/templates/script/factory.hbs
@@ -9,7 +9,7 @@ import {
 {{/if}}
 
 {{#if commonTypesInUse}}
-import type { {{commonTypesInUse}} } from "./common";
+import type { {{commonTypesInUse}} } from "../common";
 {{/if}}
 
 

--- a/packages/abi-typegen/src/templates/script/factory.ts
+++ b/packages/abi-typegen/src/templates/script/factory.ts
@@ -18,6 +18,7 @@ export function renderFactoryTemplate(params: { abi: Abi }) {
     rawContents,
     name: capitalizedName,
     hexlifiedBinContents: hexlifiedBinString,
+    commonTypesInUse,
   } = params.abi;
 
   const abiJsonString = JSON.stringify(rawContents, null, 2);
@@ -47,6 +48,7 @@ export function renderFactoryTemplate(params: { abi: Abi }) {
       capitalizedName,
       imports,
       formattedConfigurables,
+      commonTypesInUse: commonTypesInUse.join(', '),
     },
   });
 

--- a/packages/abi-typegen/test/fixtures/forc-projects/predicate/src/main.sw
+++ b/packages/abi-typegen/test/fixtures/forc-projects/predicate/src/main.sw
@@ -5,11 +5,19 @@ struct Validation {
     total_complete: u64,
 }
 
-enum MyEnum {
-    A: (),
-    B: (),
+enum MyGenericEnum<T> {
+    a: T,
 }
 
-fn main(vec: Vec<Validation>, enm: MyEnum, opt: Option<u8>) -> bool {
+struct MyGenericStruct<T> {
+    a: T,
+}
+
+fn main(
+    vec: Vec<Validation>,
+    enm: MyGenericEnum<u16>,
+    opt: Option<u8>,
+    res: Result<MyGenericStruct<str[4]>, u64>,
+) -> bool {
     return true;
 }

--- a/packages/abi-typegen/test/fixtures/forc-projects/predicate/src/main.sw
+++ b/packages/abi-typegen/test/fixtures/forc-projects/predicate/src/main.sw
@@ -5,9 +5,11 @@ struct Validation {
     total_complete: u64,
 }
 
-fn main(received: Validation) -> bool {
-    let expected_has_account: bool = true;
-    let expected_total_complete: u64 = 100;
+enum MyEnum {
+    A: (),
+    B: (),
+}
 
-    received.has_account == expected_has_account && received.total_complete == expected_total_complete
+fn main(vec: Vec<Validation>, enm: MyEnum, opt: Option<u8>) -> bool {
+    return true;
 }

--- a/packages/abi-typegen/test/fixtures/forc-projects/script/src/main.sw
+++ b/packages/abi-typegen/test/fixtures/forc-projects/script/src/main.sw
@@ -5,11 +5,19 @@ struct Score {
     points: u8,
 }
 
-enum MyEnum {
-    A: (),
-    B: (),
+enum MyGenericEnum<T> {
+    a: T,
 }
 
-fn main(vec: Vec<Score>, enm: MyEnum, opt: Option<u8>) -> bool {
+struct MyGenericStruct<T> {
+    a: T,
+}
+
+fn main(
+    vec: Vec<Score>,
+    enm: MyGenericEnum<u16>,
+    opt: Option<u8>,
+    res: Result<MyGenericStruct<str[4]>, u64>,
+) -> bool {
     return true;
 }

--- a/packages/abi-typegen/test/fixtures/forc-projects/script/src/main.sw
+++ b/packages/abi-typegen/test/fixtures/forc-projects/script/src/main.sw
@@ -5,6 +5,11 @@ struct Score {
     points: u8,
 }
 
-fn main(score: Score) -> bool {
-    return true
+enum MyEnum {
+    A: (),
+    B: (),
+}
+
+fn main(vec: Vec<Score>, enm: MyEnum, opt: Option<u8>) -> bool {
+    return true;
 }

--- a/packages/abi-typegen/test/fixtures/templates/predicate/factory.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/predicate/factory.hbs
@@ -17,43 +17,152 @@ import {
   Provider,
 } from 'fuels';
 
+import type { Option, Enum, Vec } from "./common";
+
+export enum MyEnumInput { A = 'A', B = 'B' };
+export enum MyEnumOutput { A = 'A', B = 'B' };
+
 export type ValidationInput = { has_account: boolean, total_complete: BigNumberish };
 export type ValidationOutput = { has_account: boolean, total_complete: BN };
 
 export type MyPredicateAbiConfigurables = {
 };
 
-export type MyPredicateAbiInputs = [received: ValidationInput];
+export type MyPredicateAbiInputs = [vec: Vec<ValidationInput>, enm: MyEnumInput, opt: Option<BigNumberish>];
 
 const _abi = {
   "encoding": "1",
   "types": [
     {
       "typeId": 0,
+      "type": "()",
+      "components": [],
+      "typeParameters": null
+    },
+    {
+      "typeId": 1,
       "type": "bool",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 1,
-      "type": "struct Validation",
+      "typeId": 2,
+      "type": "enum MyEnum",
       "components": [
         {
-          "name": "has_account",
+          "name": "A",
           "type": 0,
           "typeArguments": null
         },
         {
-          "name": "total_complete",
-          "type": 2,
+          "name": "B",
+          "type": 0,
           "typeArguments": null
         }
       ],
       "typeParameters": null
     },
     {
-      "typeId": 2,
+      "typeId": 3,
+      "type": "enum Option",
+      "components": [
+        {
+          "name": "None",
+          "type": 0,
+          "typeArguments": null
+        },
+        {
+          "name": "Some",
+          "type": 4,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": [
+        4
+      ]
+    },
+    {
+      "typeId": 4,
+      "type": "generic T",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 5,
+      "type": "raw untyped ptr",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 6,
+      "type": "struct RawVec",
+      "components": [
+        {
+          "name": "ptr",
+          "type": 5,
+          "typeArguments": null
+        },
+        {
+          "name": "cap",
+          "type": 9,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": [
+        4
+      ]
+    },
+    {
+      "typeId": 7,
+      "type": "struct Validation",
+      "components": [
+        {
+          "name": "has_account",
+          "type": 1,
+          "typeArguments": null
+        },
+        {
+          "name": "total_complete",
+          "type": 9,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": null
+    },
+    {
+      "typeId": 8,
+      "type": "struct Vec",
+      "components": [
+        {
+          "name": "buf",
+          "type": 6,
+          "typeArguments": [
+            {
+              "name": "",
+              "type": 4,
+              "typeArguments": null
+            }
+          ]
+        },
+        {
+          "name": "len",
+          "type": 9,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": [
+        4
+      ]
+    },
+    {
+      "typeId": 9,
       "type": "u64",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 10,
+      "type": "u8",
       "components": null,
       "typeParameters": null
     }
@@ -62,15 +171,37 @@ const _abi = {
     {
       "inputs": [
         {
-          "name": "received",
-          "type": 1,
+          "name": "vec",
+          "type": 8,
+          "typeArguments": [
+            {
+              "name": "",
+              "type": 7,
+              "typeArguments": null
+            }
+          ]
+        },
+        {
+          "name": "enm",
+          "type": 2,
           "typeArguments": null
+        },
+        {
+          "name": "opt",
+          "type": 3,
+          "typeArguments": [
+            {
+              "name": "",
+              "type": 10,
+              "typeArguments": null
+            }
+          ]
         }
       ],
       "name": "main",
       "output": {
         "name": "",
-        "type": 0,
+        "type": 1,
         "typeArguments": null
       },
       "attributes": null

--- a/packages/abi-typegen/test/fixtures/templates/predicate/factory.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/predicate/factory.hbs
@@ -17,7 +17,7 @@ import {
   Provider,
 } from 'fuels';
 
-import type { Option, Enum, Vec, Result } from "./common";
+import type { Option, Enum, Vec, Result } from "../common";
 
 export type MyGenericEnumInput<T> = Enum<{ a: T }>;
 export type MyGenericEnumOutput<T> = MyGenericEnumInput<T>;

--- a/packages/abi-typegen/test/fixtures/templates/predicate/factory.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/predicate/factory.hbs
@@ -17,18 +17,20 @@ import {
   Provider,
 } from 'fuels';
 
-import type { Option, Enum, Vec } from "./common";
+import type { Option, Enum, Vec, Result } from "./common";
 
-export enum MyEnumInput { A = 'A', B = 'B' };
-export enum MyEnumOutput { A = 'A', B = 'B' };
+export type MyGenericEnumInput<T> = Enum<{ a: T }>;
+export type MyGenericEnumOutput<T> = MyGenericEnumInput<T>;
 
+export type MyGenericStructInput<T> = { a: T };
+export type MyGenericStructOutput<T> = MyGenericStructInput<T>;
 export type ValidationInput = { has_account: boolean, total_complete: BigNumberish };
 export type ValidationOutput = { has_account: boolean, total_complete: BN };
 
 export type MyPredicateAbiConfigurables = {
 };
 
-export type MyPredicateAbiInputs = [vec: Vec<ValidationInput>, enm: MyEnumInput, opt: Option<BigNumberish>];
+export type MyPredicateAbiInputs = [vec: Vec<ValidationInput>, enm: MyGenericEnumInput<BigNumberish>, opt: Option<BigNumberish>, res: Result<MyGenericStructInput<string>, BigNumberish>];
 
 const _abi = {
   "encoding": "1",
@@ -47,20 +49,17 @@ const _abi = {
     },
     {
       "typeId": 2,
-      "type": "enum MyEnum",
+      "type": "enum MyGenericEnum",
       "components": [
         {
-          "name": "A",
-          "type": 0,
-          "typeArguments": null
-        },
-        {
-          "name": "B",
-          "type": 0,
+          "name": "a",
+          "type": 6,
           "typeArguments": null
         }
       ],
-      "typeParameters": null
+      "typeParameters": [
+        6
+      ]
     },
     {
       "typeId": 3,
@@ -73,47 +72,93 @@ const _abi = {
         },
         {
           "name": "Some",
-          "type": 4,
+          "type": 6,
           "typeArguments": null
         }
       ],
       "typeParameters": [
-        4
+        6
       ]
     },
     {
       "typeId": 4,
-      "type": "generic T",
-      "components": null,
-      "typeParameters": null
+      "type": "enum Result",
+      "components": [
+        {
+          "name": "Ok",
+          "type": 6,
+          "typeArguments": null
+        },
+        {
+          "name": "Err",
+          "type": 5,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": [
+        6,
+        5
+      ]
     },
     {
       "typeId": 5,
-      "type": "raw untyped ptr",
+      "type": "generic E",
       "components": null,
       "typeParameters": null
     },
     {
       "typeId": 6,
-      "type": "struct RawVec",
+      "type": "generic T",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 7,
+      "type": "raw untyped ptr",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 8,
+      "type": "str[4]",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 9,
+      "type": "struct MyGenericStruct",
       "components": [
         {
-          "name": "ptr",
-          "type": 5,
-          "typeArguments": null
-        },
-        {
-          "name": "cap",
-          "type": 9,
+          "name": "a",
+          "type": 6,
           "typeArguments": null
         }
       ],
       "typeParameters": [
-        4
+        6
       ]
     },
     {
-      "typeId": 7,
+      "typeId": 10,
+      "type": "struct RawVec",
+      "components": [
+        {
+          "name": "ptr",
+          "type": 7,
+          "typeArguments": null
+        },
+        {
+          "name": "cap",
+          "type": 14,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": [
+        6
+      ]
+    },
+    {
+      "typeId": 11,
       "type": "struct Validation",
       "components": [
         {
@@ -123,45 +168,51 @@ const _abi = {
         },
         {
           "name": "total_complete",
-          "type": 9,
+          "type": 14,
           "typeArguments": null
         }
       ],
       "typeParameters": null
     },
     {
-      "typeId": 8,
+      "typeId": 12,
       "type": "struct Vec",
       "components": [
         {
           "name": "buf",
-          "type": 6,
+          "type": 10,
           "typeArguments": [
             {
               "name": "",
-              "type": 4,
+              "type": 6,
               "typeArguments": null
             }
           ]
         },
         {
           "name": "len",
-          "type": 9,
+          "type": 14,
           "typeArguments": null
         }
       ],
       "typeParameters": [
-        4
+        6
       ]
     },
     {
-      "typeId": 9,
+      "typeId": 13,
+      "type": "u16",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 14,
       "type": "u64",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 10,
+      "typeId": 15,
       "type": "u8",
       "components": null,
       "typeParameters": null
@@ -172,11 +223,11 @@ const _abi = {
       "inputs": [
         {
           "name": "vec",
-          "type": 8,
+          "type": 12,
           "typeArguments": [
             {
               "name": "",
-              "type": 7,
+              "type": 11,
               "typeArguments": null
             }
           ]
@@ -184,7 +235,13 @@ const _abi = {
         {
           "name": "enm",
           "type": 2,
-          "typeArguments": null
+          "typeArguments": [
+            {
+              "name": "",
+              "type": 13,
+              "typeArguments": null
+            }
+          ]
         },
         {
           "name": "opt",
@@ -192,7 +249,29 @@ const _abi = {
           "typeArguments": [
             {
               "name": "",
-              "type": 10,
+              "type": 15,
+              "typeArguments": null
+            }
+          ]
+        },
+        {
+          "name": "res",
+          "type": 4,
+          "typeArguments": [
+            {
+              "name": "",
+              "type": 9,
+              "typeArguments": [
+                {
+                  "name": "",
+                  "type": 8,
+                  "typeArguments": null
+                }
+              ]
+            },
+            {
+              "name": "",
+              "type": 14,
               "typeArguments": null
             }
           ]

--- a/packages/abi-typegen/test/fixtures/templates/script/factory.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/script/factory.hbs
@@ -16,7 +16,7 @@ import {
   Script,
 } from 'fuels';
 
-import type { Option, Enum, Vec, Result } from "./common";
+import type { Option, Enum, Vec, Result } from "../common";
 
 export type MyGenericEnumInput<T> = Enum<{ a: T }>;
 export type MyGenericEnumOutput<T> = MyGenericEnumInput<T>;

--- a/packages/abi-typegen/test/fixtures/templates/script/factory.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/script/factory.hbs
@@ -12,13 +12,19 @@
 import {
   Account,
   BigNumberish,
+  BN,
   Script,
 } from 'fuels';
+
+import type { Option, Enum, Vec } from "./common";
+
+export enum MyEnumInput { A = 'A', B = 'B' };
+export enum MyEnumOutput { A = 'A', B = 'B' };
 
 export type ScoreInput = { user: BigNumberish, points: BigNumberish };
 export type ScoreOutput = { user: number, points: number };
 
-type MyScriptAbiInputs = [score: ScoreInput];
+type MyScriptAbiInputs = [vec: Vec<ScoreInput>, enm: MyEnumInput, opt: Option<BigNumberish>];
 type MyScriptAbiOutput = boolean;
 
 const _abi = {
@@ -26,29 +32,133 @@ const _abi = {
   "types": [
     {
       "typeId": 0,
+      "type": "()",
+      "components": [],
+      "typeParameters": null
+    },
+    {
+      "typeId": 1,
       "type": "bool",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 1,
-      "type": "struct Score",
+      "typeId": 2,
+      "type": "enum MyEnum",
       "components": [
         {
-          "name": "user",
-          "type": 2,
+          "name": "A",
+          "type": 0,
           "typeArguments": null
         },
         {
-          "name": "points",
-          "type": 2,
+          "name": "B",
+          "type": 0,
           "typeArguments": null
         }
       ],
       "typeParameters": null
     },
     {
-      "typeId": 2,
+      "typeId": 3,
+      "type": "enum Option",
+      "components": [
+        {
+          "name": "None",
+          "type": 0,
+          "typeArguments": null
+        },
+        {
+          "name": "Some",
+          "type": 4,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": [
+        4
+      ]
+    },
+    {
+      "typeId": 4,
+      "type": "generic T",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 5,
+      "type": "raw untyped ptr",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 6,
+      "type": "struct RawVec",
+      "components": [
+        {
+          "name": "ptr",
+          "type": 5,
+          "typeArguments": null
+        },
+        {
+          "name": "cap",
+          "type": 9,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": [
+        4
+      ]
+    },
+    {
+      "typeId": 7,
+      "type": "struct Score",
+      "components": [
+        {
+          "name": "user",
+          "type": 10,
+          "typeArguments": null
+        },
+        {
+          "name": "points",
+          "type": 10,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": null
+    },
+    {
+      "typeId": 8,
+      "type": "struct Vec",
+      "components": [
+        {
+          "name": "buf",
+          "type": 6,
+          "typeArguments": [
+            {
+              "name": "",
+              "type": 4,
+              "typeArguments": null
+            }
+          ]
+        },
+        {
+          "name": "len",
+          "type": 9,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": [
+        4
+      ]
+    },
+    {
+      "typeId": 9,
+      "type": "u64",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 10,
       "type": "u8",
       "components": null,
       "typeParameters": null
@@ -58,15 +168,37 @@ const _abi = {
     {
       "inputs": [
         {
-          "name": "score",
-          "type": 1,
+          "name": "vec",
+          "type": 8,
+          "typeArguments": [
+            {
+              "name": "",
+              "type": 7,
+              "typeArguments": null
+            }
+          ]
+        },
+        {
+          "name": "enm",
+          "type": 2,
           "typeArguments": null
+        },
+        {
+          "name": "opt",
+          "type": 3,
+          "typeArguments": [
+            {
+              "name": "",
+              "type": 10,
+              "typeArguments": null
+            }
+          ]
         }
       ],
       "name": "main",
       "output": {
         "name": "",
-        "type": 0,
+        "type": 1,
         "typeArguments": null
       },
       "attributes": null

--- a/packages/abi-typegen/test/fixtures/templates/script/factory.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/script/factory.hbs
@@ -16,15 +16,17 @@ import {
   Script,
 } from 'fuels';
 
-import type { Option, Enum, Vec } from "./common";
+import type { Option, Enum, Vec, Result } from "./common";
 
-export enum MyEnumInput { A = 'A', B = 'B' };
-export enum MyEnumOutput { A = 'A', B = 'B' };
+export type MyGenericEnumInput<T> = Enum<{ a: T }>;
+export type MyGenericEnumOutput<T> = MyGenericEnumInput<T>;
 
+export type MyGenericStructInput<T> = { a: T };
+export type MyGenericStructOutput<T> = MyGenericStructInput<T>;
 export type ScoreInput = { user: BigNumberish, points: BigNumberish };
 export type ScoreOutput = { user: number, points: number };
 
-type MyScriptAbiInputs = [vec: Vec<ScoreInput>, enm: MyEnumInput, opt: Option<BigNumberish>];
+type MyScriptAbiInputs = [vec: Vec<ScoreInput>, enm: MyGenericEnumInput<BigNumberish>, opt: Option<BigNumberish>, res: Result<MyGenericStructInput<string>, BigNumberish>];
 type MyScriptAbiOutput = boolean;
 
 const _abi = {
@@ -44,20 +46,17 @@ const _abi = {
     },
     {
       "typeId": 2,
-      "type": "enum MyEnum",
+      "type": "enum MyGenericEnum",
       "components": [
         {
-          "name": "A",
-          "type": 0,
-          "typeArguments": null
-        },
-        {
-          "name": "B",
-          "type": 0,
+          "name": "a",
+          "type": 6,
           "typeArguments": null
         }
       ],
-      "typeParameters": null
+      "typeParameters": [
+        6
+      ]
     },
     {
       "typeId": 3,
@@ -70,95 +69,147 @@ const _abi = {
         },
         {
           "name": "Some",
-          "type": 4,
+          "type": 6,
           "typeArguments": null
         }
       ],
       "typeParameters": [
-        4
+        6
       ]
     },
     {
       "typeId": 4,
-      "type": "generic T",
-      "components": null,
-      "typeParameters": null
+      "type": "enum Result",
+      "components": [
+        {
+          "name": "Ok",
+          "type": 6,
+          "typeArguments": null
+        },
+        {
+          "name": "Err",
+          "type": 5,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": [
+        6,
+        5
+      ]
     },
     {
       "typeId": 5,
-      "type": "raw untyped ptr",
+      "type": "generic E",
       "components": null,
       "typeParameters": null
     },
     {
       "typeId": 6,
-      "type": "struct RawVec",
+      "type": "generic T",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 7,
+      "type": "raw untyped ptr",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 8,
+      "type": "str[4]",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 9,
+      "type": "struct MyGenericStruct",
       "components": [
         {
-          "name": "ptr",
-          "type": 5,
-          "typeArguments": null
-        },
-        {
-          "name": "cap",
-          "type": 9,
+          "name": "a",
+          "type": 6,
           "typeArguments": null
         }
       ],
       "typeParameters": [
-        4
+        6
       ]
     },
     {
-      "typeId": 7,
+      "typeId": 10,
+      "type": "struct RawVec",
+      "components": [
+        {
+          "name": "ptr",
+          "type": 7,
+          "typeArguments": null
+        },
+        {
+          "name": "cap",
+          "type": 14,
+          "typeArguments": null
+        }
+      ],
+      "typeParameters": [
+        6
+      ]
+    },
+    {
+      "typeId": 11,
       "type": "struct Score",
       "components": [
         {
           "name": "user",
-          "type": 10,
+          "type": 15,
           "typeArguments": null
         },
         {
           "name": "points",
-          "type": 10,
+          "type": 15,
           "typeArguments": null
         }
       ],
       "typeParameters": null
     },
     {
-      "typeId": 8,
+      "typeId": 12,
       "type": "struct Vec",
       "components": [
         {
           "name": "buf",
-          "type": 6,
+          "type": 10,
           "typeArguments": [
             {
               "name": "",
-              "type": 4,
+              "type": 6,
               "typeArguments": null
             }
           ]
         },
         {
           "name": "len",
-          "type": 9,
+          "type": 14,
           "typeArguments": null
         }
       ],
       "typeParameters": [
-        4
+        6
       ]
     },
     {
-      "typeId": 9,
+      "typeId": 13,
+      "type": "u16",
+      "components": null,
+      "typeParameters": null
+    },
+    {
+      "typeId": 14,
       "type": "u64",
       "components": null,
       "typeParameters": null
     },
     {
-      "typeId": 10,
+      "typeId": 15,
       "type": "u8",
       "components": null,
       "typeParameters": null
@@ -169,11 +220,11 @@ const _abi = {
       "inputs": [
         {
           "name": "vec",
-          "type": 8,
+          "type": 12,
           "typeArguments": [
             {
               "name": "",
-              "type": 7,
+              "type": 11,
               "typeArguments": null
             }
           ]
@@ -181,7 +232,13 @@ const _abi = {
         {
           "name": "enm",
           "type": 2,
-          "typeArguments": null
+          "typeArguments": [
+            {
+              "name": "",
+              "type": 13,
+              "typeArguments": null
+            }
+          ]
         },
         {
           "name": "opt",
@@ -189,7 +246,29 @@ const _abi = {
           "typeArguments": [
             {
               "name": "",
-              "type": 10,
+              "type": 15,
+              "typeArguments": null
+            }
+          ]
+        },
+        {
+          "name": "res",
+          "type": 4,
+          "typeArguments": [
+            {
+              "name": "",
+              "type": 9,
+              "typeArguments": [
+                {
+                  "name": "",
+                  "type": 8,
+                  "typeArguments": null
+                }
+              ]
+            },
+            {
+              "name": "",
+              "type": 14,
               "typeArguments": null
             }
           ]


### PR DESCRIPTION
 I found this issue after running `pnpm tsc --noEmit` on typegen outputs of our `fuel-gauge` test suite.