### PR TITLE
fix: option coder decoding incorrect value

### DIFF
--- a/packages/abi-coder/src/encoding/coders/OptionCoder.test.ts
+++ b/packages/abi-coder/src/encoding/coders/OptionCoder.test.ts
@@ -1,0 +1,53 @@
+import { NumberCoder } from './NumberCoder';
+import { OptionCoder } from './OptionCoder';
+import { VoidCoder } from './VoidCoder';
+
+describe('OptionCoder', () => {
+  const coder = new OptionCoder('Option', {
+    Some: new NumberCoder('u8'),
+    None: new VoidCoder(),
+  });
+
+  describe('encode', () => {
+    it('should encode a Some value', () => {
+      const encoded = coder.encode(100);
+
+      const expected = Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 100]);
+      expect(encoded).toEqual(expected);
+    });
+
+    it('should encode a None value', () => {
+      const encoded = coder.encode(undefined);
+
+      const expected = Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 1]);
+      expect(encoded).toEqual(expected);
+    });
+
+    it('should encode a None value [optional]', () => {
+      const encoded = coder.encode();
+
+      const expected = Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 1]);
+      expect(encoded).toEqual(expected);
+    });
+  });
+
+  describe('decode', () => {
+    it('should decode a Some value', () => {
+      const input = Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 0, 100]);
+      const expected = [100, 9];
+
+      const decoded = coder.decode(input, 0);
+
+      expect(decoded).toEqual(expected);
+    });
+
+    it('should decode a None value', () => {
+      const input = Uint8Array.from([0, 0, 0, 0, 0, 0, 0, 1]);
+      const expected = [undefined, 8];
+
+      const decoded = coder.decode(input, 0);
+
+      expect(decoded).toEqual(expected);
+    });
+  });
+});

--- a/packages/abi-coder/src/encoding/coders/OptionCoder.test.ts
+++ b/packages/abi-coder/src/encoding/coders/OptionCoder.test.ts
@@ -2,6 +2,10 @@ import { NumberCoder } from './NumberCoder';
 import { OptionCoder } from './OptionCoder';
 import { VoidCoder } from './VoidCoder';
 
+/**
+ * @group node
+ * @group browser
+ */
 describe('OptionCoder', () => {
   const coder = new OptionCoder('std::option::Option', {
     Some: new NumberCoder('u8'),

--- a/packages/abi-coder/src/encoding/coders/OptionCoder.test.ts
+++ b/packages/abi-coder/src/encoding/coders/OptionCoder.test.ts
@@ -3,7 +3,7 @@ import { OptionCoder } from './OptionCoder';
 import { VoidCoder } from './VoidCoder';
 
 describe('OptionCoder', () => {
-  const coder = new OptionCoder('Option', {
+  const coder = new OptionCoder('std::option::Option', {
     Some: new NumberCoder('u8'),
     None: new VoidCoder(),
   });

--- a/packages/abi-coder/src/encoding/coders/OptionCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/OptionCoder.ts
@@ -6,12 +6,12 @@ type SwayOption<T> = { None: [] } | { Some: T };
 export type Option<T> = T | undefined;
 
 export class OptionCoder<TCoders extends Record<string, Coder>> extends EnumCoder<TCoders> {
-  encode(value: InputValueOf<TCoders>): Uint8Array {
+  encode(value?: Option<unknown>): Uint8Array {
     const result = super.encode(this.toSwayOption(value) as unknown as InputValueOf<TCoders>);
     return result;
   }
 
-  private toSwayOption(input: InputValueOf<TCoders>): SwayOption<unknown> {
+  private toSwayOption(input?: Option<unknown>): SwayOption<unknown> {
     if (input !== undefined) {
       return { Some: input };
     }

--- a/packages/abi-coder/src/encoding/coders/OptionCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/OptionCoder.ts
@@ -25,7 +25,7 @@ export class OptionCoder<TCoders extends Record<string, Coder>> extends EnumCode
   }
 
   private toOption(output?: DecodedValueOf<TCoders>): Option<unknown> {
-    if (output && Object.hasOwn(output, 'Some')) {
+    if (output && 'Some' in output) {
       return output.Some;
     }
 

--- a/packages/abi-coder/src/encoding/coders/StructCoder.test.ts
+++ b/packages/abi-coder/src/encoding/coders/StructCoder.test.ts
@@ -13,7 +13,8 @@ import { StructCoder } from './StructCoder';
  * @group browser
  */
 describe('StructCoder', () => {
-  const coder = new StructCoder('std::vec::Vec', {
+  const STRUCT_NAME = 'TestStruct';
+  const coder = new StructCoder(STRUCT_NAME, {
     a: new BooleanCoder(),
     b: new BigNumberCoder('u64'),
   });

--- a/packages/abi-coder/src/encoding/coders/StructCoder.test.ts
+++ b/packages/abi-coder/src/encoding/coders/StructCoder.test.ts
@@ -13,8 +13,7 @@ import { StructCoder } from './StructCoder';
  * @group browser
  */
 describe('StructCoder', () => {
-  const STRUCT_NAME = 'TestStruct';
-  const coder = new StructCoder(STRUCT_NAME, {
+  const coder = new StructCoder('std::vec::Vec', {
     a: new BooleanCoder(),
     b: new BigNumberCoder('u64'),
   });

--- a/packages/abi-coder/src/encoding/strategies/getCoderV1.ts
+++ b/packages/abi-coder/src/encoding/strategies/getCoderV1.ts
@@ -23,7 +23,7 @@ import {
   VOID_TYPE,
   arrayRegEx,
   enumRegEx,
-  lastNameRegExMatch,
+  fullNameRegExMatch,
   stringRegEx,
   structRegEx,
   tupleRegEx,
@@ -130,7 +130,7 @@ export const getCoder: GetCoderFn = (
   const structMatch = structRegEx.test(resolvedAbiType.type);
   if (structMatch) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const [name] = resolvedAbiType.type.match(lastNameRegExMatch)!;
+    const [name] = resolvedAbiType.type.match(fullNameRegExMatch)!;
     const coders = getCoders(components, { getCoder });
     return new StructCoder(name, coders);
   }
@@ -138,7 +138,7 @@ export const getCoder: GetCoderFn = (
   const enumMatch = enumRegEx.test(resolvedAbiType.type);
   if (enumMatch) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const [name] = resolvedAbiType.type.match(lastNameRegExMatch)!;
+    const [name] = resolvedAbiType.type.match(fullNameRegExMatch)!;
 
     const coders = getCoders(components, { getCoder });
 

--- a/packages/abi-coder/src/utils/constants.ts
+++ b/packages/abi-coder/src/utils/constants.ts
@@ -26,7 +26,7 @@ export const enumRegEx = /^enum.+$/;
 export const tupleRegEx = /^\((?<items>.*)\)$/;
 export const genericRegEx = /^generic.+$/;
 
-export const lastNameRegExMatch = /([^:\s]+)$/m;
+export const fullNameRegExMatch = /([^\s]+)$/m;
 
 /**
  * Encoding versions


### PR DESCRIPTION
# Summary

- #2856 was throwing the following error in some test cases, which was [investigated](https://github.com/FuelLabs/fuels-ts/pull/2856/files#r1698470655). Implemented the suggested solution and all test cases are green.

```console
TypeError: Cannot use 'in' operator to search for 'Some' in None
```

- Reverted the [commit](https://github.com/FuelLabs/fuels-ts/pull/2856/commits/45f3ef2bac2999f876e1390f0670ac7df5737f8b) that "fixed" the issue.
- Pulled over the OptionCoder test from #2869 to test the change.

# Checklist

- [X] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [X] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
