### PR TITLE
chore!: remove `awaitExecution` functionality

### DIFF
--- a/.changeset/cyan-doors-tickle.md
+++ b/.changeset/cyan-doors-tickle.md
@@ -4,4 +4,4 @@
 "@fuel-ts/program": minor
 ---
 
-chore!: remove awaitExecution functionality
+chore!: remove `awaitExecution` functionality

--- a/.changeset/cyan-doors-tickle.md
+++ b/.changeset/cyan-doors-tickle.md
@@ -1,0 +1,7 @@
+---
+"@fuel-ts/contract": minor
+"@fuel-ts/account": minor
+"@fuel-ts/program": minor
+---
+
+chore!: remove awaitExecution functionality

--- a/apps/docs-snippets/src/utils.ts
+++ b/apps/docs-snippets/src/utils.ts
@@ -42,7 +42,8 @@ export const getTestWallet = async (seedQuantities?: CoinQuantityLike[]) => {
   // funding the transaction with the required quantities
   await genesisWallet.fund(request, txCost);
 
-  await genesisWallet.sendTransaction(request, { awaitExecution: true });
+  const submit = await genesisWallet.sendTransaction(request);
+  await submit.waitForResult();
 
   // return the test wallet
   return testWallet;

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -580,7 +580,7 @@ export class Account extends AbstractAccount {
    */
   async sendTransaction(
     transactionRequestLike: TransactionRequestLike,
-    { estimateTxDependencies = true, awaitExecution }: ProviderSendTxParams = {}
+    { estimateTxDependencies = true }: ProviderSendTxParams = {}
   ): Promise<TransactionResponse> {
     if (this._connector) {
       return this.provider.getTransactionResponse(
@@ -592,7 +592,6 @@ export class Account extends AbstractAccount {
       await this.provider.estimateTxDependencies(transactionRequest);
     }
     return this.provider.sendTransaction(transactionRequest, {
-      awaitExecution,
       estimateTxDependencies: false,
     });
   }

--- a/packages/account/src/test-utils/seedTestWallet.ts
+++ b/packages/account/src/test-utils/seedTestWallet.ts
@@ -35,5 +35,6 @@ export const seedTestWallet = async (
 
   await genesisWallet.fund(request, txCost);
 
-  await genesisWallet.sendTransaction(request, { awaitExecution: true });
+  const submit = await genesisWallet.sendTransaction(request);
+  await submit.waitForResult();
 };

--- a/packages/account/src/wallet/base-wallet-unlocked.ts
+++ b/packages/account/src/wallet/base-wallet-unlocked.ts
@@ -108,12 +108,11 @@ export class BaseWalletUnlocked extends Account {
    *
    * @param transactionRequestLike - The transaction request to send.
    * @param estimateTxDependencies - Whether to estimate the transaction dependencies.
-   * @param awaitExecution - Whether to wait for the transaction to be executed.
    * @returns A promise that resolves to the TransactionResponse object.
    */
   async sendTransaction(
     transactionRequestLike: TransactionRequestLike,
-    { estimateTxDependencies = false, awaitExecution }: ProviderSendTxParams = {}
+    { estimateTxDependencies = false }: ProviderSendTxParams = {}
   ): Promise<TransactionResponse> {
     const transactionRequest = transactionRequestify(transactionRequestLike);
     if (estimateTxDependencies) {
@@ -121,7 +120,7 @@ export class BaseWalletUnlocked extends Account {
     }
     return this.provider.sendTransaction(
       await this.populateTransactionWitnessesSignature(transactionRequest),
-      { awaitExecution, estimateTxDependencies: false }
+      { estimateTxDependencies: false }
     );
   }
 

--- a/packages/contract/src/contract-factory.ts
+++ b/packages/contract/src/contract-factory.ts
@@ -165,9 +165,7 @@ export default class ContractFactory {
 
     const account = this.getAccount();
 
-    const transactionResponse = await account.sendTransaction(transactionRequest, {
-      awaitExecution: false,
-    });
+    const transactionResponse = await account.sendTransaction(transactionRequest);
 
     const waitForResult = async () => {
       const transactionResult = await transactionResponse.waitForResult<TransactionType.Create>();

--- a/packages/fuel-gauge/src/await-execution.test.ts
+++ b/packages/fuel-gauge/src/await-execution.test.ts
@@ -34,7 +34,8 @@ describe('await-execution', () => {
       await genesisWallet.signTransaction(transfer)
     );
 
-    const response = await provider.sendTransaction(transfer, { awaitExecution: true });
+    const response = await provider.sendTransaction(transfer);
+    await response.waitForResult();
 
     expect(response.gqlTransaction?.status?.type).toBe('SuccessStatus');
   });

--- a/packages/fuel-gauge/src/predicate/utils/predicate/fundPredicate.ts
+++ b/packages/fuel-gauge/src/predicate/utils/predicate/fundPredicate.ts
@@ -23,7 +23,8 @@ export const fundPredicate = async <T extends InputValue[]>(
   request.maxFee = txCost.maxFee;
   await wallet.fund(request, txCost);
 
-  await wallet.sendTransaction(request, { awaitExecution: true });
+  const submit = await wallet.sendTransaction(request);
+  await submit.waitForResult();
 
   return predicate.getBalance();
 };

--- a/packages/fuel-gauge/src/transaction-response.test.ts
+++ b/packages/fuel-gauge/src/transaction-response.test.ts
@@ -288,7 +288,8 @@ describe('TransactionResponse', () => {
 
       await expectToThrowFuelError(
         async () => {
-          await provider.sendTransaction(request, { awaitExecution: true });
+          const submit = await provider.sendTransaction(request);
+          await submit.waitForResult();
         },
         { code: ErrorCode.TRANSACTION_SQUEEZED_OUT }
       );

--- a/packages/program/src/functions/base-invocation-scope.ts
+++ b/packages/program/src/functions/base-invocation-scope.ts
@@ -383,7 +383,6 @@ export class BaseInvocationScope<TReturn = any> {
     const transactionRequest = await this.fundWithRequiredCoins();
 
     const response = (await this.program.account.sendTransaction(transactionRequest, {
-      awaitExecution: false,
       estimateTxDependencies: false,
     })) as TransactionResponse;
 


### PR DESCRIPTION
- Closes https://github.com/FuelLabs/fuels-ts/issues/2821

# Release notes

In this release, we:

- Remove the `awaitExecution` flag and its associated functionality

# Summary

This PR removes the `awaitExecution` flag and its functionality. After the changes introduced in https://github.com/FuelLabs/fuels-ts/pull/2597 and https://github.com/FuelLabs/fuels-ts/pull/2692 the SDK no longer uses this functionality internally. Although users could still manually submit transactions using the `awaitExecution` flag after https://github.com/FuelLabs/fuels-ts/pull/2597 and https://github.com/FuelLabs/fuels-ts/pull/2692, this is no longer supported.

# Breaking Changes

It is no longer possible to submit transactions using the `awaitExecution` flag and wait for the transaction to be processed at submission:

```ts
// before
await account.sendTransaction(transactionRequest, { awaitExecution: true }); 
```

```ts
// after
const submit = await account.sendTransaction(transactionRequest);

const response = await submit.waitForResult();
```

# Checklist

- [ ] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [x] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [x] I **_described_** — all breaking changes and the Migration Guide
