### PR TITLE
chore: fix connectors doc

### DIFF
--- a/apps/docs/src/guide/wallets/connectors.md
+++ b/apps/docs/src/guide/wallets/connectors.md
@@ -6,8 +6,8 @@ By using these connectors, developers can simplify wallet integration and enable
 
 ## Learning Resources
 
-For a deeper understanding of `Fuel Wallet Connectors` and how to start using them in your projects, consider the following resources:
+For a deeper understanding of `Fuel Connectors` and how to start using them in your projects, consider the following resources:
 
-- [**Fuel Wallet Connectors Wiki**](https://github.com/FuelLabs/fuels-wallet/wiki/Fuel-Wallet-Connectors) - read about what is `Fuel Wallet Connector` and how it works.
+- [**Fuel Connectors Wiki**](https://github.com/FuelLabs/fuel-connectors/wiki) - read about what is a `Fuel Connector` and how it works.
 - [**Fuel Connectors Guide**](https://docs.fuel.network/docs/wallet/dev/connectors/) - find out how to set up and use connectors.
 - [**GitHub Repository**](https://github.com/FuelLabs/fuel-connectors) - explore different connector implementations.

--- a/apps/docs/src/guide/wallets/connectors.md
+++ b/apps/docs/src/guide/wallets/connectors.md
@@ -8,6 +8,6 @@ By using these connectors, developers can simplify wallet integration and enable
 
 For a deeper understanding of `Fuel Connectors` and how to start using them in your projects, consider the following resources:
 
-- [**Fuel Connectors Wiki**](https://github.com/FuelLabs/fuel-connectors/wiki) - read about what is a `Fuel Connector` and how it works.
+- [**Fuel Connectors Wiki**](https://github.com/FuelLabs/fuel-connectors/wiki) - read about what a `Fuel Connector` is and how it works.
 - [**Fuel Connectors Guide**](https://docs.fuel.network/docs/wallet/dev/connectors/) - find out how to set up and use connectors.
 - [**GitHub Repository**](https://github.com/FuelLabs/fuel-connectors) - explore different connector implementations.


### PR DESCRIPTION
# Summary

Replace dead link. Previous link don't exist anymore because the Fuel Connectors wiki page was moved to https://github.com/FuelLabs/fuel-connectors repository.

# Checklist

- [ ] I **_added_** — `tests` to prove my changes
- [x] I **_updated_** — all the necessary `docs`
- [x] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
