### PR TITLE
chore: switching `Error` to `FuelError`

### DIFF
--- a/.changeset/silly-kids-beg.md
+++ b/.changeset/silly-kids-beg.md
@@ -1,4 +1,10 @@
 ---
+"@fuel-ts/account": patch
+"@fuel-ts/contract": patch
+"create-fuels": patch
+"fuels": patch
+"@fuel-ts/script": patch
+"@fuel-ts/utils": patch
 ---
 
-Switching `Error` to FuelError
+chore: switching `Error` to `FuelError`

--- a/.changeset/silly-kids-beg.md
+++ b/.changeset/silly-kids-beg.md
@@ -1,0 +1,4 @@
+---
+---
+
+Switching `Error` to FuelError

--- a/apps/docs/src/guide/errors/index.md
+++ b/apps/docs/src/guide/errors/index.md
@@ -24,6 +24,18 @@ When an [`Account`](../../api/Account/Account.md) is required for an operation. 
 
 It could be caused during the deployments of contracts when an account is required to sign the transaction. This can be resolved by following the deployment guide [here](../contracts/deploying-contracts.md).
 
+### `CONFIG_FILE_NOT_FOUND`
+
+When a configuration file is not found. This could either be a `fuels.config.[ts,js,mjs,cjs]` file or a Toml file.
+
+Ensure that the configuration file is present in the root directory of your project.
+
+### `CONFIG_FILE_ALREADY_EXISTS`
+
+When a configuration file already exists in the root directory of your project.
+
+You can not run `fuels init` more than once for a given project. Either remove the existing configuration file or update it.
+
 ### `CONVERTING_FAILED`
 
 When converting a big number into an incompatible format.
@@ -240,6 +252,12 @@ When the Fuel Node info cache is empty; This is usually caused by not being conn
 
 Ensure that the provider has connected to a Fuel Node successfully.
 
+### `TIMEOUT_EXCEEDED`
+
+When the timeout has been exceeded for a given operation.
+
+Check that you're connected to the network and that the network is stable.
+
 ### `TYPE_NOT_FOUND`
 
 When the type with the given type ID is not found in the ABI.
@@ -263,6 +281,12 @@ Check the version of the Fuel Node and use a compatible version of the SDK to ta
 A wallet manager will throw for a multitude of reasons. The error message will determine which element of the configuration is incorrect.
 
 It could be that the passphrase is incorrect and/or the wallet does _not_ exist in the manager.
+
+### `WORKSPACE_NOT_DETECTED`
+
+When the workspace is not detected in the directory indicated in the message.
+
+Ensure that the workspace is present in the directory specified.
 
 ### `HASHER_LOCKED`
 

--- a/packages/account/src/connectors/fuel-connector.ts
+++ b/packages/account/src/connectors/fuel-connector.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await */
+import { FuelError } from '@fuel-ts/errors';
 import { EventEmitter } from 'events';
 
 import type { TransactionRequestLike } from '../providers';
@@ -97,7 +98,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns Always true.
    */
   async ping(): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -107,7 +108,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns boolean - connection status.
    */
   async version(): Promise<Version> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -117,7 +118,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns The connection status.
    */
   async isConnected(): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -127,7 +128,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns The accounts addresses strings
    */
   async accounts(): Promise<Array<string>> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -140,7 +141,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns boolean - connection status.
    */
   async connect(): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -151,7 +152,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns The connection status.
    */
   async disconnect(): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -164,7 +165,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns Message signature
    */
   async signMessage(_address: string, _message: string): Promise<string> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -177,7 +178,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns Transaction signature
    */
   async signTransaction(_address: string, _transaction: TransactionRequestLike): Promise<string> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -194,7 +195,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns The transaction id
    */
   async sendTransaction(_address: string, _transaction: TransactionRequestLike): Promise<string> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -206,7 +207,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns The current account selected otherwise null.
    */
   async currentAccount(): Promise<string | null> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -221,7 +222,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns True if the asset was added successfully
    */
   async addAssets(_assets: Array<Asset>): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -236,7 +237,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns True if the asset was added successfully
    */
   async addAsset(_asset: Asset): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -245,7 +246,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns Array of assets metadata from the connector vinculated to the all accounts from a specific Wallet.
    */
   async assets(): Promise<Array<Asset>> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -257,7 +258,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns Return true if the network was added successfully
    */
   async addNetwork(_networkUrl: string): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -269,7 +270,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns Return true if the network was added successfully
    */
   async selectNetwork(_network: Network): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -278,7 +279,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns Return all the networks added to the connector.
    */
   async networks(): Promise<Array<Network>> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -287,7 +288,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns Return the current network selected inside the connector.
    */
   async currentNetwork(): Promise<Network> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -298,7 +299,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns Return true if the ABI was added successfully.
    */
   async addABI(_contractId: string, _abi: FuelABI): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -308,7 +309,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns The ABI if it exists, otherwise return null.
    */
   async getABI(_id: string): Promise<FuelABI | null> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**
@@ -318,7 +319,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
    * @returns Returns true if the abi exists or false if not.
    */
   async hasABI(_id: string): Promise<boolean> {
-    throw new Error('Method not implemented.');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 
   /**

--- a/packages/account/src/connectors/fuel.ts
+++ b/packages/account/src/connectors/fuel.ts
@@ -174,7 +174,8 @@ export class Fuel extends FuelConnector implements FuelSdk {
     const hasConnector = await this.hasConnector();
     await this.pingConnector();
     if (!this._currentConnector || !hasConnector) {
-      throw new Error(
+      throw new FuelError(
+        ErrorCode.MISSING_CONNECTOR,
         `No connector selected for calling ${method}. Use hasConnector before executing other methods.`
       );
     }
@@ -255,7 +256,7 @@ export class Fuel extends FuelConnector implements FuelSdk {
         cacheTime: PING_CACHE_TIME,
       })();
     } catch {
-      throw new Error('Current connector is not available.');
+      throw new FuelError(ErrorCode.INVALID_PROVIDER, 'Current connector is not available.');
     }
   }
 

--- a/packages/account/src/connectors/utils/promises.ts
+++ b/packages/account/src/connectors/utils/promises.ts
@@ -1,3 +1,5 @@
+import { FuelError } from '@fuel-ts/errors';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type DeferPromise<R = unknown> = {
   promise: Promise<R>;
@@ -23,7 +25,7 @@ export async function withTimeout<F extends Promise<unknown>, RT = Awaited<F>>(
 ): Promise<RT> {
   const timeoutPromise = new Promise((resolve, reject) => {
     setTimeout(() => {
-      reject(new Error('Promise timed out'));
+      reject(new FuelError(FuelError.CODES.TIMEOUT_EXCEEDED, 'Promise timed out'));
     }, timeout);
   });
   return Promise.race([timeoutPromise, promise]) as any;

--- a/packages/account/src/predicate/predicate.ts
+++ b/packages/account/src/predicate/predicate.ts
@@ -228,18 +228,25 @@ export class Predicate<TInputData extends InputValue[]> extends Account {
 
     try {
       if (!abiInterface) {
-        throw new Error(
+        throw new FuelError(
+          ErrorCode.INVALID_CONFIGURABLE_CONSTANTS,
           'Cannot validate configurable constants because the Predicate was instantiated without a JSON ABI'
         );
       }
 
       if (Object.keys(abiInterface.configurables).length === 0) {
-        throw new Error('Predicate has no configurable constants to be set');
+        throw new FuelError(
+          ErrorCode.INVALID_CONFIGURABLE_CONSTANTS,
+          'Predicate has no configurable constants to be set'
+        );
       }
 
       Object.entries(configurableConstants).forEach(([key, value]) => {
         if (!abiInterface?.configurables[key]) {
-          throw new Error(`No configurable constant named '${key}' found in the Predicate`);
+          throw new FuelError(
+            ErrorCode.CONFIGURABLE_NOT_FOUND,
+            `No configurable constant named '${key}' found in the Predicate`
+          );
         }
 
         const { offset } = abiInterface.configurables[key];

--- a/packages/account/src/providers/transaction-request/transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/transaction-request.ts
@@ -2,6 +2,7 @@ import { UTXO_ID_LEN } from '@fuel-ts/abi-coder';
 import { Address, addressify } from '@fuel-ts/address';
 import { ZeroBytes32 } from '@fuel-ts/address/configs';
 import { randomBytes } from '@fuel-ts/crypto';
+import { FuelError } from '@fuel-ts/errors';
 import type { AddressLike, AbstractAddress, BytesLike } from '@fuel-ts/interfaces';
 import type { BN, BigNumberish } from '@fuel-ts/math';
 import { bn } from '@fuel-ts/math';
@@ -526,7 +527,7 @@ export abstract class BaseTransactionRequest implements BaseTransactionRequestLi
    * @hidden
    */
   metadataGas(_gasCosts: GasCosts): BN {
-    throw new Error('Not implemented');
+    throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Not implemented');
   }
 
   /**

--- a/packages/contract/src/contract-factory.ts
+++ b/packages/contract/src/contract-factory.ts
@@ -187,12 +187,18 @@ export default class ContractFactory {
       const hasConfigurable = Object.keys(this.interface.configurables).length;
 
       if (!hasConfigurable) {
-        throw new Error('Contract does not have configurables to be set');
+        throw new FuelError(
+          ErrorCode.CONFIGURABLE_NOT_FOUND,
+          'Contract does not have configurables to be set'
+        );
       }
 
       Object.entries(configurableConstants).forEach(([key, value]) => {
         if (!this.interface.configurables[key]) {
-          throw new Error(`Contract does not have a configurable named: '${key}'`);
+          throw new FuelError(
+            ErrorCode.CONFIGURABLE_NOT_FOUND,
+            `Contract does not have a configurable named: '${key}'`
+          );
         }
 
         const { offset } = this.interface.configurables[key];

--- a/packages/create-fuels/src/cli.ts
+++ b/packages/create-fuels/src/cli.ts
@@ -1,3 +1,4 @@
+import { FuelError } from '@fuel-ts/errors';
 import { versions } from '@fuel-ts/versions';
 import toml from '@iarna/toml';
 import chalk from 'chalk';
@@ -62,7 +63,10 @@ export const runScaffoldCli = async ({
 
     // Exit the program if we are testing to prevent hanging
     if (process.env.VITEST) {
-      throw new Error();
+      throw new FuelError(
+        FuelError.CODES.UNKNOWN,
+        'An error occurred due to the environmental variable `VITEST` was detected.'
+      );
     }
 
     projectPath = await promptForProjectPath();
@@ -73,7 +77,10 @@ export const runScaffoldCli = async ({
 
     // Exit the program if we are testing to prevent hanging
     if (process.env.VITEST) {
-      throw new Error();
+      throw new FuelError(
+        FuelError.CODES.UNKNOWN,
+        'An error occurred due to the environmental variable `VITEST` was detected.'
+      );
     }
 
     projectPath = await promptForProjectPath();

--- a/packages/errors/src/error-codes.ts
+++ b/packages/errors/src/error-codes.ts
@@ -19,6 +19,10 @@ export enum ErrorCode {
   INVALID_DATA = 'invalid-data',
   FUNCTION_NOT_FOUND = 'function-not-found',
   UNSUPPORTED_ENCODING_VERSION = 'unsupported-encoding-version',
+  TIMEOUT_EXCEEDED = 'timeout-exceeded',
+  CONFIG_FILE_NOT_FOUND = 'config-file-not-found',
+  CONFIG_FILE_ALREADY_EXISTS = 'config-file-already-exists',
+  WORKSPACE_NOT_DETECTED = 'workspace-not-detected',
 
   // address
   INVALID_BECH32_ADDRESS = 'invalid-bech32-address',

--- a/packages/fuel-gauge/src/predicate/predicate-configurables.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-configurables.test.ts
@@ -1,5 +1,5 @@
-import { getRandomB256, WalletUnlocked, Predicate } from 'fuels';
-import { launchTestNode } from 'fuels/test-utils';
+import { getRandomB256, WalletUnlocked, Predicate, FuelError } from 'fuels';
+import { expectToThrowFuelError, launchTestNode } from 'fuels/test-utils';
 
 import {
   PredicateTrueAbi__factory,
@@ -270,18 +270,22 @@ describe('Predicate', () => {
 
       const { provider } = launched;
 
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const predicate = new Predicate({
-          bytecode: PredicateTrueAbi__factory.bin,
-          abi: PredicateTrueAbi__factory.abi,
-          provider,
-          inputData: ['NADA'],
-          configurableConstants: {
-            constant: 'NADA',
-          },
-        });
-      }).toThrow('Predicate has no configurable constants to be set');
+      await expectToThrowFuelError(
+        () =>
+          new Predicate({
+            bytecode: PredicateTrueAbi__factory.bin,
+            abi: PredicateTrueAbi__factory.abi,
+            provider,
+            inputData: ['NADA'],
+            configurableConstants: {
+              constant: 'NADA',
+            },
+          }),
+        new FuelError(
+          FuelError.CODES.INVALID_CONFIGURABLE_CONSTANTS,
+          'Error setting configurable constants: Predicate has no configurable constants to be set.'
+        )
+      );
     });
 
     it('throws when setting invalid configurable', async () => {
@@ -289,39 +293,43 @@ describe('Predicate', () => {
 
       const { provider } = launched;
 
-      const errMsg = `Error setting configurable constants: No configurable constant named 'NOPE' found in the Predicate.`;
-
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const predicate = new Predicate({
-          bytecode: PredicateWithConfigurableAbi__factory.bin,
-          abi: PredicateWithConfigurableAbi__factory.abi,
-          provider,
-          inputData: ['NADA'],
-          configurableConstants: {
-            NOPE: 'NADA',
-          },
-        });
-      }).toThrow(errMsg);
+      await expectToThrowFuelError(
+        () =>
+          new Predicate({
+            bytecode: PredicateWithConfigurableAbi__factory.bin,
+            abi: PredicateWithConfigurableAbi__factory.abi,
+            provider,
+            inputData: ['NADA'],
+            configurableConstants: {
+              NOPE: 'NADA',
+            },
+          }),
+        new FuelError(
+          FuelError.CODES.INVALID_CONFIGURABLE_CONSTANTS,
+          `Error setting configurable constants: No configurable constant named 'NOPE' found in the Predicate.`
+        )
+      );
     });
 
     it('throws when setting a configurable with no ABI', async () => {
       using launched = await launchTestNode();
 
       const { provider } = launched;
-      const errMsg = `Error setting configurable constants: Cannot validate configurable constants because the Predicate was instantiated without a JSON ABI.`;
-
-      expect(() => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const predicate = new Predicate({
-          bytecode: PredicateWithConfigurableAbi__factory.bin,
-          provider,
-          inputData: ['NADA'],
-          configurableConstants: {
-            NOPE: 'NADA',
-          },
-        });
-      }).toThrow(errMsg);
+      await expectToThrowFuelError(
+        () =>
+          new Predicate({
+            bytecode: PredicateWithConfigurableAbi__factory.bin,
+            provider,
+            inputData: ['NADA'],
+            configurableConstants: {
+              NOPE: 'NADA',
+            },
+          }),
+        new FuelError(
+          FuelError.CODES.INVALID_CONFIGURABLE_CONSTANTS,
+          `Error setting configurable constants: Cannot validate configurable constants because the Predicate was instantiated without a JSON ABI.`
+        )
+      );
     });
   });
 });

--- a/packages/fuels/src/cli/commands/deploy/createWallet.ts
+++ b/packages/fuels/src/cli/commands/deploy/createWallet.ts
@@ -9,7 +9,10 @@ export async function createWallet(providerUrl: string, privateKey?: string) {
   } else if (process.env.PRIVATE_KEY) {
     pvtKey = process.env.PRIVATE_KEY;
   } else {
-    throw new Error('You must provide a privateKey via config.privateKey or env PRIVATE_KEY');
+    throw new FuelError(
+      FuelError.CODES.MISSING_REQUIRED_PARAMETER,
+      'You must provide a privateKey via config.privateKey or env PRIVATE_KEY'
+    );
   }
 
   try {

--- a/packages/fuels/src/cli/commands/init/index.ts
+++ b/packages/fuels/src/cli/commands/init/index.ts
@@ -1,3 +1,4 @@
+import { FuelError } from '@fuel-ts/errors';
 import { type Command } from 'commander';
 import { existsSync, writeFileSync } from 'fs';
 import { globSync } from 'glob';
@@ -45,7 +46,10 @@ export function init(program: Command) {
     const fuelsConfigPath = join(path, 'fuels.config.ts');
 
     if (existsSync(fuelsConfigPath)) {
-      throw new Error(`Config file exists, aborting.\n  ${fuelsConfigPath}`);
+      throw new FuelError(
+        FuelError.CODES.CONFIG_FILE_ALREADY_EXISTS,
+        `Config file exists, aborting.\n  ${fuelsConfigPath}`
+      );
     }
 
     const renderedConfig = renderFuelsConfigTemplate({

--- a/packages/fuels/src/cli/config/forcUtils.ts
+++ b/packages/fuels/src/cli/config/forcUtils.ts
@@ -1,3 +1,4 @@
+import { FuelError } from '@fuel-ts/errors';
 import { readFileSync, existsSync } from 'fs';
 import camelCase from 'lodash.camelcase';
 import { join } from 'path';
@@ -35,7 +36,10 @@ export function readForcToml(path: string) {
   const forcPath = join(path, './Forc.toml');
 
   if (!existsSync(forcPath)) {
-    throw new Error(`Toml file not found:\n  ${forcPath}`);
+    throw new FuelError(
+      FuelError.CODES.CONFIG_FILE_NOT_FOUND,
+      `Toml file not found:\n  ${forcPath}`
+    );
   }
 
   if (!forcFiles.has(forcPath)) {

--- a/packages/fuels/src/cli/config/loadConfig.ts
+++ b/packages/fuels/src/cli/config/loadConfig.ts
@@ -1,4 +1,5 @@
 import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
+import { FuelError } from '@fuel-ts/errors';
 import { defaultConsensusKey } from '@fuel-ts/utils';
 import { bundleRequire } from 'bundle-require';
 import type { BuildOptions } from 'esbuild';
@@ -23,7 +24,7 @@ export async function loadUserConfig(
   });
 
   if (!configPath) {
-    throw new Error('Config file not found!');
+    throw new FuelError(FuelError.CODES.CONFIG_FILE_NOT_FOUND, 'Config file not found!');
   }
 
   const esbuildOptions: BuildOptions = {
@@ -97,7 +98,10 @@ export async function loadConfig(cwd: string): Promise<FuelsConfig> {
       const swayProgramType = readSwayType(workspace);
       const exampleMsg = `Try using '${swayProgramType}s' instead of 'workspace' in:\n  ${configPath}`;
 
-      throw new Error([workspaceMsg, exampleMsg].join('\n\n'));
+      throw new FuelError(
+        FuelError.CODES.WORKSPACE_NOT_DETECTED,
+        [workspaceMsg, exampleMsg].join('\n\n')
+      );
     }
 
     const swayMembers = forcToml.workspace.members.map((member) => resolve(workspace, member));

--- a/packages/script/src/script.test.ts
+++ b/packages/script/src/script.test.ts
@@ -5,7 +5,8 @@ import type { Account, TransactionResponse, TransactionResult } from '@fuel-ts/a
 import { Provider, ScriptTransactionRequest } from '@fuel-ts/account';
 import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
 import { generateTestWallet } from '@fuel-ts/account/test-utils';
-import { safeExec } from '@fuel-ts/errors/test-utils';
+import { FuelError } from '@fuel-ts/errors';
+import { expectToThrowFuelError } from '@fuel-ts/errors/test-utils';
 import type { BigNumberish } from '@fuel-ts/math';
 import { bn } from '@fuel-ts/math';
 import { ScriptRequest } from '@fuel-ts/program';
@@ -129,11 +130,13 @@ describe('Script', () => {
 
     const newScript = new Script(scriptBin, jsonAbiFragmentMock, wallet);
 
-    const { error } = await safeExec(() => newScript.setConfigurableConstants({ FEE: 8 }));
-
-    const errMsg = `Error setting configurable constants: The script does not have configurable constants to be set.`;
-
-    expect((<Error>error).message).toBe(errMsg);
+    await expectToThrowFuelError(
+      () => newScript.setConfigurableConstants({ FEE: 8 }),
+      new FuelError(
+        FuelError.CODES.INVALID_CONFIGURABLE_CONSTANTS,
+        'Error setting configurable constants: The script does not have configurable constants to be set.'
+      )
+    );
   });
 
   it('should throw when setting configurable with wrong name', async () => {
@@ -156,10 +159,12 @@ describe('Script', () => {
 
     const script = new Script(scriptBin, jsonAbiWithConfigurablesMock, wallet);
 
-    const { error } = await safeExec(() => script.setConfigurableConstants({ NOT_DEFINED: 8 }));
-
-    const errMsg = `Error setting configurable constants: The script does not have a configurable constant named: 'NOT_DEFINED'.`;
-
-    expect((<Error>error).message).toBe(errMsg);
+    await expectToThrowFuelError(
+      () => script.setConfigurableConstants({ NOT_DEFINED: 8 }),
+      new FuelError(
+        FuelError.CODES.INVALID_CONFIGURABLE_CONSTANTS,
+        `Error setting configurable constants: The script does not have a configurable constant named: 'NOT_DEFINED'.`
+      )
+    );
   });
 });

--- a/packages/script/src/script.ts
+++ b/packages/script/src/script.ts
@@ -2,7 +2,7 @@
 import { Interface } from '@fuel-ts/abi-coder';
 import type { InputValue, JsonAbi } from '@fuel-ts/abi-coder';
 import type { Account, Provider } from '@fuel-ts/account';
-import { ErrorCode, FuelError } from '@fuel-ts/errors';
+import { FuelError } from '@fuel-ts/errors';
 import { AbstractScript } from '@fuel-ts/interfaces';
 import type { BytesLike } from '@fuel-ts/interfaces';
 import type { BN } from '@fuel-ts/math';
@@ -91,12 +91,18 @@ export class Script<TInput extends Array<any>, TOutput> extends AbstractScript {
   setConfigurableConstants(configurables: { [name: string]: unknown }) {
     try {
       if (!Object.keys(this.interface.configurables).length) {
-        throw new Error(`The script does not have configurable constants to be set`);
+        throw new FuelError(
+          FuelError.CODES.INVALID_CONFIGURABLE_CONSTANTS,
+          `The script does not have configurable constants to be set`
+        );
       }
 
       Object.entries(configurables).forEach(([key, value]) => {
         if (!this.interface.configurables[key]) {
-          throw new Error(`The script does not have a configurable constant named: '${key}'`);
+          throw new FuelError(
+            FuelError.CODES.CONFIGURABLE_NOT_FOUND,
+            `The script does not have a configurable constant named: '${key}'`
+          );
         }
 
         const { offset } = this.interface.configurables[key];
@@ -107,7 +113,7 @@ export class Script<TInput extends Array<any>, TOutput> extends AbstractScript {
       });
     } catch (err) {
       throw new FuelError(
-        ErrorCode.INVALID_CONFIGURABLE_CONSTANTS,
+        FuelError.CODES.INVALID_CONFIGURABLE_CONSTANTS,
         `Error setting configurable constants: ${(<Error>err).message}.`
       );
     }

--- a/packages/utils/src/test-utils/expectToBeInRange.test.ts
+++ b/packages/utils/src/test-utils/expectToBeInRange.test.ts
@@ -1,3 +1,6 @@
+import { FuelError } from '@fuel-ts/errors';
+import { expectToThrowFuelError } from '@fuel-ts/errors/test-utils';
+
 import { expectToBeInRange } from './expectToBeInRange';
 
 /**
@@ -5,24 +8,34 @@ import { expectToBeInRange } from './expectToBeInRange';
  * @group browser
  */
 describe('expectValueToBeInRange', () => {
-  it('should throw an error when value is less than the minimum', () => {
-    expect(() =>
-      expectToBeInRange({
-        value: 4,
-        min: 5,
-        max: 10,
-      })
-    ).toThrow(`Expected value: '4' to be within range: '5-10'`);
+  it('should throw an error when value is less than the minimum', async () => {
+    await expectToThrowFuelError(
+      () =>
+        expectToBeInRange({
+          value: 4,
+          min: 5,
+          max: 10,
+        }),
+      new FuelError(
+        FuelError.CODES.INVALID_INPUT_PARAMETERS,
+        `Expected value: '4' to be within range: '5-10'`
+      )
+    );
   });
 
-  it('should throw an error when value is greater than the maximum', () => {
-    expect(() =>
-      expectToBeInRange({
-        value: 11,
-        min: 5,
-        max: 10,
-      })
-    ).toThrow(`Expected value: '11' to be within range: '5-10'`);
+  it('should throw an error when value is greater than the maximum', async () => {
+    await expectToThrowFuelError(
+      () =>
+        expectToBeInRange({
+          value: 11,
+          min: 5,
+          max: 10,
+        }),
+      new FuelError(
+        FuelError.CODES.INVALID_INPUT_PARAMETERS,
+        `Expected value: '11' to be within range: '5-10'`
+      )
+    );
   });
 
   it('should return true when value is equal to the minimum', () => {

--- a/packages/utils/src/test-utils/expectToBeInRange.ts
+++ b/packages/utils/src/test-utils/expectToBeInRange.ts
@@ -1,8 +1,13 @@
+import { FuelError } from '@fuel-ts/errors';
+
 export const expectToBeInRange = (params: { value: number; min: number; max: number }) => {
   const { value, min, max } = params;
   if (value >= min && value <= max) {
     return true;
   }
 
-  throw new Error(`Expected value: '${value}' to be within range: '${min}-${max}'`);
+  throw new FuelError(
+    FuelError.CODES.INVALID_INPUT_PARAMETERS,
+    `Expected value: '${value}' to be within range: '${min}-${max}'`
+  );
 };


### PR DESCRIPTION
- Closes #2001

# Summary

- Replaces generic `Error` instances with `FuelError`
- Finalised @mvares great work in:
  #2549 

# Checklist

- [X] I **_added_** — `tests` to prove my changes
- [X] I **_updated_** — all the necessary `docs`
- [X] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
