### PR TITLE
fix: `launchTestNode` multiple contracts type inference

### DIFF
--- a/.changeset/soft-cycles-do.md
+++ b/.changeset/soft-cycles-do.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/contract": patch
+---
+
+fix: `launchTestNode` multiple contracts type inference

--- a/packages/contract/src/test-utils/launch-test-node.ts
+++ b/packages/contract/src/test-utils/launch-test-node.ts
@@ -130,14 +130,12 @@ function getWalletForDeployment(config: DeployContractConfig, wallets: WalletUnl
   return wallets[config.walletIndex];
 }
 
-export async function launchTestNode<const TFactories extends DeployContractConfig[]>(
-  {
-    providerOptions = {},
-    walletsConfig = {},
-    nodeOptions = {},
-    contractsConfigs,
-  }: Partial<LaunchTestNodeOptions<TFactories>> = {} as const
-): Promise<LaunchTestNodeReturn<TFactories>> {
+export async function launchTestNode<const TFactories extends DeployContractConfig[]>({
+  providerOptions = {},
+  walletsConfig = {},
+  nodeOptions = {},
+  contractsConfigs,
+}: Partial<LaunchTestNodeOptions<TFactories>> = {}): Promise<LaunchTestNodeReturn<TFactories>> {
   const snapshotConfig = getChainSnapshot(nodeOptions);
   const args = getFuelCoreArgs(nodeOptions);
   const { provider, wallets, cleanup } = await setupTestProviderAndWallets({

--- a/packages/contract/src/test-utils/launch-test-node.ts
+++ b/packages/contract/src/test-utils/launch-test-node.ts
@@ -130,12 +130,14 @@ function getWalletForDeployment(config: DeployContractConfig, wallets: WalletUnl
   return wallets[config.walletIndex];
 }
 
-export async function launchTestNode<TFactories extends DeployContractConfig[]>({
-  providerOptions = {},
-  walletsConfig = {},
-  nodeOptions = {},
-  contractsConfigs,
-}: Partial<LaunchTestNodeOptions<TFactories>> = {}): Promise<LaunchTestNodeReturn<TFactories>> {
+export async function launchTestNode<const TFactories extends DeployContractConfig[]>(
+  {
+    providerOptions = {},
+    walletsConfig = {},
+    nodeOptions = {},
+    contractsConfigs,
+  }: Partial<LaunchTestNodeOptions<TFactories>> = {} as const
+): Promise<LaunchTestNodeReturn<TFactories>> {
   const snapshotConfig = getChainSnapshot(nodeOptions);
   const args = getFuelCoreArgs(nodeOptions);
   const { provider, wallets, cleanup } = await setupTestProviderAndWallets({

--- a/packages/fuel-gauge/src/launch-test-node-types.test.ts
+++ b/packages/fuel-gauge/src/launch-test-node-types.test.ts
@@ -4,10 +4,10 @@ import type { AdvancedLoggingAbi, CallTestContractAbi } from '../test/typegen';
 import { AdvancedLoggingAbi__factory, CallTestContractAbi__factory } from '../test/typegen';
 import AdvancedLoggingBytecode from '../test/typegen/contracts/AdvancedLoggingAbi.hex';
 import CallTestContractBytecode from '../test/typegen/contracts/CallTestContractAbi.hex';
-    /**
-	 * @group node
-	 * @group browser
-    */
+/**
+ * @group node
+ * @group browser
+ */
 describe('type level tests for launchTestNode', () => {
   test('infers types correctly', async () => {
     using launched = await launchTestNode({

--- a/packages/fuel-gauge/src/launch-test-node-types.test.ts
+++ b/packages/fuel-gauge/src/launch-test-node-types.test.ts
@@ -4,6 +4,7 @@ import type { AdvancedLoggingAbi, CallTestContractAbi } from '../test/typegen';
 import { AdvancedLoggingAbi__factory, CallTestContractAbi__factory } from '../test/typegen';
 import AdvancedLoggingBytecode from '../test/typegen/contracts/AdvancedLoggingAbi.hex';
 import CallTestContractBytecode from '../test/typegen/contracts/CallTestContractAbi.hex';
+
 /**
  * @group node
  * @group browser

--- a/packages/fuel-gauge/src/launch-test-node-types.test.ts
+++ b/packages/fuel-gauge/src/launch-test-node-types.test.ts
@@ -1,0 +1,25 @@
+import { launchTestNode } from 'fuels/test-utils';
+
+import type { AdvancedLoggingAbi, CallTestContractAbi } from '../test/typegen';
+import { AdvancedLoggingAbi__factory, CallTestContractAbi__factory } from '../test/typegen';
+import AdvancedLoggingBytecode from '../test/typegen/contracts/AdvancedLoggingAbi.hex';
+import CallTestContractBytecode from '../test/typegen/contracts/CallTestContractAbi.hex';
+
+describe('type level tests for launchTestNode', () => {
+  test('infers types correctly', async () => {
+    using launched = await launchTestNode({
+      contractsConfigs: [
+        { deployer: AdvancedLoggingAbi__factory, bytecode: AdvancedLoggingBytecode },
+        { deployer: CallTestContractAbi__factory, bytecode: CallTestContractBytecode },
+        { deployer: AdvancedLoggingAbi__factory, bytecode: AdvancedLoggingBytecode },
+      ],
+    });
+    const {
+      contracts: [c1, c2, c3],
+    } = launched;
+
+    expectTypeOf(c1).toMatchTypeOf<AdvancedLoggingAbi>();
+    expectTypeOf(c2).toMatchTypeOf<CallTestContractAbi>();
+    expectTypeOf(c3).toMatchTypeOf<AdvancedLoggingAbi>();
+  });
+});

--- a/packages/fuel-gauge/src/launch-test-node-types.test.ts
+++ b/packages/fuel-gauge/src/launch-test-node-types.test.ts
@@ -4,7 +4,10 @@ import type { AdvancedLoggingAbi, CallTestContractAbi } from '../test/typegen';
 import { AdvancedLoggingAbi__factory, CallTestContractAbi__factory } from '../test/typegen';
 import AdvancedLoggingBytecode from '../test/typegen/contracts/AdvancedLoggingAbi.hex';
 import CallTestContractBytecode from '../test/typegen/contracts/CallTestContractAbi.hex';
-
+    /**
+	 * @group node
+	 * @group browser
+    */
 describe('type level tests for launchTestNode', () => {
   test('infers types correctly', async () => {
     using launched = await launchTestNode({


### PR DESCRIPTION
- closes #2754

# Summary

Contracts inferred from an array of factories were inferred as a discriminated union of all factory contract returns instead of matching the sequence of contract factories in the `contractConfigs` array:
```ts
using launched = await launchTestNode({
  contractsConfigs: [
    { deployer: AdvancedLoggingAbi__factory, bytecode: '' },
    { deployer: CallTestContractAbi__factory, bytecode: '' },
  ],
});

const {
  contracts: [c1, c2],
} = launched;

// before: c1 and c2 are both AdvancedLoggingAbi | CallTestContractAbi
// after: c1 is AdvancedLoggingAbi, c2 is CallTestContractAbi
```

# Checklist

- [ ] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [x] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
