### PR TITLE
docs: update `@fuel-ts/errors` imports in README

### DIFF
--- a/.changeset/purple-worms-kick.md
+++ b/.changeset/purple-worms-kick.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/errors": patch
+---
+
+docs: update `@fuel-ts/errors` imports in README

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -75,7 +75,8 @@ describe('this and that' () => {
 ### External usage
 
 ```ts
-import { FuelError, Provider } from "fuels";
+import { Provider } from "fuels";
+import { FuelError } from "@fuel-ts/errors";
 
 type Locale = "pt-BR" | "bs-BA" | "en-GB";
 


### PR DESCRIPTION
This error was noticed by a user trying to import `FuelError` from `fuels` based on what's stated on [npm](https://www.npmjs.com/package/@fuel-ts/errors#external-usage)