### PR TITLE
ci: fix workflow run for changeset validation on master

### DIFF
--- a/.changeset/hot-pumpkins-applaud.md
+++ b/.changeset/hot-pumpkins-applaud.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: fix workflow run for changeset validation on master

--- a/.github/workflows/pr-validate-changesets.yaml
+++ b/.github/workflows/pr-validate-changesets.yaml
@@ -2,9 +2,10 @@ name: Validate Changesets
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
+    types:
+      - opened
+      - edited
+      - synchronize
 
 permissions:
   contents: write


### PR DESCRIPTION
master is [currently failing](https://github.com/FuelLabs/fuels-ts/actions/runs/9259587381/job/25471817316) due to an [unnecessary validation of changesets](https://github.com/FuelLabs/fuels-ts/pull/2305/files#diff-900c14db30cf12f70161bd32e69363c032130443d4f052508d970d7d2fbfa472R3-R7) merged in #2035 