### PR TITLE
fix: `enum` size validation

### DIFF
--- a/.changeset/modern-students-poke.md
+++ b/.changeset/modern-students-poke.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-coder": patch
+---
+
+fix: `enum` size validation

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    # if: false
+    if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    if: false
+    # if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/packages/abi-coder/src/encoding/coders/EnumCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/EnumCoder.ts
@@ -3,7 +3,7 @@ import { toNumber } from '@fuel-ts/math';
 import { concat } from '@fuel-ts/utils';
 import type { RequireExactlyOne } from 'type-fest';
 
-import { OPTION_CODER_TYPE, WORD_SIZE } from '../../utils/constants';
+import { OPTION_CODER_TYPE } from '../../utils/constants';
 import { hasNestedOption } from '../../utils/utilities';
 
 import type { TypesOfCoder } from './AbstractCoder';

--- a/packages/abi-coder/src/encoding/coders/EnumCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/EnumCoder.ts
@@ -36,7 +36,7 @@ export class EnumCoder<TCoders extends Record<string, Coder>> extends Coder<
   constructor(name: string, coders: TCoders) {
     const caseIndexCoder = new BigNumberCoder('u64');
     const encodedValueSize = Object.values(coders).reduce(
-      (max, coder) => Math.max(max, coder.encodedLength),
+      (min, coder) => Math.min(min, coder.encodedLength),
       0
     );
     super(`enum ${name}`, `enum ${name}`, caseIndexCoder.encodedLength + encodedValueSize);
@@ -80,7 +80,7 @@ export class EnumCoder<TCoders extends Record<string, Coder>> extends Coder<
   }
 
   decode(data: Uint8Array, offset: number): [DecodedValueOf<TCoders>, number] {
-    if (this.#shouldValidateLength && data.length < this.#encodedValueSize) {
+    if (this.#shouldValidateLength && data.length < this.encodedLength) {
       throw new FuelError(ErrorCode.DECODE_ERROR, `Invalid enum data size.`);
     }
 
@@ -93,9 +93,12 @@ export class EnumCoder<TCoders extends Record<string, Coder>> extends Coder<
         `Invalid caseIndex "${caseIndex}". Valid cases: ${Object.keys(this.coders)}.`
       );
     }
-
     const valueCoder = this.coders[caseKey];
-    const offsetAndCase = offset + WORD_SIZE;
+    const offsetAndCase = offset + this.#caseIndexCoder.encodedLength;
+
+    if (this.#shouldValidateLength && data.length < offsetAndCase + valueCoder.encodedLength) {
+      throw new FuelError(ErrorCode.DECODE_ERROR, `Invalid enum data size.`);
+    }
 
     const [decoded, newOffset] = valueCoder.decode(data, offsetAndCase);
 

--- a/packages/fuel-gauge/src/options.test.ts
+++ b/packages/fuel-gauge/src/options.test.ts
@@ -192,4 +192,26 @@ describe('Options Tests', () => {
 
     expect(value).toStrictEqual(undefined);
   });
+
+  it('echoes option enum diff sizes', async () => {
+    const { value } = await contractInstance.functions.echo_enum_diff_sizes(undefined).call();
+
+    expect(value).toStrictEqual(undefined);
+
+    const { value: value2 } = await contractInstance.functions
+      .echo_enum_diff_sizes({ a: U8_MAX })
+      .call();
+
+    expect(value2).toStrictEqual({ a: U8_MAX });
+
+    const { value: value3 } = await contractInstance.functions
+      .echo_enum_diff_sizes({
+        b: '0x9ae5b658754e096e4d681c548daf46354495a437cc61492599e33fc64dcdc30c',
+      })
+      .call();
+
+    expect(value3).toStrictEqual({
+      b: '0x9ae5b658754e096e4d681c548daf46354495a437cc61492599e33fc64dcdc30c',
+    });
+  });
 });

--- a/packages/fuel-gauge/test/fixtures/forc-projects/options/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/options/src/main.sw
@@ -56,6 +56,11 @@ struct SomeStruct {
     b: u64,
 }
 
+enum DiffSizeEnum {
+    a: u8,
+    b: b256,
+}
+
 storage {
     stuff: StorageMap<Identity, SomeStruct> = StorageMap {},
 }
@@ -71,6 +76,7 @@ abi OptionContract {
     fn echo_array_option(arg: [Option<u16>; 3]) -> [Option<u16>; 3];
     fn print_enum_option_array() -> GardenVector;
     fn echo_deeply_nested_option(arg: DeepStruct) -> DeepStruct;
+    fn echo_enum_diff_sizes(arg: Option<DiffSizeEnum>) -> Option<DiffSizeEnum>;
 }
 
 impl OptionContract for Contract {
@@ -108,6 +114,10 @@ impl OptionContract for Contract {
     }
 
     fn echo_deeply_nested_option(arg: DeepStruct) -> DeepStruct {
+        arg
+    }
+
+    fn echo_enum_diff_sizes(arg: Option<DiffSizeEnum>) -> Option<DiffSizeEnum> {
         arg
     }
 }


### PR DESCRIPTION
Currently, we are validating the size of an `enum` against the [maximum](https://github.com/FuelLabs/fuels-ts/blob/5a6ca46ef46b856db780562b455dd9d742977404/packages/abi-coder/src/encoding/coders/EnumCoder.ts#L38-L41) size of a child value. If an `enum` contains both a `u8` and a `b512` and we pass the `u8` value, we'd expect this to throw for underflow. It is not, as we are incorrectly [validating](https://github.com/FuelLabs/fuels-ts/blob/5a6ca46ef46b856db780562b455dd9d742977404/packages/abi-coder/src/encoding/coders/EnumCoder.ts#L83) against the value size rather than the `encodedLength` which does not include the case length. 

This PR now correctly checks for `encodedLength`, as well as setting this value to the size of the smallest coder. We will then do another size check once we have checked the case key, so have the actual values expected length to validate against.

> **NOTE:**  `EnumCoder` is the only coder that calculates the `encodedLength` using `reduce` on the child coders, so this will not impact other coders.