### PR TITLE
ci: introduce github credentials for committing changesets

### DIFF
--- a/.changeset/fifty-worms-sleep.md
+++ b/.changeset/fifty-worms-sleep.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: introduce github credentials for committing changesets

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "sunday"
-    open-pull-requests-limit: 10
+      interval: "daily"
+    open-pull-requests-limit: 1
     labels:
       - "chore"
     commit-message:

--- a/.github/workflows/pr-validate-changesets.yaml
+++ b/.github/workflows/pr-validate-changesets.yaml
@@ -39,6 +39,13 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
 
+      - name: Set up .netrc file
+        run: |
+          echo "machine github.com" > $HOME/.netrc
+          echo "login github-actions[bot]" >> $HOME/.netrc
+          echo "password ${{ secrets.REPO_TOKEN }}" >> $HOME/.netrc
+          chmod 600 $HOME/.netrc
+
       - name: Commit Changeset
         run: |
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
- Closes https://github.com/FuelLabs/fuels-ts/issues/2673


# Summary
This PR creates a `.netrc` file for handling autologin for github credentials in order to be able to commit the changesets in the consequent job. 

> [!NOTE]
> - This also temporarily reduces the amount of pull requests Dependabot can open for the purposes of testing this PR over the next few days.
> - This also increases the frequency with which dependabot will open PRs.




# Checklist
- [x]  I added tests
- [ ]  I triple-checked the docs
- [x] I reviewed the entire PR myself
- [ ]  I described all breaking changes