### PR TITLE
fix: stop overring user input `maxFee` at `deployContract` method

### DIFF
--- a/.changeset/fifty-bugs-build.md
+++ b/.changeset/fifty-bugs-build.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/contract": patch
+---
+
+fix: stop overring user input maxFee at `deployContract` method

--- a/.changeset/fifty-bugs-build.md
+++ b/.changeset/fifty-bugs-build.md
@@ -2,4 +2,4 @@
 "@fuel-ts/contract": patch
 ---
 
-fix: stop overring user input maxFee at `deployContract` method
+fix: stop overring user input `maxFee` at `deployContract` method

--- a/packages/contract/src/contract-factory.ts
+++ b/packages/contract/src/contract-factory.ts
@@ -148,14 +148,16 @@ export default class ContractFactory {
 
     const { maxFee: setMaxFee } = deployContractOptions;
 
-    if (isDefined(setMaxFee) && txCost.maxFee.gt(setMaxFee)) {
-      throw new FuelError(
-        ErrorCode.MAX_FEE_TOO_LOW,
-        `Max fee '${deployContractOptions.maxFee}' is lower than the required: '${txCost.maxFee}'.`
-      );
+    if (isDefined(setMaxFee)) {
+      if (txCost.maxFee.gt(setMaxFee)) {
+        throw new FuelError(
+          ErrorCode.MAX_FEE_TOO_LOW,
+          `Max fee '${deployContractOptions.maxFee}' is lower than the required: '${txCost.maxFee}'.`
+        );
+      }
+    } else {
+      transactionRequest.maxFee = txCost.maxFee;
     }
-
-    transactionRequest.maxFee = txCost.maxFee;
 
     await this.account.fund(transactionRequest, txCost);
     await this.account.sendTransaction(transactionRequest, {

--- a/packages/fuel-gauge/src/contract-factory.test.ts
+++ b/packages/fuel-gauge/src/contract-factory.test.ts
@@ -1,4 +1,4 @@
-import type { TransactionResult } from '@fuel-ts/account';
+import type { Account, TransactionResult } from '@fuel-ts/account';
 import { generateTestWallet } from '@fuel-ts/account/test-utils';
 import { FuelError, ErrorCode } from '@fuel-ts/errors';
 import { expectToThrowFuelError } from '@fuel-ts/errors/test-utils';
@@ -106,6 +106,23 @@ describe('Contract Factory', () => {
       txParameters: undefined,
       forward: undefined,
     });
+  });
+
+  it('should not override user input maxFee when calling deployContract', async () => {
+    const factory = await createContractFactory();
+    const setFee = bn(120_000);
+
+    const spy = vi.spyOn(factory.account as Account, 'sendTransaction');
+
+    await factory.deployContract({
+      maxFee: setFee,
+    });
+
+    const transactionRequestArg = spy.mock.calls[0][0];
+
+    expect(transactionRequestArg.maxFee?.toString()).toEqual(setFee.toString());
+
+    vi.restoreAllMocks();
   });
 
   it('Creates a contract with initial storage fixed var names', async () => {


### PR DESCRIPTION
- Close: https://github.com/FuelLabs/fuels-ts/issues/2519