### PR TITLE
fix: export interfaces in typegen

### DIFF
--- a/.changeset/three-candles-appear.md
+++ b/.changeset/three-candles-appear.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-typegen": patch
+---
+
+fix: export interfaces in typegen

--- a/packages/abi-typegen/src/templates/contract/dts.hbs
+++ b/packages/abi-typegen/src/templates/contract/dts.hbs
@@ -48,7 +48,7 @@ export type {{capitalizedName}}Configurables = Partial<{
 }>;
 {{/if}}
 
-interface {{capitalizedName}}Interface extends Interface {
+export interface {{capitalizedName}}Interface extends Interface {
   functions: {
     {{#each functionsFragments}}
     {{this}}: FunctionFragment;

--- a/packages/abi-typegen/test/fixtures/templates/contract-with-configurable/dts.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/contract-with-configurable/dts.hbs
@@ -22,7 +22,7 @@ export type MyContractAbiConfigurables = Partial<{
   SHOULD_RETURN: boolean;
 }>;
 
-interface MyContractAbiInterface extends Interface {
+export interface MyContractAbiInterface extends Interface {
   functions: {
     main: FunctionFragment;
   };

--- a/packages/abi-typegen/test/fixtures/templates/contract/dts.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/contract/dts.hbs
@@ -53,7 +53,7 @@ export type MyStructOutput = { x: number, y: number, state: MyEnumOutput };
 export type StructWithMultiOptionInput = { multiple: [Option<BigNumberish>, Option<BigNumberish>, Option<BigNumberish>, Option<BigNumberish>, Option<BigNumberish>] };
 export type StructWithMultiOptionOutput = { multiple: [Option<number>, Option<number>, Option<number>, Option<number>, Option<number>] };
 
-interface MyContractAbiInterface extends Interface {
+export interface MyContractAbiInterface extends Interface {
   functions: {
     type_address: FunctionFragment;
     type_contract_id: FunctionFragment;


### PR DESCRIPTION
- Closes #2842 

# Summary

Just prefixing the hbs file with the `export` keyword.

# Checklist

- [x] I **_added_** — `tests` to prove my changes
- [x] I **_updated_** — all the necessary `docs`
- [x] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [x] I **_described_** — all breaking changes and the Migration Guide
