### PR TITLE
fix: export `launchTestNode` interfaces

### DIFF
--- a/.changeset/gorgeous-donuts-stare.md
+++ b/.changeset/gorgeous-donuts-stare.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/contract": patch
+---
+
+fix: export `launchTestNode` interfaces

--- a/packages/contract/src/test-utils/launch-test-node.ts
+++ b/packages/contract/src/test-utils/launch-test-node.ts
@@ -14,7 +14,7 @@ import { mergeDeepRight } from 'ramda';
 
 import type { DeployContractOptions } from '../contract-factory';
 
-interface ContractDeployer {
+export interface ContractDeployer {
   deployContract(
     bytecode: BytesLike,
     wallet: Account,
@@ -22,7 +22,7 @@ interface ContractDeployer {
   ): Promise<Contract>;
 }
 
-interface DeployContractConfig {
+export interface DeployContractConfig {
   /**
    * Contract deployer object compatible with factories outputted by `pnpm fuels typegen`.
    */
@@ -41,7 +41,7 @@ interface DeployContractConfig {
   walletIndex?: number;
 }
 
-interface LaunchTestNodeOptions<TContractConfigs extends DeployContractConfig[]>
+export interface LaunchTestNodeOptions<TContractConfigs extends DeployContractConfig[]>
   extends LaunchCustomProviderAndGetWalletsOptions {
   /**
    * Pass in either the path to the contract's root directory to deploy the contract or use `DeployContractConfig` for more control.
@@ -51,7 +51,7 @@ interface LaunchTestNodeOptions<TContractConfigs extends DeployContractConfig[]>
 type TContracts<T extends DeployContractConfig[]> = {
   [K in keyof T]: Awaited<ReturnType<T[K]['deployer']['deployContract']>>;
 };
-interface LaunchTestNodeReturn<TFactories extends DeployContractConfig[]>
+export interface LaunchTestNodeReturn<TFactories extends DeployContractConfig[]>
   extends SetupTestProviderAndWalletsReturn {
   contracts: TContracts<TFactories>;
 }

--- a/packages/contract/src/test-utils/launch-test-node.ts
+++ b/packages/contract/src/test-utils/launch-test-node.ts
@@ -48,7 +48,7 @@ export interface LaunchTestNodeOptions<TContractConfigs extends DeployContractCo
    */
   contractsConfigs: TContractConfigs;
 }
-type TContracts<T extends DeployContractConfig[]> = {
+export type TContracts<T extends DeployContractConfig[]> = {
   [K in keyof T]: Awaited<ReturnType<T[K]['deployer']['deployContract']>>;
 };
 export interface LaunchTestNodeReturn<TFactories extends DeployContractConfig[]>


### PR DESCRIPTION
# Summary

The following code yields a compilation error*:
```ts
import { launchTestNode } from 'fuels/test-utils';

export const myHelper = async () => {
  const node = await launchTestNode();
  const doMore = 'stuff';
  return { doMore, node };
};
```
Exporting the interfaces tied to `launchTestNode` fixes the issue.

*The compilation error is:
```
Exported variable 'myHelper' has or is using name 'DeployContractConfig' from external module "/fuels-ts/packages/contract/dist/test-utils/launch-test-node" but cannot be named

Exported variable 'myHelper' has or is using name 'LaunchTestNodeReturn' from external module "/fuels-ts/packages/contract/dist/test-utils/launch-test-node" but cannot be named

⚠ Error (TS4023) | 
Exported variable myHelper has or is using name DeployContractConfig from external module 
 but cannot be named.

⚠ Error (TS4023) | 
Exported variable myHelper has or is using name LaunchTestNodeReturn from external module 
 but cannot be named.
```

# Checklist

- [ ] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [x] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
