### PR TITLE
chore!: renamed `AssetId` to `TestAssetId`

### DIFF
--- a/.changeset/yellow-eagles-breathe.md
+++ b/.changeset/yellow-eagles-breathe.md
@@ -2,4 +2,4 @@
 "@fuel-ts/account": patch
 ---
 
-chore: renamed `AssetId` to `TestAssetId`
+chore!: renamed `AssetId` to `TestAssetId`

--- a/.changeset/yellow-eagles-breathe.md
+++ b/.changeset/yellow-eagles-breathe.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+chore: renamed `AssetId` to `TestAssetId`

--- a/apps/docs-snippets/src/guide/testing/launching-a-test-node.test.ts
+++ b/apps/docs-snippets/src/guide/testing/launching-a-test-node.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { WalletUnlocked } from 'fuels';
-import { AssetId, TestMessage, launchTestNode } from 'fuels/test-utils';
+import { TestAssetId, TestMessage, launchTestNode } from 'fuels/test-utils';
 import { join } from 'path';
 
 import { Counter, CounterFactory } from '../../../test/typegen/contracts';
@@ -72,11 +72,11 @@ describe('launching a test node', () => {
 
   test('multiple contracts and wallets', async () => {
     // #region advanced-example
-    // #import { launchTestNode, AssetId, TestMessage };
+    // #import { launchTestNode, TestAssetId, TestMessage };
 
     // #context import { CounterFactory } from 'path/to/typegen/output';
 
-    const assets = AssetId.random(2);
+    const assets = TestAssetId.random(2);
     const message = new TestMessage({ amount: 1000 });
 
     using launched = await launchTestNode({
@@ -146,9 +146,9 @@ describe('launching a test node', () => {
 
   test('customizing node options', async () => {
     // #region custom-node-options
-    // #import { launchTestNode, AssetId };
+    // #import { launchTestNode, TestAssetId };
 
-    const [baseAssetId] = AssetId.random();
+    const [baseAssetId] = TestAssetId.random();
 
     using launched = await launchTestNode({
       nodeOptions: {
@@ -166,11 +166,11 @@ describe('launching a test node', () => {
     // #endregion custom-node-options
   });
 
-  test('using assetId', async () => {
+  test('using TestAssetId', async () => {
     // #region asset-ids
-    // #import { launchTestNode, AssetId };
+    // #import { launchTestNode, TestAssetId };
 
-    const assets = AssetId.random();
+    const assets = TestAssetId.random();
 
     using launched = await launchTestNode({
       walletsConfig: {

--- a/apps/docs/src/guide/testing/test-node-options.md
+++ b/apps/docs/src/guide/testing/test-node-options.md
@@ -14,15 +14,15 @@ This reference describes all the options of the [`launchTestNode`](./launching-a
 Used to set the node's genesis block state (coins and messages).
 
 - `count`: number of wallets/addresses to generate on the genesis block.
-- `assets`: configure how many unique assets each wallet will own with the base asset included. Can be `number` or `AssetId[]`.
-  - The `AssetId` utility simplifies testing when different assets are necessary.
+- `assets`: configure how many unique assets each wallet will own with the base asset included. Can be `number` or `TestAssetId[]`.
+  - The `TestAssetId` utility simplifies testing when different assets are necessary.
 - `coinsPerAsset`: number of coins (UTXOs) per asset id.
 - `amountPerCoin`: for each coin, the amount it'll contain.
 - `messages`: messages to assign to the wallets.
 
 ### `walletsConfig.assets`
 
-The `AssetId` utility integrates with [`walletsConfig`](./test-node-options.md#walletsconfig) and gives you an easy way to generate multiple random asset ids via the `AssetId.random` static method.
+The `TestAssetId` utility integrates with [`walletsConfig`](./test-node-options.md#walletsconfig) and gives you an easy way to generate multiple random asset ids via the `TestAssetId.random` static method.
 
 <<< @/../../docs-snippets/src/guide/testing/launching-a-test-node.test.ts#asset-ids{ts:line-numbers}
 

--- a/packages/account/src/test-util.test.ts
+++ b/packages/account/src/test-util.test.ts
@@ -11,6 +11,6 @@ describe('test-utils.js', () => {
     expect(testUtilsMod.setupTestProviderAndWallets).toBeTruthy();
     expect(testUtilsMod.WalletsConfig).toBeTruthy();
     expect(testUtilsMod.TestMessage).toBeTruthy();
-    expect(testUtilsMod.AssetId).toBeTruthy();
+    expect(testUtilsMod.TestAssetId).toBeTruthy();
   });
 });

--- a/packages/account/src/test-utils.ts
+++ b/packages/account/src/test-utils.ts
@@ -4,4 +4,4 @@ export * from './test-utils/launchNode';
 export * from './test-utils/setup-test-provider-and-wallets';
 export * from './test-utils/wallet-config';
 export * from './test-utils/test-message';
-export * from './test-utils/asset-id';
+export * from './test-utils/test-asset-id';

--- a/packages/account/src/test-utils/setup-test-provider-and-wallets.test.ts
+++ b/packages/account/src/test-utils/setup-test-provider-and-wallets.test.ts
@@ -10,9 +10,9 @@ import { Provider } from '../providers';
 import { Signer } from '../signer';
 import { WalletUnlocked } from '../wallet';
 
-import { AssetId } from './asset-id';
 import * as launchNodeMod from './launchNode';
 import { setupTestProviderAndWallets } from './setup-test-provider-and-wallets';
+import { TestAssetId } from './test-asset-id';
 import type { ChainMessage } from './test-message';
 import { TestMessage } from './test-message';
 
@@ -91,7 +91,7 @@ describe('setupTestProviderAndWallets', () => {
     expect(sutCoin.blockCreated.toNumber()).toEqual(coin.tx_pointer_block_height);
   });
 
-  it('default: two wallets, three assets (BaseAssetId, AssetId.A, AssetId.B), one coin, 10_000_000_000_ amount', async () => {
+  it('default: two wallets, three assets (BaseAssetId, TestAssetId.A, TestAssetId.B), one coin, 10_000_000_000_ amount', async () => {
     using providerAndWallets = await setupTestProviderAndWallets();
     const { wallets, provider } = providerAndWallets;
 
@@ -119,16 +119,16 @@ describe('setupTestProviderAndWallets', () => {
     expect(baseAssetIdCoin.amount.toNumber()).toBe(10_000_000_000);
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const assetACoin = coins1.find((x) => x.assetId === AssetId.A.value)!;
+    const assetACoin = coins1.find((x) => x.assetId === TestAssetId.A.value)!;
     expect(assetACoin.amount.toNumber()).toBe(10_000_000_000);
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const assetBCoin = coins1.find((x) => x.assetId === AssetId.B.value)!;
+    const assetBCoin = coins1.find((x) => x.assetId === TestAssetId.B.value)!;
     expect(assetBCoin.amount.toNumber()).toBe(10_000_000_000);
   });
 
   it('can be given custom asset id and message', async () => {
-    const [assetId] = AssetId.random();
+    const [assetId] = TestAssetId.random();
     const spendableMessage = new TestMessage();
     const dataMessage = new TestMessage({
       data: '0x2bca2aa612b304ece5b25988818dd7234e049913233eb918c11638af89d575be',

--- a/packages/account/src/test-utils/setup-test-provider-and-wallets.ts
+++ b/packages/account/src/test-utils/setup-test-provider-and-wallets.ts
@@ -6,9 +6,9 @@ import type { ProviderOptions } from '../providers';
 import { Provider } from '../providers';
 import type { WalletUnlocked } from '../wallet';
 
-import { AssetId } from './asset-id';
 import type { LaunchNodeOptions } from './launchNode';
 import { launchNode } from './launchNode';
+import { TestAssetId } from './test-asset-id';
 import type { WalletsConfigOptions } from './wallet-config';
 import { WalletsConfig } from './wallet-config';
 
@@ -28,7 +28,7 @@ export interface LaunchCustomProviderAndGetWalletsOptions {
 
 const defaultWalletConfigOptions: WalletsConfigOptions = {
   count: 2,
-  assets: [AssetId.A, AssetId.B],
+  assets: [TestAssetId.A, TestAssetId.B],
   coinsPerAsset: 1,
   amountPerCoin: 10_000_000_000,
   messages: [],

--- a/packages/account/src/test-utils/test-asset-id.ts
+++ b/packages/account/src/test-utils/test-asset-id.ts
@@ -1,12 +1,12 @@
 import { randomBytes } from '@fuel-ts/crypto';
 import { hexlify } from '@fuel-ts/utils';
 
-export class AssetId {
-  public static A = new AssetId(
+export class TestAssetId {
+  public static A = new TestAssetId(
     '0x0101010101010101010101010101010101010101010101010101010101010101'
   );
 
-  public static B = new AssetId(
+  public static B = new TestAssetId(
     '0x0202020202020202020202020202020202020202020202020202020202020202'
   );
 
@@ -15,7 +15,7 @@ export class AssetId {
   public static random(count: number = 1) {
     const assetIds = [];
     for (let i = 0; i < count; i++) {
-      assetIds.push(new AssetId(hexlify(randomBytes(32))));
+      assetIds.push(new TestAssetId(hexlify(randomBytes(32))));
     }
     return assetIds;
   }

--- a/packages/account/src/test-utils/wallet-config.test.ts
+++ b/packages/account/src/test-utils/wallet-config.test.ts
@@ -3,7 +3,7 @@ import { FuelError } from '@fuel-ts/errors';
 import { expectToThrowFuelError } from '@fuel-ts/errors/test-utils';
 import { hexlify } from '@fuel-ts/utils';
 
-import { AssetId } from './asset-id';
+import { TestAssetId } from './test-asset-id';
 import type { WalletsConfigOptions } from './wallet-config';
 import { WalletsConfig } from './wallet-config';
 
@@ -13,7 +13,7 @@ import { WalletsConfig } from './wallet-config';
 describe('WalletsConfig', () => {
   const configOptions: WalletsConfigOptions = {
     count: 2,
-    assets: [AssetId.A, AssetId.B],
+    assets: [TestAssetId.A, TestAssetId.B],
     coinsPerAsset: 1,
     amountPerCoin: 10_000_000_000,
     messages: [],
@@ -90,7 +90,7 @@ describe('WalletsConfig', () => {
   });
 
   it('allows custom assets to be provided', () => {
-    const [assetId] = AssetId.random();
+    const [assetId] = TestAssetId.random();
     const baseAssetId = hexlify(randomBytes(32));
     const {
       stateConfig: { coins: allCoins },

--- a/packages/account/src/test-utils/wallet-config.ts
+++ b/packages/account/src/test-utils/wallet-config.ts
@@ -5,7 +5,7 @@ import type { PartialDeep } from 'type-fest';
 
 import { WalletUnlocked } from '../wallet';
 
-import { AssetId } from './asset-id';
+import { TestAssetId } from './test-asset-id';
 import type { TestMessage } from './test-message';
 
 export interface WalletsConfigOptions {
@@ -17,9 +17,9 @@ export interface WalletsConfigOptions {
   /**
    * If `number`, the number of unique asset ids each wallet will own with the base asset included.
    *
-   * If `AssetId[]`, the asset ids the each wallet will own besides the base asset.
+   * If `TestAssetId[]`, the asset ids the each wallet will own besides the base asset.
    */
-  assets: number | AssetId[];
+  assets: number | TestAssetId[];
 
   /**
    * Number of coins (UTXOs) per asset id.
@@ -103,7 +103,7 @@ export class WalletsConfig {
   private static createCoins(
     wallets: WalletUnlocked[],
     baseAssetId: string,
-    assets: number | AssetId[],
+    assets: number | TestAssetId[],
     coinsPerAsset: number,
     amountPerCoin: number
   ) {
@@ -113,7 +113,7 @@ export class WalletsConfig {
     if (Array.isArray(assets)) {
       assetIds = assetIds.concat(assets.map((a) => a.value));
     } else {
-      assetIds = assetIds.concat(AssetId.random(assets - 1).map((a) => a.value));
+      assetIds = assetIds.concat(TestAssetId.random(assets - 1).map((a) => a.value));
     }
 
     wallets

--- a/packages/fuel-gauge/src/doc-examples.test.ts
+++ b/packages/fuel-gauge/src/doc-examples.test.ts
@@ -15,7 +15,7 @@ import {
   ZeroBytes32,
   Predicate,
 } from 'fuels';
-import { AssetId, launchTestNode } from 'fuels/test-utils';
+import { TestAssetId, launchTestNode } from 'fuels/test-utils';
 
 import { PredicateTrue } from '../test/typegen';
 import { CallTestContract } from '../test/typegen/contracts';
@@ -199,8 +199,8 @@ describe('Doc Examples', () => {
     const submitted = await fundingWallet.batchTransfer([
       { amount: 100, destination: walletA.address, assetId: baseAssetId },
       { amount: 100, destination: walletB.address, assetId: baseAssetId },
-      { amount: 100, destination: walletB.address, assetId: AssetId.B.value },
-      { amount: 100, destination: walletB.address, assetId: AssetId.A.value },
+      { amount: 100, destination: walletB.address, assetId: TestAssetId.B.value },
+      { amount: 100, destination: walletB.address, assetId: TestAssetId.A.value },
     ]);
 
     await submitted.waitForResult();
@@ -216,8 +216,8 @@ describe('Doc Examples', () => {
     // validate balances
     expect(walletABalances).toEqual([{ assetId: provider.getBaseAssetId(), amount: bn(100) }]);
     expect(walletBBalances).toEqual([
-      { assetId: AssetId.A.value, amount: bn(100) },
-      { assetId: AssetId.B.value, amount: bn(100) },
+      { assetId: TestAssetId.A.value, amount: bn(100) },
+      { assetId: TestAssetId.B.value, amount: bn(100) },
       { assetId: provider.getBaseAssetId(), amount: bn(100) },
     ]);
     expect(walletCBalances).toEqual([]);


### PR DESCRIPTION
- Closes #2904

# Release notes

<!--
Use this only if this PR requires a mention in the Release
Notes Summary. Valuable features and critical fixes are good
examples. For everything else, please delete the whole section.
-->

In this release, we:

- Renamed testing class `AssetId` to `TestAssetId`

# Breaking Changes

- Renamed testing class `AssetId` to `TestAssetId`

```ts
// Before
import { AssetId } from 'fuels/test-utils';

const [assetA] = AssetId.random();
```

```ts
// After
import { TestAssetId } from 'fuels/test-utils';

const [assetA] = TestAssetId.random();
```


# Checklist

- [X] I **_added_** — `tests` to prove my changes
- [X] I **_updated_** — all the necessary `docs`
- [X] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [X] I **_described_** — all breaking changes and the Migration Guide
