### PR TITLE
docs: fix `getMintedAssetId` example

### DIFF
--- a/.changeset/pink-walls-roll.md
+++ b/.changeset/pink-walls-roll.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: fix `getMintedAssetId` example

--- a/apps/docs-snippets/src/guide/contracts/minted-token-asset-id.test.ts
+++ b/apps/docs-snippets/src/guide/contracts/minted-token-asset-id.test.ts
@@ -25,7 +25,7 @@ describe(__filename, () => {
     const { waitForResult } = await contract.functions.mint_coins(subID, mintAmount).call();
     const txResult = await waitForResult();
 
-    const mintedAssetId = getMintedAssetId(subID, contract.id.toB256());
+    const mintedAssetId = getMintedAssetId(contract.id.toB256(), subID);
     // #endregion minted-token-asset-id-2
 
     expect(mintedAssetId).toBeDefined();

--- a/apps/docs-snippets/src/guide/contracts/minted-token-asset-id.test.ts
+++ b/apps/docs-snippets/src/guide/contracts/minted-token-asset-id.test.ts
@@ -1,20 +1,22 @@
-import type { Contract } from 'fuels';
 import { bn, getMintedAssetId } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
-import { DocSnippetProjectsEnum } from '../../../test/fixtures/forc-projects';
-import { createAndDeployContractFromProject } from '../../utils';
+import { TokenAbi__factory } from '../../../test/typegen';
+import TokenAbiHex from '../../../test/typegen/contracts/TokenAbi.hex';
 
 /**
  * @group node
  */
 describe(__filename, () => {
-  let contract: Contract;
-
-  beforeAll(async () => {
-    contract = await createAndDeployContractFromProject(DocSnippetProjectsEnum.TOKEN);
-  });
-
   it('should successfully execute contract call with forwarded amount', async () => {
+    using launched = await launchTestNode({
+      contractsConfigs: [{ deployer: TokenAbi__factory, bytecode: TokenAbiHex }],
+    });
+
+    const {
+      contracts: [contract],
+    } = launched;
+
     // #region minted-token-asset-id-2
     // #import { bn, getMintedAssetId };
 


### PR DESCRIPTION
# Summary

- Updated documentation to reflect the correct usage of `getMintedAssetId` - passing the `contractId` and `subId`
https://github.com/FuelLabs/fuels-ts/blob/a7ef2c59d32400316de1652a590d5d15db7daed4/packages/transactions/src/coders/receipt.ts#L770

- Using `launchTestNode` in related test.

# Checklist

- [ ] I **_added_** — `tests` to prove my changes
- [X] I **_updated_** — all the necessary `docs`
- [X] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
