### PR TITLE
fix: `create-fuels` install dependencies by default

### DIFF
--- a/.changeset/rare-ducks-sort.md
+++ b/.changeset/rare-ducks-sort.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: `create-fuels` install dependencies by default

--- a/packages/create-fuels/src/cli.ts
+++ b/packages/create-fuels/src/cli.ts
@@ -118,7 +118,7 @@ export const runScaffoldCli = async ({
 
   fileCopySpinner.succeed('Copied template files!');
 
-  if (opts['no-install'] === false) {
+  if (opts.install) {
     const installDepsSpinner = ora({
       text: 'Installing dependencies..',
       color: 'green',

--- a/packages/create-fuels/src/lib/setupProgram.test.ts
+++ b/packages/create-fuels/src/lib/setupProgram.test.ts
@@ -11,6 +11,7 @@ describe('setupProgram', () => {
     expect(program.opts().pnpm).toBe(true);
     expect(program.opts().npm).toBe(true);
     expect(program.opts().bun).toBe(true);
+    expect(program.opts().install).toBe(true);
   });
 
   test('setupProgram - no args', () => {
@@ -19,5 +20,12 @@ describe('setupProgram', () => {
     expect(program.opts().pnpm).toBe(undefined);
     expect(program.opts().npm).toBe(undefined);
     expect(program.opts().bun).toBe(undefined);
+    expect(program.opts().install).toBe(true);
+  });
+
+  test('setupProgram - `--no-install`', () => {
+    const program = setupProgram();
+    program.parse(['', '', 'test-project-name', '--no-install']);
+    expect(program.opts().install).toBe(false);
   });
 });

--- a/packages/create-fuels/src/lib/setupProgram.ts
+++ b/packages/create-fuels/src/lib/setupProgram.ts
@@ -10,7 +10,7 @@ export interface ProgramOptions {
   npm?: boolean;
   bun?: boolean;
   verbose?: boolean;
-  'no-install'?: boolean;
+  install?: boolean;
 }
 
 export const setupProgram = () => {
@@ -21,7 +21,7 @@ export const setupProgram = () => {
     .option('--npm', 'Use npm to install dependencies')
     .option('--bun', 'Use bun to install dependencies')
     .option('--verbose', 'Enable verbose logging')
-    .option('--no-install', `Do not install dependencies after scaffolding`, false)
+    .option('--no-install', 'Do not install dependencies')
     .addHelpCommand()
     .showHelpAfterError(true);
   return program;


### PR DESCRIPTION
- Closes #2778

# Summary

-  `create-fuels` now installs dependencies by default

# Checklist

- [X] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [X] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
