### PR TITLE
feat: map 'not enough coins' error

### DIFF
--- a/.changeset/rare-shrimps-clap.md
+++ b/.changeset/rare-shrimps-clap.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/account": patch
+"@fuel-ts/errors": patch
+---
+
+feat: map 'not enough coins' error

--- a/packages/account/src/providers/fuel-graphql-subscriber.ts
+++ b/packages/account/src/providers/fuel-graphql-subscriber.ts
@@ -2,6 +2,8 @@ import { ErrorCode, FuelError } from '@fuel-ts/errors';
 import type { DocumentNode } from 'graphql';
 import { print } from 'graphql';
 
+import { handleGqlErrorMessage } from './utils/handle-gql-error-message';
+
 type FuelGraphQLSubscriberOptions = {
   url: string;
   query: DocumentNode;
@@ -48,10 +50,8 @@ export class FuelGraphqlSubscriber implements AsyncIterator<unknown> {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const { data, errors } = this.events.shift()!;
         if (Array.isArray(errors)) {
-          throw new FuelError(
-            FuelError.CODES.INVALID_REQUEST,
-            errors.map((err) => err.message).join('\n\n')
-          );
+          const errorMessage = errors.map((err) => err.message).join('\n\n');
+          handleGqlErrorMessage(errorMessage);
         }
         return { value: data, done: false };
       }

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -60,6 +60,7 @@ import {
 } from './utils';
 import type { RetryOptions } from './utils/auto-retry-fetch';
 import { autoRetryFetch } from './utils/auto-retry-fetch';
+import { handleGqlErrorMessage } from './utils/handle-gql-error-message';
 
 const MAX_RETRIES = 10;
 
@@ -567,11 +568,12 @@ Supported fuel-core version: ${supportedVersion}.`
       responseMiddleware: (response: GraphQLResponse<unknown> | Error) => {
         if ('response' in response) {
           const graphQlResponse = response.response as GraphQLResponse;
+
           if (Array.isArray(graphQlResponse?.errors)) {
-            throw new FuelError(
-              FuelError.CODES.INVALID_REQUEST,
-              graphQlResponse.errors.map((err: Error) => err.message).join('\n\n')
-            );
+            const errorMessage = graphQlResponse.errors
+              .map((err: Error) => err.message)
+              .join('\n\n');
+            handleGqlErrorMessage(errorMessage);
           }
         }
       },

--- a/packages/account/src/providers/utils/handle-gql-error-message.ts
+++ b/packages/account/src/providers/utils/handle-gql-error-message.ts
@@ -1,0 +1,17 @@
+import { ErrorCode, FuelError } from '@fuel-ts/errors';
+
+export enum GqlErrorMessage {
+  NOT_ENOUGH_COINS = 'not enough coins to fit the target',
+}
+
+export const handleGqlErrorMessage = (errorMessage: string) => {
+  switch (errorMessage) {
+    case GqlErrorMessage.NOT_ENOUGH_COINS:
+      throw new FuelError(
+        ErrorCode.NOT_ENOUGH_FUNDS,
+        'This account does not have enough funds to cover this transaction.'
+      );
+    default:
+      throw new FuelError(ErrorCode.INVALID_REQUEST, `Unknown error: ${errorMessage}`);
+  }
+};

--- a/packages/errors/src/error-codes.ts
+++ b/packages/errors/src/error-codes.ts
@@ -56,6 +56,7 @@ export enum ErrorCode {
   MISSING_REQUIRED_PARAMETER = 'missing-required-parameter',
   INVALID_REQUEST = 'invalid-request',
   INVALID_TRANSFER_AMOUNT = 'invalid-transfer-amount',
+  NOT_ENOUGH_FUNDS = 'not-enough-funds',
 
   // crypto
   INVALID_CREDENTIALS = 'invalid-credentials',

--- a/packages/fuel-gauge/src/not-enough-coins.test.ts
+++ b/packages/fuel-gauge/src/not-enough-coins.test.ts
@@ -1,0 +1,19 @@
+import { Contract, ErrorCode, Wallet } from 'fuels';
+import { expectToThrowFuelError } from 'fuels/test-utils';
+
+import { CallTestContractFactory } from '../test/typegen/contracts';
+
+import { launchTestContract } from './utils';
+
+test('not enough coins error', async () => {
+  using contract = await launchTestContract({ factory: CallTestContractFactory });
+
+  const emptyWallet = Wallet.generate({ provider: contract.provider });
+
+  const emptyWalletContract = new Contract(contract.id, contract.interface.jsonAbi, emptyWallet);
+
+  await expectToThrowFuelError(() => emptyWalletContract.functions.return_void().call(), {
+    code: ErrorCode.NOT_ENOUGH_FUNDS,
+    message: 'This account does not have enough funds to cover this transaction.',
+  });
+});


### PR DESCRIPTION
- Closes #2522 

# Release notes

In this release, we:

- Mapped the 'not enough coins' error to a readable error message

# Summary

This PR maps the `not enough coins to fit the target error` to a proper readable error message. It also lays down the foundation for adding the mapping of more VM errors like this one (#2467).

# Checklist

- [ ] I **_added_** — `tests` to prove my changes
- [ ] I **_updated_** — all the necessary `docs`
- [ ] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [ ] I **_described_** — all breaking changes and the Migration Guide
