### PR TITLE
fix: allow setting min gas price in `launchNode` args

### DIFF
--- a/.changeset/mighty-crews-vanish.md
+++ b/.changeset/mighty-crews-vanish.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-fix: support minimum gas price in args
+fix: allow setting min gas price in `launchNode` args

--- a/.changeset/mighty-crews-vanish.md
+++ b/.changeset/mighty-crews-vanish.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: support minimum gas price in args

--- a/packages/account/src/providers/provider.test.ts
+++ b/packages/account/src/providers/provider.test.ts
@@ -1072,18 +1072,17 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     });
   });
 
-  // TODO: validate if this test still makes sense
-  it.skip('should ensure estimated fee values on getTransactionCost are never 0', async () => {
-    using launched = await setupTestProviderAndWallets();
+  it('should ensure estimated fee values on getTransactionCost are never 0', async () => {
+    using launched = await setupTestProviderAndWallets({
+      nodeOptions: { args: ['--min-gas-price', '0'] },
+    });
     const { provider } = launched;
+
     const request = new ScriptTransactionRequest();
 
-    // forcing calculatePriceWithFactor to return 0
-    const calculateGasFeeMock = vi.spyOn(gasMod, 'calculateGasFee').mockReturnValue(bn(0));
+    const { minFee, maxFee, gasPrice } = await provider.getTransactionCost(request);
 
-    const { minFee, maxFee } = await provider.getTransactionCost(request);
-
-    expect(calculateGasFeeMock).toHaveBeenCalled();
+    expect(gasPrice.eq(0)).toBeTruthy();
 
     expect(maxFee.eq(0)).not.toBeTruthy();
     expect(minFee.eq(0)).not.toBeTruthy();

--- a/packages/account/src/test-utils/launchNode.ts
+++ b/packages/account/src/test-utils/launchNode.ts
@@ -129,6 +129,8 @@ export const launchNode = async ({
       '--consensus-key',
       '--db-type',
       '--poa-instant',
+      '--min-gas-price',
+      '--native-executor-version',
     ]);
 
     const snapshotDir = getFlagValueFromArgs(args, '--snapshot');

--- a/packages/account/src/test-utils/launchNode.ts
+++ b/packages/account/src/test-utils/launchNode.ts
@@ -142,6 +142,8 @@ export const launchNode = async ({
 
     const nativeExecutorVersion = getFlagValueFromArgs(args, '--native-executor-version') || '0';
 
+    const minGasPrice = getFlagValueFromArgs(args, '--min-gas-price') || '1';
+
     // This string is logged by the client when the node has successfully started. We use it to know when to resolve.
     const graphQLStartSubstring = 'Binding GraphQL provider to';
 
@@ -194,7 +196,7 @@ export const launchNode = async ({
         ['--ip', ipToUse],
         ['--port', portToUse],
         useInMemoryDb ? ['--db-type', 'in-memory'] : ['--db-path', tempDir],
-        ['--min-gas-price', '1'],
+        ['--min-gas-price', minGasPrice],
         poaInstant ? ['--poa-instant', 'true'] : [],
         ['--native-executor-version', nativeExecutorVersion],
         ['--consensus-key', consensusKey],


### PR DESCRIPTION
- Closes #2813 

# Summary
In the previous solution, the `minGasPrice` was already defined by default. This PR fixes it by basing it on the `params`.
# Checklist

- [x] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [ ] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
