### PR TITLE
fix: `typegen` enum using specified generic

### DIFF
--- a/packages/abi-typegen/src/abi/types/EnumType.ts
+++ b/packages/abi-typegen/src/abi/types/EnumType.ts
@@ -3,6 +3,7 @@ import type { TargetEnum } from '../../types/enums/TargetEnum';
 import type { IType } from '../../types/interfaces/IType';
 import { extractStructName } from '../../utils/extractStructName';
 import { findType } from '../../utils/findType';
+import { parseTypeArguments } from '../../utils/parseTypeArguments';
 
 import { AType } from './AType';
 import { EmptyType } from './EmptyType';
@@ -75,14 +76,29 @@ export class EnumType extends AType implements IType {
     const attributeKey: 'inputLabel' | 'outputLabel' = `${target}Label`;
 
     const contents = enumComponents.map((component) => {
-      const { name, type: typeId } = component;
+      const { name, type: typeId, typeArguments } = component;
 
       if (typeId === 0) {
         return `${name}: []`;
       }
 
-      const { attributes } = findType({ types, typeId });
-      return `${name}: ${attributes[attributeKey]}`;
+      const type = findType({ types, typeId });
+      let typeDecl: string;
+
+      if (typeArguments) {
+        // recursively process child `typeArguments`
+        typeDecl = parseTypeArguments({
+          types,
+          target,
+          parentTypeId: typeId,
+          typeArguments,
+        });
+      } else {
+        // or just collect type declaration
+        typeDecl = type.attributes[attributeKey];
+      }
+
+      return `${name}: ${typeDecl}`;
     });
 
     return contents.join(', ');

--- a/packages/abi-typegen/test/fixtures/forc-projects/full/src/main.sw
+++ b/packages/abi-typegen/test/fixtures/forc-projects/full/src/main.sw
@@ -15,6 +15,11 @@ enum GenericEnum<T1, T2> {
     b: T2,
 }
 
+enum EnumWithVector {
+    num: u8,
+    vec: Vec<u8>,
+}
+
 struct GenericStructWithEnum<T1, T2> {
     a: T1,
     b: GenericEnum<T1, T2>,
@@ -65,6 +70,7 @@ abi MyContract {
     fn types_array(x: [u8; 3]) -> [u8; 3];
     fn types_tuple(x: (u8, u8, u8)) -> (u8, u8, u8);
     fn types_enum(x: MyEnum) -> MyEnum;
+    fn types_enum_with_vector(x: EnumWithVector) -> EnumWithVector;
     fn types_vector_u8(x: Vec<u8>) -> Vec<u8>;
     fn types_vector_geo(x: Vec<MyStruct>) -> Vec<MyStruct>;
     fn types_vector_option(x: Vec<StructWithMultiOption>) -> Vec<StructWithMultiOption>;
@@ -135,6 +141,10 @@ impl MyContract for Contract {
     fn types_enum(x: MyEnum) -> MyEnum {
         x
     }
+    fn types_enum_with_vector(x: EnumWithVector) -> EnumWithVector {
+        x
+    }
+
     fn types_vector_u8(x: Vec<u8>) -> Vec<u8> {
         x
     }

--- a/packages/abi-typegen/test/fixtures/templates/contract/dts.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/contract/dts.hbs
@@ -26,6 +26,8 @@ import type {
 
 import type { Option, Enum, Vec, Result } from "./common";
 
+export type EnumWithVectorInput = Enum<{ num: BigNumberish, vec: Vec<BigNumberish> }>;
+export type EnumWithVectorOutput = Enum<{ num: number, vec: Vec<number> }>;
 export type GenericEnumInput<T1, T2> = Enum<{ a: T1, b: T2 }>;
 export type GenericEnumOutput<T1, T2> = GenericEnumInput<T1, T2>;
 export enum MyEnumInput { Checked = 'Checked', Pending = 'Pending' };
@@ -53,6 +55,7 @@ interface MyContractAbiInterface extends Interface {
     types_empty: FunctionFragment;
     types_empty_then_value: FunctionFragment;
     types_enum: FunctionFragment;
+    types_enum_with_vector: FunctionFragment;
     types_evm_address: FunctionFragment;
     types_generic_enum: FunctionFragment;
     types_generic_struct: FunctionFragment;
@@ -85,6 +88,7 @@ interface MyContractAbiInterface extends Interface {
   encodeFunctionData(functionFragment: 'types_empty', values: []): Uint8Array;
   encodeFunctionData(functionFragment: 'types_empty_then_value', values: [BigNumberish]): Uint8Array;
   encodeFunctionData(functionFragment: 'types_enum', values: [MyEnumInput]): Uint8Array;
+  encodeFunctionData(functionFragment: 'types_enum_with_vector', values: [EnumWithVectorInput]): Uint8Array;
   encodeFunctionData(functionFragment: 'types_evm_address', values: [EvmAddress]): Uint8Array;
   encodeFunctionData(functionFragment: 'types_generic_enum', values: [GenericEnumInput<BigNumberish, BigNumberish>]): Uint8Array;
   encodeFunctionData(functionFragment: 'types_generic_struct', values: [GenericStructWithEnumInput<BigNumberish, BigNumberish>]): Uint8Array;
@@ -116,6 +120,7 @@ interface MyContractAbiInterface extends Interface {
   decodeFunctionData(functionFragment: 'types_empty', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'types_empty_then_value', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'types_enum', data: BytesLike): DecodedValue;
+  decodeFunctionData(functionFragment: 'types_enum_with_vector', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'types_evm_address', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'types_generic_enum', data: BytesLike): DecodedValue;
   decodeFunctionData(functionFragment: 'types_generic_struct', data: BytesLike): DecodedValue;
@@ -151,6 +156,7 @@ export class MyContractAbi extends Contract {
     types_empty: InvokeFunction<[], void>;
     types_empty_then_value: InvokeFunction<[y: BigNumberish], void>;
     types_enum: InvokeFunction<[x: MyEnumInput], MyEnumOutput>;
+    types_enum_with_vector: InvokeFunction<[x: EnumWithVectorInput], EnumWithVectorOutput>;
     types_evm_address: InvokeFunction<[x: EvmAddress], EvmAddress>;
     types_generic_enum: InvokeFunction<[x: GenericEnumInput<BigNumberish, BigNumberish>], GenericEnumOutput<number, number>>;
     types_generic_struct: InvokeFunction<[x: GenericStructWithEnumInput<BigNumberish, BigNumberish>], GenericStructWithEnumOutput<number, number>>;


### PR DESCRIPTION
 I found this issue after running `pnpm tsc --noEmit` on typegen outputs of our `fuel-gauge` test suite.