### PR TITLE
fix: add back `create fuels` template metadata

### DIFF
--- a/.changeset/curly-forks-unite.md
+++ b/.changeset/curly-forks-unite.md
@@ -1,0 +1,5 @@
+---
+"create-fuels": patch
+---
+
+fix: add back `create fuels` template metadata

--- a/apps/create-fuels-counter-guide/src/app/layout.tsx
+++ b/apps/create-fuels-counter-guide/src/app/layout.tsx
@@ -45,6 +45,10 @@ export default function RootLayout({ children }: RootLayoutProps) {
 
   return (
     <html lang="en" className="bg-black text-white">
+      <head>
+        <link rel="icon" href="/fuel.ico" />
+        <title>Fuel dApp</title>
+      </head>
       <body>
         <React.StrictMode>
           <QueryClientProvider client={queryClient}>

--- a/templates/nextjs/src/app/layout.tsx
+++ b/templates/nextjs/src/app/layout.tsx
@@ -45,6 +45,10 @@ export default function RootLayout({ children }: RootLayoutProps) {
 
   return (
     <html lang="en" className="bg-black text-white">
+      <head>
+        <link rel="icon" href="/fuel.ico" />
+        <title>Fuel dApp</title>
+      </head>
       <body>
         <React.StrictMode>
           <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
- Closes #2753 

# Summary

This PR adds back the proper metadata/favicon for the template that got removed in the migration to the Next.js App router.

![image](https://github.com/user-attachments/assets/bbc7bcde-bf11-416e-988e-d605b9a476cf)

# Checklist

- [ ] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [ ] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
