### PR TITLE
fix: transaction revert error with status change

### DIFF
--- a/.changeset/famous-pans-press.md
+++ b/.changeset/famous-pans-press.md
@@ -1,0 +1,8 @@
+---
+"@internal/fuel-core": patch
+"@fuel-ts/versions": patch
+"@fuel-ts/account": patch
+"@fuel-ts/utils": patch
+---
+
+fix: transaction revert error with status change

--- a/.fuel-core/configs/chainConfig.json
+++ b/.fuel-core/configs/chainConfig.json
@@ -40,51 +40,47 @@
       },
       "chain_id": 0,
       "gas_costs": {
-        "V1": {
+        "V4": {
           "add": 2,
           "addi": 2,
-          "aloc": 2,
           "and": 2,
           "andi": 2,
-          "bal": 86,
+          "bal": 29,
           "bhei": 2,
           "bhsh": 2,
-          "burn": 25770,
+          "burn": 19976,
           "cb": 2,
-          "cfei": 2,
           "cfsi": 2,
           "div": 2,
           "divi": 2,
-          "eck1": 3114,
-          "ecr1": 42270,
-          "ed19": 2878,
+          "eck1": 1907,
+          "ecr1": 26135,
           "eq": 2,
           "exp": 2,
           "expi": 2,
-          "flag": 1,
+          "flag": 2,
           "gm": 2,
           "gt": 2,
-          "gtf": 12,
+          "gtf": 13,
           "ji": 2,
           "jmp": 2,
           "jne": 2,
           "jnei": 2,
           "jnzi": 2,
-          "jmpf": 1,
-          "jmpb": 1,
-          "jnzf": 1,
-          "jnzb": 1,
-          "jnef": 1,
-          "jneb": 1,
+          "jmpf": 2,
+          "jmpb": 2,
+          "jnzf": 2,
+          "jnzb": 2,
+          "jnef": 2,
+          "jneb": 2,
           "lb": 2,
-          "log": 165,
+          "log": 102,
           "lt": 2,
           "lw": 2,
-          "mint": 29024,
+          "mint": 18042,
           "mlog": 2,
-          "mod_op": 2,
           "modi": 2,
-          "move_op": 2,
+          "mod_op": 2,
           "movi": 2,
           "mroo": 4,
           "mul": 2,
@@ -96,55 +92,68 @@
           "ori": 2,
           "poph": 3,
           "popl": 3,
-          "pshh": 4,
-          "pshl": 4,
-          "ret": 134,
-          "rvrt": 153,
+          "pshh": 5,
+          "pshl": 5,
+          "move_op": 2,
+          "ret": 53,
           "sb": 2,
           "sll": 2,
           "slli": 2,
           "srl": 2,
           "srli": 2,
-          "srw": 209,
+          "srw": 177,
           "sub": 2,
           "subi": 2,
           "sw": 2,
-          "sww": 22501,
-          "time": 50,
-          "tr": 33912,
-          "tro": 24294,
+          "sww": 17302,
+          "time": 35,
+          "tr": 27852,
+          "tro": 19718,
           "wdcm": 2,
-          "wqcm": 3,
+          "wqcm": 2,
           "wdop": 3,
           "wqop": 3,
           "wdml": 3,
-          "wqml": 4,
-          "wddv": 5,
-          "wqdv": 6,
-          "wdmd": 10,
-          "wqmd": 17,
-          "wdam": 9,
-          "wqam": 11,
-          "wdmm": 10,
-          "wqmm": 10,
+          "wqml": 3,
+          "wddv": 4,
+          "wqdv": 5,
+          "wdmd": 8,
+          "wqmd": 12,
+          "wdam": 7,
+          "wqam": 8,
+          "wdmm": 8,
+          "wqmm": 8,
           "xor": 2,
           "xori": 2,
-          "alocDependentCost": {
+          "rvrt": 2,
+          "aloc": {
             "HeavyOperation": {
               "base": 2,
-              "gasPerUnit": 0
+              "gas_per_unit": 0
+            }
+          },
+          "bsiz": {
+            "LightOperation": {
+              "base": 17,
+              "units_per_gas": 790
+            }
+          },
+          "bldd": {
+            "LightOperation": {
+              "base": 15,
+              "units_per_gas": 272
             }
           },
           "cfe": {
             "HeavyOperation": {
               "base": 2,
-              "gasPerUnit": 0
+              "gas_per_unit": 0
             }
           },
-          "cfeiDependentCost": {
+          "cfei": {
             "HeavyOperation": {
               "base": 2,
-              "gasPerUnit": 0
+              "gas_per_unit": 0
             }
           },
           "call": {
@@ -166,6 +175,12 @@
             }
           },
           "csiz": {
+            "LightOperation": {
+              "base": 45,
+              "units_per_gas": 237
+            }
+          },
+          "ed19": {
             "LightOperation": {
               "base": 45,
               "units_per_gas": 237

--- a/.fuel-core/configs/stateConfig.json
+++ b/.fuel-core/configs/stateConfig.json
@@ -469,6 +469,7 @@
     }
   ],
   "contracts": [],
+  "blobs": [],
   "block_height": 0,
   "da_block_height": 0
 }

--- a/internal/fuel-core/VERSION
+++ b/internal/fuel-core/VERSION
@@ -1,1 +1,1 @@
-0.31.0
+git:feature/transaction-from-status

--- a/packages/account/src/providers/fuel-core-schema.graphql
+++ b/packages/account/src/providers/fuel-core-schema.graphql
@@ -63,6 +63,8 @@ input BalanceFilterInput {
   owner: Address!
 }
 
+scalar BlobId
+
 type Block {
   version: BlockVersion!
   id: BlockId!
@@ -351,6 +353,7 @@ type FailureStatus {
   transactionId: TransactionId!
   blockHeight: U32!
   block: Block!
+  transaction: Transaction!
   time: Tai64Timestamp!
   reason: String!
   programState: ProgramState
@@ -460,12 +463,15 @@ type GasCosts {
   xor: U64!
   xori: U64!
   alocDependentCost: DependentCost!
+  bldd: DependentCost
+  bsiz: DependentCost
   cfe: DependentCost!
   cfeiDependentCost: DependentCost!
   call: DependentCost!
   ccp: DependentCost!
   croo: DependentCost!
   csiz: DependentCost!
+  ed19DependentCost: DependentCost!
   k256: DependentCost!
   ldc: DependentCost!
   logd: DependentCost!
@@ -975,6 +981,11 @@ type Query {
   estimatePredicates(tx: HexString!): Transaction!
 
   """
+  Returns all possible receipts for test purposes.
+  """
+  allReceipts: [Receipt!]!
+
+  """
   Returns true when the GraphQL API is serving requests.
   """
   health: Boolean!
@@ -1242,6 +1253,7 @@ type SuccessStatus {
   transactionId: TransactionId!
   blockHeight: U32!
   block: Block!
+  transaction: Transaction!
   time: Tai64Timestamp!
   programState: ProgramState
   receipts: [Receipt!]!
@@ -1268,6 +1280,7 @@ type Transaction {
   isMint: Boolean!
   isUpgrade: Boolean!
   isUpload: Boolean!
+  isBlob: Boolean!
   inputs: [Input!]
   outputs: [Output!]!
   outputContract: ContractOutput
@@ -1277,6 +1290,7 @@ type Transaction {
   script: HexString
   scriptData: HexString
   bytecodeWitnessIndex: U16
+  blobId: BlobId
   salt: Salt
   storageSlots: [HexString!]
   bytecodeRoot: Bytes32

--- a/packages/account/src/providers/operations.graphql
+++ b/packages/account/src/providers/operations.graphql
@@ -63,6 +63,16 @@ fragment transactionStatusFragment on TransactionStatus {
 
 fragment transactionStatusSubscriptionFragment on TransactionStatus {
   type: __typename
+  ... on SuccessStatus {
+    transaction {
+      ...transactionFragment
+    }
+  }
+  ... on FailureStatus {
+    transaction {
+      ...transactionFragment
+    }
+  }
   ... on SqueezedOutStatus {
     reason
   }

--- a/packages/account/src/providers/operations.graphql
+++ b/packages/account/src/providers/operations.graphql
@@ -416,6 +416,9 @@ fragment GasCostsFragment on GasCosts {
   csiz {
     ...DependentCostFragment
   }
+  ed19DependentCost {
+    ...DependentCostFragment
+  }
   k256 {
     ...DependentCostFragment
   }

--- a/packages/account/src/providers/transaction-response/transaction-response.ts
+++ b/packages/account/src/providers/transaction-response/transaction-response.ts
@@ -89,7 +89,7 @@ export class TransactionResponse {
   gasUsed: BN = bn(0);
   /** The graphql Transaction with receipts object. */
   gqlTransaction?: GqlTransaction;
-
+  /** The ABIs used for decoding logs */
   abis?: JsonAbisFromAllCalls;
 
   /**
@@ -97,6 +97,7 @@ export class TransactionResponse {
    *
    * @param id - The transaction ID.
    * @param provider - The provider.
+   * @param abis - The ABIs used for decoding logs.
    */
   constructor(id: string, provider: Provider, abis?: JsonAbisFromAllCalls) {
     this.id = id;

--- a/packages/account/test/fixtures/chain.ts
+++ b/packages/account/test/fixtures/chain.ts
@@ -174,6 +174,11 @@ export const MOCK_CHAIN: GqlChainInfoFragment = {
         base: '17',
         unitsPerGas: '790',
       },
+      ed19DependentCost: {
+        type: 'LightOperation',
+        base: '3000',
+        unitsPerGas: '214',
+      },
       k256: {
         type: 'LightOperation',
         base: '11',

--- a/packages/fuels/test/fixtures/project/.fuels/chainConfig.json
+++ b/packages/fuels/test/fixtures/project/.fuels/chainConfig.json
@@ -135,6 +135,18 @@
               "gasPerUnit": 0
             }
           },
+          "bsiz": {
+            "LightOperation": {
+              "base": 17,
+              "units_per_gas": 790
+            }
+          },
+          "bldd": {
+            "LightOperation": {
+              "base": 15,
+              "units_per_gas": 272
+            }
+          },
           "cfe": {
             "HeavyOperation": {
               "base": 2,

--- a/packages/fuels/test/fixtures/project/.fuels/stateConfig.json
+++ b/packages/fuels/test/fixtures/project/.fuels/stateConfig.json
@@ -461,6 +461,7 @@
     }
   ],
   "contracts": [],
+  "blobs": [],
   "block_height": 0,
   "da_block_height": 0
 }

--- a/packages/utils/src/utils/defaultSnapshotConfigs.ts
+++ b/packages/utils/src/utils/defaultSnapshotConfigs.ts
@@ -4,6 +4,7 @@ import stateConfigJson from './defaultSnapshots/stateConfig.json';
 import type { SnapshotConfigs } from './types';
 
 export const defaultSnapshotConfigs: SnapshotConfigs = {
+  // @ts-expect-error Getting type errors as we can't gen the fuel schema for v4 gas costs
   chainConfig: chainConfigJson,
   metadata: metadataJson,
   stateConfig: stateConfigJson,

--- a/packages/utils/src/utils/defaultSnapshots/chainConfig.json
+++ b/packages/utils/src/utils/defaultSnapshots/chainConfig.json
@@ -40,51 +40,47 @@
       },
       "chain_id": 0,
       "gas_costs": {
-        "V1": {
+        "V4": {
           "add": 2,
           "addi": 2,
-          "aloc": 2,
           "and": 2,
           "andi": 2,
-          "bal": 86,
+          "bal": 29,
           "bhei": 2,
           "bhsh": 2,
-          "burn": 25770,
+          "burn": 19976,
           "cb": 2,
-          "cfei": 2,
           "cfsi": 2,
           "div": 2,
           "divi": 2,
-          "eck1": 3114,
-          "ecr1": 42270,
-          "ed19": 2878,
+          "eck1": 1907,
+          "ecr1": 26135,
           "eq": 2,
           "exp": 2,
           "expi": 2,
-          "flag": 1,
+          "flag": 2,
           "gm": 2,
           "gt": 2,
-          "gtf": 12,
+          "gtf": 13,
           "ji": 2,
           "jmp": 2,
           "jne": 2,
           "jnei": 2,
           "jnzi": 2,
-          "jmpf": 1,
-          "jmpb": 1,
-          "jnzf": 1,
-          "jnzb": 1,
-          "jnef": 1,
-          "jneb": 1,
+          "jmpf": 2,
+          "jmpb": 2,
+          "jnzf": 2,
+          "jnzb": 2,
+          "jnef": 2,
+          "jneb": 2,
           "lb": 2,
-          "log": 165,
+          "log": 102,
           "lt": 2,
           "lw": 2,
-          "mint": 29024,
+          "mint": 18042,
           "mlog": 2,
-          "mod_op": 2,
           "modi": 2,
-          "move_op": 2,
+          "mod_op": 2,
           "movi": 2,
           "mroo": 4,
           "mul": 2,
@@ -96,55 +92,68 @@
           "ori": 2,
           "poph": 3,
           "popl": 3,
-          "pshh": 4,
-          "pshl": 4,
-          "ret": 134,
-          "rvrt": 153,
+          "pshh": 5,
+          "pshl": 5,
+          "move_op": 2,
+          "ret": 53,
           "sb": 2,
           "sll": 2,
           "slli": 2,
           "srl": 2,
           "srli": 2,
-          "srw": 209,
+          "srw": 177,
           "sub": 2,
           "subi": 2,
           "sw": 2,
-          "sww": 22501,
-          "time": 50,
-          "tr": 33912,
-          "tro": 24294,
+          "sww": 17302,
+          "time": 35,
+          "tr": 27852,
+          "tro": 19718,
           "wdcm": 2,
-          "wqcm": 3,
+          "wqcm": 2,
           "wdop": 3,
           "wqop": 3,
           "wdml": 3,
-          "wqml": 4,
-          "wddv": 5,
-          "wqdv": 6,
-          "wdmd": 10,
-          "wqmd": 17,
-          "wdam": 9,
-          "wqam": 11,
-          "wdmm": 10,
-          "wqmm": 10,
+          "wqml": 3,
+          "wddv": 4,
+          "wqdv": 5,
+          "wdmd": 8,
+          "wqmd": 12,
+          "wdam": 7,
+          "wqam": 8,
+          "wdmm": 8,
+          "wqmm": 8,
           "xor": 2,
           "xori": 2,
-          "alocDependentCost": {
+          "rvrt": 2,
+          "aloc": {
             "HeavyOperation": {
               "base": 2,
-              "gasPerUnit": 0
+              "gas_per_unit": 0
+            }
+          },
+          "bsiz": {
+            "LightOperation": {
+              "base": 17,
+              "units_per_gas": 790
+            }
+          },
+          "bldd": {
+            "LightOperation": {
+              "base": 15,
+              "units_per_gas": 272
             }
           },
           "cfe": {
             "HeavyOperation": {
               "base": 2,
-              "gasPerUnit": 0
+              "gas_per_unit": 0
             }
           },
-          "cfeiDependentCost": {
+          "cfei": {
             "HeavyOperation": {
               "base": 2,
-              "gasPerUnit": 0
+              "gas_per_unit": 0
             }
           },
           "call": {
@@ -166,6 +175,12 @@
             }
           },
           "csiz": {
+            "LightOperation": {
+              "base": 45,
+              "units_per_gas": 237
+            }
+          },
+          "ed19": {
             "LightOperation": {
               "base": 45,
               "units_per_gas": 237

--- a/packages/utils/src/utils/defaultSnapshots/stateConfig.json
+++ b/packages/utils/src/utils/defaultSnapshots/stateConfig.json
@@ -469,6 +469,7 @@
     }
   ],
   "contracts": [],
+  "blobs": [],
   "block_height": 0,
   "da_block_height": 0
 }

--- a/packages/utils/src/utils/types.ts
+++ b/packages/utils/src/utils/types.ts
@@ -51,6 +51,8 @@ interface GasCosts {
   bhei: number;
   bhsh: number;
   burn: number;
+  bldd: Operation;
+  bsiz: Operation;
   cb: number;
   cfei: number;
   cfsi: number;

--- a/packages/versions/src/lib/getBuiltinVersions.ts
+++ b/packages/versions/src/lib/getBuiltinVersions.ts
@@ -1,7 +1,7 @@
 export function getBuiltinVersions() {
   return {
     FORC: '0.62.0',
-    FUEL_CORE: '0.31.0',
+    FUEL_CORE: 'git:feature/transaction-from-status',
     FUELS: '0.93.0',
   };
 }


### PR DESCRIPTION
- Closes #2898
- Closes #1644

# Release notes

In this release, we:

- Fixed bug with transaction reverting with unknown reason.

# Summary

- Within our transaction flow, we listen to the `statusChange` subscription. Once a change of status occurs, we perform a `getTransactionWithReceipts` query.
- The `statusChange` subscription was posting a `SuccessStatus`, but the sub-sequential call to the `getTransactionWithReceipts` query returned a `SubmittedStatus`, which the SDK interprets as an erroneous condition.
- This change uses the transaction posted from the `statusChange` for `SuccessStatus` and `FailureStatus` results.

# Checklist

- [ ] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [X] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
