### PR TITLE
chore: updating pull request tasklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,5 +37,5 @@ Remove this section if there are no breaking changes.
 
 - [ ] All **changes** are **covered** by **tests** (or not applicable)
 - [ ] All **changes** are **documented** (or not applicable)
-- [ ] I **reviewed** the **entire PR** myself (prefarably, on GH UI)
+- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
 - [ ] I **described** all **Breaking Changes** (or there's none)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,7 +35,7 @@ Remove this section if there are no breaking changes.
 
 # Checklist
 
-- [ ] I **_added_** — `tests` to prove my changes
-- [ ] I **_updated_** — all the necessary `docs`
-- [ ] I **_reviewed_** — the entire PR myself, using the GitHub UI
-- [ ] I **_described_** — all breaking changes and the Migration Guide
+- [ ] All **changes** are **covered** by **tests** (or not applicable)
+- [ ] All **changes** are **documented** (or not applicable)
+- [ ] I **reviewed** the **entire PR** myself (prefarably, on GH UI)
+- [ ] I **described** all **Breaking Changes** (or there's none)


### PR DESCRIPTION
# Summary

I considered re-wording the PR tasklist, so all items must **_always_** be ☑️ completed.

This way, all tasks must be completed for a PR to be ready, adding consistency and removing ambiguity.

![inconsistent](https://github.com/user-attachments/assets/c5a16253-b4f6-4255-b59e-1eb6371a217f)

The tasklist 👇 for this PR already follows the new model for demo purposes:

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
