### PR TITLE
chore: default TestMessage to be spendable

### DIFF
--- a/.changeset/rude-goats-smile.md
+++ b/.changeset/rude-goats-smile.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+chore: default TestMessage to be spendable

--- a/packages/account/src/test-utils/test-message.ts
+++ b/packages/account/src/test-utils/test-message.ts
@@ -14,6 +14,8 @@ interface TestMessageSpecs {
   da_height: number;
 }
 
+export type ChainMessage = SnapshotConfigs['stateConfig']['messages'][0];
+
 export class TestMessage {
   public readonly sender: AbstractAddress;
   public readonly recipient: AbstractAddress;
@@ -44,13 +46,15 @@ export class TestMessage {
     this.da_height = da_height;
   }
 
-  toChainMessage(recipient?: AbstractAddress): SnapshotConfigs['stateConfig']['messages'][0] {
+  toChainMessage(recipient?: AbstractAddress): ChainMessage {
+    // Fuel-core throwns error for message data prefixed with 0x within the stateConfig.json file
+    const data = /^0x/.test(this.data) ? this.data.replace(/^0x/, '') : this.data;
     return {
       sender: this.sender.toB256(),
       recipient: recipient?.toB256() ?? this.recipient.toB256(),
       nonce: this.nonce,
       amount: bn(this.amount).toNumber(),
-      data: this.data,
+      data,
       da_height: this.da_height,
     };
   }

--- a/packages/account/src/test-utils/test-message.ts
+++ b/packages/account/src/test-utils/test-message.ts
@@ -33,7 +33,7 @@ export class TestMessage {
     recipient = Address.fromRandom(),
     nonce = hexlify(randomBytes(32)),
     amount = 1_000_000,
-    data = '02',
+    data = '', // Will default to empty data in order to be a spendable message
     da_height = 0,
   }: Partial<TestMessageSpecs> = {}) {
     this.sender = sender;

--- a/packages/fuel-gauge/src/transaction-summary.test.ts
+++ b/packages/fuel-gauge/src/transaction-summary.test.ts
@@ -583,7 +583,7 @@ describe('TransactionSummary', () => {
     });
 
     it('should ensure that transfer operations are assembled correctly if only seeded with a MessageInput (SPENDABLE MESSAGE)', async () => {
-      const testMessage = new TestMessage({ amount: 1000000, data: '' });
+      const testMessage = new TestMessage({ amount: 1000000 });
 
       using launched = await launchTestNode({
         contractsConfigs: [


### PR DESCRIPTION
# Summary

This PR updates the default value of the `data` property in [TestMessage](https://github.com/FuelLabs/fuels-ts/blob/master/packages/account/src/test-utils/test-message.ts) to an empty string. This change ensures that a new instance of `TestMessage` is spendable by default when the `data` property is not provided.

# Checklist

- [x] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [x] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
