### PR TITLE
chore: exporting `FuelError` class in umbrella package

### DIFF
--- a/.changeset/rotten-tomatoes-draw.md
+++ b/.changeset/rotten-tomatoes-draw.md
@@ -1,0 +1,5 @@
+---
+"fuels": patch
+---
+
+chore: exporting `FuelError` class in umbrella package

--- a/packages/fuels/src/index.test.ts
+++ b/packages/fuels/src/index.test.ts
@@ -10,6 +10,7 @@ describe('index.js', () => {
 
     expect(fuels.Interface).toBeTruthy();
     expect(fuels.Address).toBeTruthy();
+    expect(fuels.FuelError).toBeTruthy();
     expect(fuels.Contract).toBeTruthy();
     expect(fuels.Predicate).toBeTruthy();
     expect(fuels.Account).toBeTruthy();

--- a/packages/fuels/src/index.ts
+++ b/packages/fuels/src/index.ts
@@ -5,6 +5,7 @@ export * from '@fuel-ts/address';
 export * from '@fuel-ts/address/configs';
 export * from '@fuel-ts/contract';
 export * from '@fuel-ts/crypto';
+export * from '@fuel-ts/errors';
 export * from '@fuel-ts/hasher';
 export * from '@fuel-ts/interfaces';
 export * from '@fuel-ts/math';


### PR DESCRIPTION
 - Close #2396