### PR TITLE
chore: suppress `MemoryStore` on tests using `launchTestNode` 

### DIFF
--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -568,10 +568,22 @@ Supported fuel-core version: ${supportedVersion}.`
         if ('response' in response) {
           const graphQlResponse = response.response as GraphQLResponse;
           if (Array.isArray(graphQlResponse?.errors)) {
-            throw new FuelError(
-              FuelError.CODES.INVALID_REQUEST,
-              graphQlResponse.errors.map((err: Error) => err.message).join('\n\n')
-            );
+            const filteredErrors = graphQlResponse.errors.filter((err: Error) => {
+              if (err.message.includes('historical view is not implemented for `MemoryStore`')) {
+                console.warn(
+                  'Historical view is not implemented for MemoryStore. Some features may not work as expected.'
+                );
+                return false; // Remove this error from the list
+              }
+              return true; // Keep all other errors
+            });
+
+            if (filteredErrors.length > 0) {
+              throw new FuelError(
+                FuelError.CODES.INVALID_REQUEST,
+                filteredErrors.map((err: Error) => err.message).join('\n\n')
+              );
+            }
           }
         }
       },


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

- Closes https://github.com/FuelLabs/fuels-ts/issues/2857
# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

This PR suppresses [the error](https://github.com/FuelLabs/fuels-ts/actions/runs/10166882335/job/28118020107?pr=2811#step:5:1049) thrown in CI by `launchTestNode` on some tests regarding  the historical view not  being implemented for `MemoryStore`

# Checklist

- [ ] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [ ] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
