### PR TITLE
chore: deprecate `FUEL_NETWORK_URL` and `LOCAL_NETWORK_URL`

### DIFF
--- a/apps/demo-bun-fuels/src/bun.test.ts
+++ b/apps/demo-bun-fuels/src/bun.test.ts
@@ -5,25 +5,21 @@
  * It ensures that built code is fully working.
  */
 
-import { Provider, toHex, Wallet, FUEL_NETWORK_URL } from 'fuels';
-import { generateTestWallet, safeExec } from 'fuels/test-utils';
+import { toHex, Wallet } from 'fuels';
+import { launchTestNode, safeExec } from 'fuels/test-utils';
 
 import { Sample, SampleFactory } from './sway-programs-api';
 
-let baseAssetId: string;
-
 /**
  * @group node
+ * @group browser
  */
 describe('ExampleContract', () => {
-  beforeAll(async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    baseAssetId = provider.getBaseAssetId();
-  });
-
   it('should return the input', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const wallet = await generateTestWallet(provider, [[500_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      wallets: [wallet],
+    } = launched;
 
     // Deploy
     const factory = new SampleFactory(wallet);
@@ -49,8 +45,10 @@ describe('ExampleContract', () => {
   });
 
   it('deploy method', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const wallet = await generateTestWallet(provider, [[500_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      wallets: [wallet],
+    } = launched;
 
     // Deploy
     const deploy = await SampleFactory.deploy(wallet);
@@ -67,8 +65,12 @@ describe('ExampleContract', () => {
   });
 
   it('should throw when simulating via contract factory with wallet with no resources', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const fundedWallet = await generateTestWallet(provider, [[500_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [fundedWallet],
+    } = launched;
+
     const unfundedWallet = Wallet.generate({ provider });
 
     const deploy = await SampleFactory.deploy(fundedWallet);
@@ -84,8 +86,12 @@ describe('ExampleContract', () => {
   });
 
   it('should not throw when dry running via contract factory with wallet with no resources', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const fundedWallet = await generateTestWallet(provider, [[500_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [fundedWallet],
+    } = launched;
+
     const unfundedWallet = Wallet.generate({ provider });
 
     const deploy = await SampleFactory.deploy(fundedWallet);
@@ -97,9 +103,13 @@ describe('ExampleContract', () => {
   });
 
   it('should demo how to use generated files just fine', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const wallet = await generateTestWallet(provider, [[500_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      wallets: [wallet],
+    } = launched;
+
     const { waitForResult } = await SampleFactory.deploy(wallet);
+
     const { contract: depoloyed } = await waitForResult();
     const contractsIds = {
       sample: depoloyed.id,

--- a/apps/demo-fuels/src/index.test.ts
+++ b/apps/demo-fuels/src/index.test.ts
@@ -5,25 +5,21 @@
  * It ensures that built code is fully working.
  */
 
-import { Provider, toHex, Wallet, FUEL_NETWORK_URL } from 'fuels';
-import { generateTestWallet, safeExec } from 'fuels/test-utils';
+import { toHex, Wallet } from 'fuels';
+import { launchTestNode, safeExec } from 'fuels/test-utils';
 
 import { SampleFactory, Sample } from './sway-programs-api';
 
-let baseAssetId: string;
-
 /**
  * @group node
+ * @group browser
  */
 describe('ExampleContract', () => {
-  beforeAll(async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    baseAssetId = provider.getBaseAssetId();
-  });
-
   it('should return the input', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const wallet = await generateTestWallet(provider, [[500_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      wallets: [wallet],
+    } = launched;
 
     // Deploy
     const deploy = await SampleFactory.deploy(wallet);
@@ -44,8 +40,10 @@ describe('ExampleContract', () => {
   });
 
   it('should deploy contract', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const wallet = await generateTestWallet(provider, [[500_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      wallets: [wallet],
+    } = launched;
 
     // Deploy
     const deploy = await SampleFactory.deploy(wallet);
@@ -60,8 +58,12 @@ describe('ExampleContract', () => {
   });
 
   it('should throw when simulating via contract factory with wallet with no resources', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const fundedWallet = await generateTestWallet(provider, [[500_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [fundedWallet],
+    } = launched;
+
     const unfundedWallet = Wallet.generate({ provider });
 
     const deploy = await SampleFactory.deploy(fundedWallet);
@@ -77,8 +79,12 @@ describe('ExampleContract', () => {
   });
 
   it('should not throw when dry running via contract factory with wallet with no resources', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const fundedWallet = await generateTestWallet(provider, [[500_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [fundedWallet],
+    } = launched;
+
     const unfundedWallet = Wallet.generate({ provider });
 
     const { waitForResult } = await SampleFactory.deploy(fundedWallet);
@@ -89,12 +95,16 @@ describe('ExampleContract', () => {
   });
 
   it('should demo how to use generated files just fine', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const wallet = await generateTestWallet(provider, [[500_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      wallets: [wallet],
+    } = launched;
+
     const deploy = await SampleFactory.deploy(wallet);
-    const { contract: depoloyed } = await deploy.waitForResult();
+    const { contract: deployed } = await deploy.waitForResult();
+
     const contractsIds = {
-      sample: depoloyed.id,
+      sample: deployed.id,
     };
 
     // #region using-generated-files

--- a/apps/docs-snippets/src/guide/contracts/calls-with-different-wallets.test.ts
+++ b/apps/docs-snippets/src/guide/contracts/calls-with-different-wallets.test.ts
@@ -1,23 +1,25 @@
-import type { Contract } from 'fuels';
-import { FUEL_NETWORK_URL, Provider, WalletUnlocked } from 'fuels';
+import { WalletUnlocked } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
-import { DocSnippetProjectsEnum } from '../../../test/fixtures/forc-projects';
-import { createAndDeployContractFromProject } from '../../utils';
+import { ReturnContextFactory } from '../../../test/typegen';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
-  let deployedContract: Contract;
-
-  beforeAll(async () => {
-    deployedContract = await createAndDeployContractFromProject(
-      DocSnippetProjectsEnum.RETURN_CONTEXT
-    );
-  });
-
+describe('Calls with different wallets', () => {
   it('should successfully update contract instance wallet', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await launchTestNode({
+      contractsConfigs: [
+        {
+          factory: ReturnContextFactory,
+        },
+      ],
+    });
+    const {
+      provider,
+      contracts: [deployedContract],
+    } = launched;
     const newWallet = WalletUnlocked.generate({
       provider,
     });
@@ -30,20 +32,4 @@ describe(__filename, () => {
 
     expect(deployedContract.account.address).toBe(newWallet.address);
   });
-
-  // TODO: We are skipping and commenting out this test because the constructor for `Provider` is private now.
-  /*
-  it('should successfully update contract instance provider', () => {
-    // use the `chainInfo` from the deployed contract's provider to create a new dummy provider
-    const newProvider = new Provider('http://provider:9999');
-
-    expect(deployedContract.provider?.url).not.toBe(newProvider.url);
-
-    // #region calls-with-different-wallets-2
-    deployedContract.provider = newProvider;
-    // #endregion calls-with-different-wallets-2
-
-    expect(deployedContract.provider.url).toBe(newProvider.url);
-  });
-  */
 });

--- a/apps/docs-snippets/src/guide/contracts/contract-balance.test.ts
+++ b/apps/docs-snippets/src/guide/contracts/contract-balance.test.ts
@@ -1,22 +1,27 @@
-import type { Contract, AssetId } from 'fuels';
-import { Wallet, BN, Provider, FUEL_NETWORK_URL } from 'fuels';
+import type { AssetId } from 'fuels';
+import { Wallet, BN } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
-import { DocSnippetProjectsEnum } from '../../../test/fixtures/forc-projects';
-import { createAndDeployContractFromProject } from '../../utils';
+import { TransferToAddressFactory } from '../../../test/typegen';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
-  let contract: Contract;
-  let provider: Provider;
-
-  beforeAll(async () => {
-    provider = await Provider.create(FUEL_NETWORK_URL);
-    contract = await createAndDeployContractFromProject(DocSnippetProjectsEnum.TRANSFER_TO_ADDRESS);
-  });
-
+describe('Contract Balance', () => {
   it('should successfully get a contract balance', async () => {
+    using launched = await launchTestNode({
+      contractsConfigs: [
+        {
+          factory: TransferToAddressFactory,
+        },
+      ],
+    });
+    const {
+      provider,
+      contracts: [contract],
+    } = launched;
+
     // #region contract-balance-3
     // #import { AssetId, Wallet, BN };
 

--- a/apps/docs-snippets/src/guide/contracts/deploying-contracts.test.ts
+++ b/apps/docs-snippets/src/guide/contracts/deploying-contracts.test.ts
@@ -1,31 +1,29 @@
 import { readFileSync } from 'fs';
-import { Provider, FUEL_NETWORK_URL, Wallet, ContractFactory } from 'fuels';
+import { Wallet, ContractFactory } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 import { join } from 'path';
 
 import { DocSnippetProjectsEnum } from '../../../test/fixtures/forc-projects';
-import { getTestWallet } from '../../utils';
 
 /**
  * @group node
  */
-describe(__filename, () => {
-  let PRIVATE_KEY: string;
-  let projectsPath: string;
-  let contractName: string;
 
-  beforeAll(async () => {
-    const wallet = await getTestWallet();
-    PRIVATE_KEY = wallet.privateKey;
-    projectsPath = join(__dirname, '../../../test/fixtures/forc-projects');
-
-    contractName = DocSnippetProjectsEnum.ECHO_VALUES;
-  });
-
+// #TODO: This will need to be updated post-merge of https://github.com/FuelLabs/fuels-ts/pull/2827
+describe('Deploying contracts', () => {
   it('should successfully deploy and execute contract function', async () => {
+    const projectsPath = join(__dirname, '../../../test/fixtures/forc-projects');
+    const contractName = DocSnippetProjectsEnum.ECHO_VALUES;
+
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [testWallet],
+    } = launched;
+    const PRIVATE_KEY = testWallet.privateKey;
+
     // #region contract-setup-1
     // #context const PRIVATE_KEY = "..."
-
-    const provider = await Provider.create(FUEL_NETWORK_URL);
 
     const wallet = Wallet.fromPrivateKey(PRIVATE_KEY, provider);
     // #endregion contract-setup-1
@@ -33,7 +31,6 @@ describe(__filename, () => {
     // #region contract-setup-2
     // #context const contractsDir = join(__dirname, '../path/to/contracts/dir')
     // #context const contractName = "contract-name"
-
     const byteCodePath = join(projectsPath, `${contractName}/out/release/${contractName}.bin`);
     const byteCode = readFileSync(byteCodePath);
 
@@ -43,7 +40,6 @@ describe(__filename, () => {
 
     // #region contract-setup-3
     const factory = new ContractFactory(byteCode, abi, wallet);
-
     const { contractId, transactionId, waitForResult } = await factory.deploy();
     // #endregion contract-setup-3
 

--- a/apps/docs-snippets/src/guide/cookbook/generate-fake-resources.test.ts
+++ b/apps/docs-snippets/src/guide/cookbook/generate-fake-resources.test.ts
@@ -1,36 +1,26 @@
 import type { TransactionResultReturnDataReceipt } from 'fuels';
-import {
-  FUEL_NETWORK_URL,
-  Provider,
-  ReceiptType,
-  ScriptTransactionRequest,
-  Wallet,
-  bn,
-} from 'fuels';
+import { ReceiptType, ScriptTransactionRequest, bn } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
-import {
-  DocSnippetProjectsEnum,
-  getDocsSnippetsForcProject,
-} from '../../../test/fixtures/forc-projects';
+import { ReturnScript } from '../../../test/typegen';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
+describe('Generate fake resources', () => {
   it('should generate fake resources just fine', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const wallet = Wallet.generate({ provider });
+    const {
+      provider,
+      wallets: [wallet],
+    } = await launchTestNode();
     const baseAssetId = provider.getBaseAssetId();
-
-    const { binHexlified: scriptHexBytes } = getDocsSnippetsForcProject(
-      DocSnippetProjectsEnum.RETURN_SCRIPT
-    );
 
     // #region generate-fake-resources-2
     const transactionRequest = new ScriptTransactionRequest({
       gasLimit: bn(62_000),
       maxFee: bn(60_000),
-      script: scriptHexBytes,
+      script: ReturnScript.bytecode,
     });
 
     const resources = wallet.generateFakeResources([

--- a/apps/docs-snippets/src/guide/encoding/encode-and-decode.test.ts
+++ b/apps/docs-snippets/src/guide/encoding/encode-and-decode.test.ts
@@ -1,35 +1,25 @@
-import {
-  FUEL_NETWORK_URL,
-  Provider,
-  AbiCoder,
-  Script,
-  ReceiptType,
-  arrayify,
-  buildFunctionResult,
-} from 'fuels';
-import type { Account, JsonAbi, JsonAbiArgument, TransactionResultReturnDataReceipt } from 'fuels';
-import { generateTestWallet } from 'fuels/test-utils';
+import { AbiCoder, Script, ReceiptType, arrayify, buildFunctionResult } from 'fuels';
+import type { JsonAbi, JsonAbiArgument, TransactionResultReturnDataReceipt } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 import abiSnippet from '../../../test/fixtures/abi/encode-and-decode.jsonc';
 import { SumScript as factory } from '../../../test/typegen/scripts/SumScript';
 
 /**
  * @group node
+ * @group browser
  */
 describe('encode and decode', () => {
-  let wallet: Account;
-
-  beforeAll(async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const assetId = provider.getBaseAssetId();
-    wallet = await generateTestWallet(provider, [{ assetId, amount: 500_000 }]);
-  });
-
   it('generates valid ABI', () => {
     expect(abiSnippet).toEqual(factory.abi);
   });
 
   it('encodes and decodes', async () => {
+    using launched = await launchTestNode();
+    const {
+      wallets: [wallet],
+    } = launched;
+
     // #region encode-and-decode-3
     // #import { JsonAbi, Script };
     // #context import { factory } from './sway-programs-api';

--- a/apps/docs-snippets/src/guide/introduction/getting-started.test.ts
+++ b/apps/docs-snippets/src/guide/introduction/getting-started.test.ts
@@ -1,22 +1,22 @@
-import { FUEL_NETWORK_URL, TESTNET_NETWORK_URL, Provider, Wallet, WalletUnlocked } from 'fuels';
+import { TESTNET_NETWORK_URL, Provider, Wallet, WalletUnlocked } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
  * @group browser
  */
 describe('Getting started', () => {
-  beforeAll(async () => {
-    // Avoids using the actual network.
-    const mockProvider = await Provider.create(FUEL_NETWORK_URL);
-    vi.spyOn(Provider, 'create').mockResolvedValue(mockProvider);
-  });
-
   it('can connect to a local network', async () => {
+    using launched = await launchTestNode();
+
+    const mockedProvider = await Provider.create(launched.provider.url);
+    vi.spyOn(Provider, 'create').mockResolvedValueOnce(mockedProvider);
+
     // #region connecting-to-the-local-node
     // #import { Provider, Wallet };
 
     // Create a provider.
-    const LOCAL_FUEL_NETWORK = 'http://127.0.0.1:4000/v1/graphql';
+    const LOCAL_FUEL_NETWORK = `http://127.0.0.1:4000/v1/graphql`;
     const provider = await Provider.create(LOCAL_FUEL_NETWORK);
 
     // Create our wallet (with a private key).
@@ -31,6 +31,11 @@ describe('Getting started', () => {
   });
 
   it('can connect to testnet', async () => {
+    using launched = await launchTestNode();
+
+    const mockedProvider = await Provider.create(launched.provider.url);
+    vi.spyOn(Provider, 'create').mockResolvedValueOnce(mockedProvider);
+
     // #region connecting-to-the-testnet
     // #import { Provider, Wallet, TESTNET_NETWORK_URL };
 

--- a/apps/docs-snippets/src/guide/predicates/index.test.ts
+++ b/apps/docs-snippets/src/guide/predicates/index.test.ts
@@ -1,5 +1,6 @@
 import type { PredicateParams } from 'fuels';
-import { FUEL_NETWORK_URL, Provider, Predicate } from 'fuels';
+import { Predicate } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 import {
   DocSnippetProjectsEnum,
@@ -15,10 +16,11 @@ describe(__filename, () => {
   );
 
   it('should successfully instantiate a predicate', async () => {
-    // #region predicate-index-2
-    // #import { Predicate, Provider, FUEL_NETWORK_URL };
+    using launched = await launchTestNode();
+    const { provider } = launched;
 
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    // #region predicate-index-2
+    // #import { Predicate, PredicateParams };
     const predicateParams: PredicateParams = {
       bytecode: binary,
       provider,

--- a/apps/docs-snippets/src/guide/provider/pagination.test.ts
+++ b/apps/docs-snippets/src/guide/provider/pagination.test.ts
@@ -1,9 +1,10 @@
 import type { GqlPageInfo } from '@fuel-ts/account/dist/providers/__generated__/operations';
 import type { CursorPaginationArgs } from 'fuels';
-import { FUEL_NETWORK_URL, Provider, Wallet } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
+ * @group browser
  */
 describe('querying the chain', () => {
   it('pagination snippet test 1', () => {
@@ -30,12 +31,13 @@ describe('querying the chain', () => {
   });
 
   it('pagination snippet test 2', async () => {
-    // #region pagination-3
-    // #import { Provider, CursorPaginationArgs, FUEL_NETWORK_URL, Wallet };
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [myWallet],
+    } = launched;
 
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const baseAssetId = provider.getBaseAssetId();
-    const myWallet = Wallet.generate({ provider });
+    // #region pagination-3
 
     let paginationArgs: CursorPaginationArgs = {
       first: 10, // It will return only the first 10 coins
@@ -43,7 +45,7 @@ describe('querying the chain', () => {
 
     const { coins, pageInfo } = await provider.getCoins(
       myWallet.address,
-      baseAssetId,
+      provider.getBaseAssetId(),
       paginationArgs
     );
 
@@ -53,7 +55,7 @@ describe('querying the chain', () => {
         first: 10,
       };
       // The coins array will include the next 10 coins after the last one in the previous array
-      await provider.getCoins(myWallet.address, baseAssetId, paginationArgs);
+      await provider.getCoins(myWallet.address, provider.getBaseAssetId(), paginationArgs);
     }
     // #endregion pagination-3
 
@@ -65,7 +67,7 @@ describe('querying the chain', () => {
       };
 
       // It will includes the previous 10 coins before the first one in the previous array
-      await provider.getCoins(myWallet.address, baseAssetId, paginationArgs);
+      await provider.getCoins(myWallet.address, provider.getBaseAssetId(), paginationArgs);
     }
     // #endregion pagination-4
 
@@ -90,11 +92,12 @@ describe('querying the chain', () => {
   });
 
   it('pagination snippet test 5', async () => {
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [myWallet],
+    } = launched;
     // #region pagination-7
-    // #import { Provider, FUEL_NETWORK_URL, Wallet };
-
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const myWallet = Wallet.generate({ provider });
 
     // It will return the first 100 coins of the base asset
     const { coins, pageInfo } = await provider.getCoins(myWallet.address);

--- a/apps/docs-snippets/src/guide/provider/provider.test.ts
+++ b/apps/docs-snippets/src/guide/provider/provider.test.ts
@@ -1,11 +1,5 @@
-import {
-  FUEL_NETWORK_URL,
-  Provider,
-  ScriptTransactionRequest,
-  sleep,
-  WalletUnlocked,
-  Address,
-} from 'fuels';
+import { Provider, ScriptTransactionRequest, sleep, WalletUnlocked, Address } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 async function fetchSomeExternalCredentials() {
   return Promise.resolve('credential');
@@ -21,8 +15,15 @@ function decorateResponseWithCustomLogic(response: Response) {
  */
 describe('Provider', () => {
   it('base examples', async () => {
+    using launched = await launchTestNode();
+
+    const mockedProvider = await Provider.create(launched.provider.url);
+    vi.spyOn(Provider, 'create').mockResolvedValueOnce(mockedProvider);
+
     // #region provider-definition
-    // #import { Provider, FUEL_NETWORK_URL, WalletUnlocked };
+    // #import { Provider, WalletUnlocked };
+
+    const FUEL_NETWORK_URL = 'http://127.0.0.1:4000/v1/graphql';
 
     // Create the provider
     const provider = await Provider.create(FUEL_NETWORK_URL);
@@ -46,6 +47,10 @@ describe('Provider', () => {
   });
 
   test('options: requestMiddleware', async () => {
+    using launched = await launchTestNode();
+
+    const FUEL_NETWORK_URL = launched.provider.url;
+
     // #region options-requestMiddleware
     // synchronous request middleware
     await Provider.create(FUEL_NETWORK_URL, {
@@ -70,6 +75,10 @@ describe('Provider', () => {
   });
 
   it('options: timeout', async () => {
+    using launched = await launchTestNode();
+
+    const FUEL_NETWORK_URL = launched.provider.url;
+
     // #region options-timeout
     await Provider.create(FUEL_NETWORK_URL, {
       timeout: 30000, // will abort if request takes 30 seconds to complete
@@ -78,6 +87,10 @@ describe('Provider', () => {
   });
 
   it('options: retryOptions', async () => {
+    using launched = await launchTestNode();
+
+    const FUEL_NETWORK_URL = launched.provider.url;
+
     // #region options-retryOptions
     await Provider.create(FUEL_NETWORK_URL, {
       retryOptions: {
@@ -90,6 +103,10 @@ describe('Provider', () => {
   });
 
   it('options: fetch', async () => {
+    using launched = await launchTestNode();
+
+    const FUEL_NETWORK_URL = launched.provider.url;
+
     // #region options-fetch
     await Provider.create(FUEL_NETWORK_URL, {
       fetch: async (url: string, requestInit: RequestInit | undefined) => {
@@ -108,6 +125,9 @@ describe('Provider', () => {
   });
 
   it('options: resourceCacheTTL', async () => {
+    using launched = await launchTestNode();
+
+    const FUEL_NETWORK_URL = launched.provider.url;
     // #region options-cache-utxo
     const provider = await Provider.create(FUEL_NETWORK_URL, {
       resourceCacheTTL: 5000, // cache resources (Coin's and Message's) for 5 seconds
@@ -119,9 +139,15 @@ describe('Provider', () => {
 
   it('fetches the base asset ID', async () => {
     const recipientAddress = Address.fromRandom();
+    using launched = await launchTestNode();
+
+    const mockedProvider = await Provider.create(launched.provider.url);
+    vi.spyOn(Provider, 'create').mockResolvedValueOnce(mockedProvider);
 
     // #region provider-getBaseAssetId
-    // #import { Provider, FUEL_NETWORK_URL, ScriptTransactionRequest };
+    // #import { Provider, ScriptTransactionRequest };
+
+    const FUEL_NETWORK_URL = 'http://127.0.0.1:4000/v1/graphql';
 
     // Fetch the base asset ID using the provider
     const provider = await Provider.create(FUEL_NETWORK_URL);
@@ -138,6 +164,10 @@ describe('Provider', () => {
   });
 
   it('using operations', async () => {
+    using launched = await launchTestNode();
+
+    const FUEL_NETWORK_URL = launched.provider.url;
+
     // #region operations
     const provider = await Provider.create(FUEL_NETWORK_URL);
 

--- a/apps/docs-snippets/src/guide/provider/provider.test.ts
+++ b/apps/docs-snippets/src/guide/provider/provider.test.ts
@@ -1,4 +1,14 @@
-import { Provider, ScriptTransactionRequest, sleep, WalletUnlocked, Address } from 'fuels';
+/* eslint-disable @typescript-eslint/no-shadow */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import {
+  Provider,
+  ScriptTransactionRequest,
+  sleep,
+  WalletUnlocked,
+  Address,
+  FUEL_NETWORK_URL,
+} from 'fuels';
 import { launchTestNode } from 'fuels/test-utils';
 
 async function fetchSomeExternalCredentials() {
@@ -17,13 +27,10 @@ describe('Provider', () => {
   it('base examples', async () => {
     using launched = await launchTestNode();
 
-    const mockedProvider = await Provider.create(launched.provider.url);
-    vi.spyOn(Provider, 'create').mockResolvedValueOnce(mockedProvider);
+    const FUEL_NETWORK_URL = launched.provider.url;
 
     // #region provider-definition
-    // #import { Provider, WalletUnlocked };
-
-    const FUEL_NETWORK_URL = 'http://127.0.0.1:4000/v1/graphql';
+    // #import { Provider, FUEL_NETWORK_URL, WalletUnlocked };
 
     // Create the provider
     const provider = await Provider.create(FUEL_NETWORK_URL);
@@ -50,7 +57,6 @@ describe('Provider', () => {
     using launched = await launchTestNode();
 
     const FUEL_NETWORK_URL = launched.provider.url;
-
     // #region options-requestMiddleware
     // synchronous request middleware
     await Provider.create(FUEL_NETWORK_URL, {
@@ -141,13 +147,10 @@ describe('Provider', () => {
     const recipientAddress = Address.fromRandom();
     using launched = await launchTestNode();
 
-    const mockedProvider = await Provider.create(launched.provider.url);
-    vi.spyOn(Provider, 'create').mockResolvedValueOnce(mockedProvider);
+    const FUEL_NETWORK_URL = launched.provider.url;
 
     // #region provider-getBaseAssetId
-    // #import { Provider, ScriptTransactionRequest };
-
-    const FUEL_NETWORK_URL = 'http://127.0.0.1:4000/v1/graphql';
+    // #import { Provider, FUEL_NETWORK_URL, ScriptTransactionRequest };
 
     // Fetch the base asset ID using the provider
     const provider = await Provider.create(FUEL_NETWORK_URL);

--- a/apps/docs-snippets/src/guide/provider/provider.test.ts
+++ b/apps/docs-snippets/src/guide/provider/provider.test.ts
@@ -1,14 +1,4 @@
-/* eslint-disable @typescript-eslint/no-shadow */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-import {
-  Provider,
-  ScriptTransactionRequest,
-  sleep,
-  WalletUnlocked,
-  Address,
-  FUEL_NETWORK_URL,
-} from 'fuels';
+import { Provider, ScriptTransactionRequest, sleep, WalletUnlocked, Address } from 'fuels';
 import { launchTestNode } from 'fuels/test-utils';
 
 async function fetchSomeExternalCredentials() {
@@ -27,10 +17,13 @@ describe('Provider', () => {
   it('base examples', async () => {
     using launched = await launchTestNode();
 
-    const FUEL_NETWORK_URL = launched.provider.url;
+    const mockedProvider = await Provider.create(launched.provider.url);
+    vi.spyOn(Provider, 'create').mockResolvedValueOnce(mockedProvider);
 
     // #region provider-definition
-    // #import { Provider, FUEL_NETWORK_URL, WalletUnlocked };
+    // #import { Provider, WalletUnlocked };
+
+    const FUEL_NETWORK_URL = 'http://127.0.0.1:4000/v1/graphql';
 
     // Create the provider
     const provider = await Provider.create(FUEL_NETWORK_URL);
@@ -57,6 +50,7 @@ describe('Provider', () => {
     using launched = await launchTestNode();
 
     const FUEL_NETWORK_URL = launched.provider.url;
+
     // #region options-requestMiddleware
     // synchronous request middleware
     await Provider.create(FUEL_NETWORK_URL, {
@@ -147,10 +141,13 @@ describe('Provider', () => {
     const recipientAddress = Address.fromRandom();
     using launched = await launchTestNode();
 
-    const FUEL_NETWORK_URL = launched.provider.url;
+    const mockedProvider = await Provider.create(launched.provider.url);
+    vi.spyOn(Provider, 'create').mockResolvedValueOnce(mockedProvider);
 
     // #region provider-getBaseAssetId
-    // #import { Provider, FUEL_NETWORK_URL, ScriptTransactionRequest };
+    // #import { Provider, ScriptTransactionRequest };
+
+    const FUEL_NETWORK_URL = 'http://127.0.0.1:4000/v1/graphql';
 
     // Fetch the base asset ID using the provider
     const provider = await Provider.create(FUEL_NETWORK_URL);

--- a/apps/docs-snippets/src/guide/provider/querying-the-chain.test.ts
+++ b/apps/docs-snippets/src/guide/provider/querying-the-chain.test.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-shadow */
 import type {
   TransactionResultMessageOutReceipt,
   CoinQuantityLike,
   ExcludeResourcesOption,
 } from 'fuels';
-import { ScriptTransactionRequest, FUEL_NETWORK_URL, Provider } from 'fuels';
+import { ScriptTransactionRequest, Provider } from 'fuels';
 import { TestAssetId, TestMessage, launchTestNode } from 'fuels/test-utils';
 
 /**
@@ -28,7 +27,7 @@ describe('querying the chain', () => {
     const FUEL_NETWORK_URL = testProvider.url;
 
     // #region get-coins-1
-    // #import { Provider, FUEL_NETWORK_URL };
+    // #import { Provider };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
 
@@ -74,7 +73,7 @@ describe('querying the chain', () => {
     const FUEL_NETWORK_URL = testProvider.url;
 
     // #region get-spendable-resources-1
-    // #import { Provider, FUEL_NETWORK_URL, ScriptTransactionRequest, CoinQuantityLike, ExcludeResourcesOption };
+    // #import { Provider, ScriptTransactionRequest, CoinQuantityLike, ExcludeResourcesOption };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
     const assetIdA = '0x0101010101010101010101010101010101010101010101010101010101010101';
@@ -125,7 +124,7 @@ describe('querying the chain', () => {
     const FUEL_NETWORK_URL = testProvider.url;
 
     // #region get-balances-1
-    // #import { Provider, FUEL_NETWORK_URL };
+    // #import { Provider };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
 
@@ -149,7 +148,7 @@ describe('querying the chain', () => {
     const FUEL_NETWORK_URL = launched.provider.url;
 
     // #region Provider-get-blocks
-    // #import { Provider, FUEL_NETWORK_URL };
+    // #import { Provider };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
 
@@ -172,7 +171,7 @@ describe('querying the chain', () => {
     const FUEL_NETWORK_URL = testProvider.url;
 
     // #region get-message-by-nonce-1
-    // #import { Provider, FUEL_NETWORK_URL };
+    // #import { Provider };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
 

--- a/apps/docs-snippets/src/guide/provider/querying-the-chain.test.ts
+++ b/apps/docs-snippets/src/guide/provider/querying-the-chain.test.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-shadow */
 import type {
   TransactionResultMessageOutReceipt,
   CoinQuantityLike,
   ExcludeResourcesOption,
 } from 'fuels';
-import { ScriptTransactionRequest, Provider } from 'fuels';
+import { ScriptTransactionRequest, FUEL_NETWORK_URL, Provider } from 'fuels';
 import { TestAssetId, TestMessage, launchTestNode } from 'fuels/test-utils';
 
 /**
@@ -27,7 +28,7 @@ describe('querying the chain', () => {
     const FUEL_NETWORK_URL = testProvider.url;
 
     // #region get-coins-1
-    // #import { Provider };
+    // #import { Provider, FUEL_NETWORK_URL };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
 
@@ -73,7 +74,7 @@ describe('querying the chain', () => {
     const FUEL_NETWORK_URL = testProvider.url;
 
     // #region get-spendable-resources-1
-    // #import { Provider, ScriptTransactionRequest, CoinQuantityLike, ExcludeResourcesOption };
+    // #import { Provider, FUEL_NETWORK_URL, ScriptTransactionRequest, CoinQuantityLike, ExcludeResourcesOption };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
     const assetIdA = '0x0101010101010101010101010101010101010101010101010101010101010101';
@@ -124,7 +125,7 @@ describe('querying the chain', () => {
     const FUEL_NETWORK_URL = testProvider.url;
 
     // #region get-balances-1
-    // #import { Provider };
+    // #import { Provider, FUEL_NETWORK_URL };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
 
@@ -148,7 +149,7 @@ describe('querying the chain', () => {
     const FUEL_NETWORK_URL = launched.provider.url;
 
     // #region Provider-get-blocks
-    // #import { Provider };
+    // #import { Provider, FUEL_NETWORK_URL };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
 
@@ -171,7 +172,7 @@ describe('querying the chain', () => {
     const FUEL_NETWORK_URL = testProvider.url;
 
     // #region get-message-by-nonce-1
-    // #import { Provider };
+    // #import { Provider, FUEL_NETWORK_URL };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
 

--- a/apps/docs-snippets/src/guide/provider/querying-the-chain.test.ts
+++ b/apps/docs-snippets/src/guide/provider/querying-the-chain.test.ts
@@ -1,39 +1,50 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import type {
   TransactionResultMessageOutReceipt,
   CoinQuantityLike,
   ExcludeResourcesOption,
 } from 'fuels';
-import { FUEL_NETWORK_URL, Provider, ScriptTransactionRequest } from 'fuels';
-import { TestMessage, generateTestWallet, launchTestNode } from 'fuels/test-utils';
+import { ScriptTransactionRequest, Provider } from 'fuels';
+import { TestAssetId, TestMessage, launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
+ * @group browser
  */
 describe('querying the chain', () => {
   it('query coins', async () => {
+    using launched = await launchTestNode({
+      walletsConfig: {
+        amountPerCoin: 100,
+        assets: [TestAssetId.A],
+      },
+    });
+    const {
+      provider: testProvider,
+      wallets: [wallet],
+    } = launched;
+
+    const FUEL_NETWORK_URL = testProvider.url;
+
     // #region get-coins-1
-    // #import { Provider, FUEL_NETWORK_URL, generateTestWallet };
+    // #import { Provider };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
+
     const assetIdA = '0x0101010101010101010101010101010101010101010101010101010101010101';
     const baseAssetId = provider.getBaseAssetId();
-
-    const wallet = await generateTestWallet(provider, [
-      [42, baseAssetId],
-      [100, assetIdA],
-    ]);
 
     // fetches up to 100 coins from baseAssetId
     const { coins, pageInfo } = await provider.getCoins(wallet.address, baseAssetId);
     // [
-    //   { amount: bn(42), assetId: baseAssetId },
+    //   { amount: bn(100), assetId: baseAssetId },
     //   ...
     // ]
 
     // fetches up to 100 coins from all assets
     await provider.getCoins(wallet.address);
     // [
-    //   { amount: bn(42), assetId: baseAssetId }
+    //   { amount: bn(100), assetId: baseAssetId }
     //   { amount: bn(100), assetId: assetIdA }
     //   ...
     // ]
@@ -48,17 +59,26 @@ describe('querying the chain', () => {
   });
 
   it('get spendable resources', async () => {
+    using launched = await launchTestNode({
+      walletsConfig: {
+        amountPerCoin: 100,
+        assets: [TestAssetId.A],
+      },
+    });
+    const {
+      provider: testProvider,
+      wallets: [wallet],
+    } = launched;
+
+    const FUEL_NETWORK_URL = testProvider.url;
+
     // #region get-spendable-resources-1
-    // #import { Provider, FUEL_NETWORK_URL, generateTestWallet, ScriptTransactionRequest, CoinQuantityLike, ExcludeResourcesOption };
+    // #import { Provider, ScriptTransactionRequest, CoinQuantityLike, ExcludeResourcesOption };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
     const assetIdA = '0x0101010101010101010101010101010101010101010101010101010101010101';
-    const baseAssetId = provider.getBaseAssetId();
 
-    const wallet = await generateTestWallet(provider, [
-      [42, baseAssetId],
-      [100, assetIdA],
-    ]);
+    const baseAssetId = provider.getBaseAssetId();
 
     const quantities: CoinQuantityLike[] = [
       { amount: 32, assetId: baseAssetId, max: 42 },
@@ -90,17 +110,23 @@ describe('querying the chain', () => {
   });
 
   it('get balances', async () => {
+    using launched = await launchTestNode({
+      walletsConfig: {
+        amountPerCoin: 100,
+        assets: [TestAssetId.A],
+      },
+    });
+    const {
+      provider: testProvider,
+      wallets: [wallet],
+    } = launched;
+
+    const FUEL_NETWORK_URL = testProvider.url;
+
     // #region get-balances-1
-    // #import { Provider, FUEL_NETWORK_URL, generateTestWallet };
+    // #import { Provider };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
-    const assetIdA = '0x0101010101010101010101010101010101010101010101010101010101010101';
-    const baseAssetId = provider.getBaseAssetId();
-
-    const wallet = await generateTestWallet(provider, [
-      [42, baseAssetId],
-      [100, assetIdA],
-    ]);
 
     const { balances } = await provider.getBalances(wallet.address);
     // [
@@ -117,10 +143,15 @@ describe('querying the chain', () => {
   });
 
   it('can getBlocks', async () => {
+    using launched = await launchTestNode();
+
+    const FUEL_NETWORK_URL = launched.provider.url;
+
     // #region Provider-get-blocks
-    // #import { Provider, FUEL_NETWORK_URL };
+    // #import { Provider };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
+
     const blockToProduce = 3;
 
     // Force-producing some blocks to make sure that 10 blocks exist
@@ -134,8 +165,13 @@ describe('querying the chain', () => {
   });
 
   it('can getMessageByNonce', async () => {
+    using launched = await launchTestNode();
+    const { provider: testProvider } = launched;
+
+    const FUEL_NETWORK_URL = testProvider.url;
+
     // #region get-message-by-nonce-1
-    // #import { FUEL_NETWORK_URL, Provider };
+    // #import { Provider };
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
 

--- a/apps/docs-snippets/src/guide/scripts/script-custom-transaction.test.ts
+++ b/apps/docs-snippets/src/guide/scripts/script-custom-transaction.test.ts
@@ -1,57 +1,31 @@
-import {
-  BN,
-  ContractFactory,
-  FUEL_NETWORK_URL,
-  ScriptTransactionRequest,
-  coinQuantityfy,
-  Provider,
-} from 'fuels';
-import type { CoinQuantityLike, Contract, WalletUnlocked } from 'fuels';
-import { ASSET_A, ASSET_B } from 'fuels/test-utils';
+import { BN, ScriptTransactionRequest, coinQuantityfy } from 'fuels';
+import { ASSET_A, ASSET_B, launchTestNode } from 'fuels/test-utils';
 
-import {
-  DocSnippetProjectsEnum,
-  getDocsSnippetsForcProject,
-} from '../../../test/fixtures/forc-projects';
-import { defaultTxParams, getTestWallet } from '../../utils';
+import { EchoValuesFactory, ScriptTransferToContract } from '../../../test/typegen';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
-  let wallet: WalletUnlocked;
-  let provider: Provider;
-  let contract: Contract;
-  let baseAssetId: string;
-
-  const { binHexlified: scriptBin, abiContents } = getDocsSnippetsForcProject(
-    DocSnippetProjectsEnum.SCRIPT_TRANSFER_TO_CONTRACT
-  );
-
-  const { abiContents: contractAbi, binHexlified: contractBin } = getDocsSnippetsForcProject(
-    DocSnippetProjectsEnum.ECHO_VALUES
-  );
-
-  beforeAll(async () => {
-    provider = await Provider.create(FUEL_NETWORK_URL);
-    baseAssetId = provider.getBaseAssetId();
-    const seedQuantities: CoinQuantityLike[] = [
-      [1000, ASSET_A],
-      [500, ASSET_B],
-      [300_000, baseAssetId],
-    ];
-    wallet = await getTestWallet(seedQuantities);
-    const factory = new ContractFactory(contractBin, contractAbi, wallet);
-    const { waitForResult } = await factory.deploy();
-    ({ contract } = await waitForResult());
-  });
-
+describe('Script Custom Transaction', () => {
   it('transfer multiple assets to a contract', async () => {
+    using launched = await launchTestNode({
+      contractsConfigs: [{ factory: EchoValuesFactory }],
+    });
+    const {
+      contracts: [contract],
+      wallets: [wallet],
+    } = launched;
+
     const contractInitialBalanceAssetA = await contract.getBalance(ASSET_A);
     const contractInitialBalanceAssetB = await contract.getBalance(ASSET_B);
 
     expect(contractInitialBalanceAssetA).toStrictEqual(new BN(0));
     expect(contractInitialBalanceAssetB).toStrictEqual(new BN(0));
+
+    const defaultTxParams = {
+      gasLimit: 10000,
+    };
 
     // #region custom-transactions-2
     // #import { BN, ScriptTransactionRequest };
@@ -60,7 +34,7 @@ describe(__filename, () => {
     const request = new ScriptTransactionRequest({
       ...defaultTxParams,
       gasLimit: 3_000_000,
-      script: scriptBin,
+      script: ScriptTransferToContract.bytecode,
     });
 
     // 2. Instantiate the script main arguments
@@ -73,7 +47,9 @@ describe(__filename, () => {
     ];
 
     // 3. Populate the script data and add the contract input and output
-    request.setData(abiContents, scriptArguments).addContractInputAndOutput(contract.id);
+    request
+      .setData(ScriptTransferToContract.abi, scriptArguments)
+      .addContractInputAndOutput(contract.id);
 
     // 4. Get the transaction resources
     const quantities = [coinQuantityfy([1000, ASSET_A]), coinQuantityfy([500, ASSET_B])];

--- a/apps/docs-snippets/src/guide/transactions/transaction-request.test.ts
+++ b/apps/docs-snippets/src/guide/transactions/transaction-request.test.ts
@@ -7,64 +7,18 @@ import {
   Address,
   bn,
   Predicate,
-  Provider,
-  FUEL_NETWORK_URL,
   WalletUnlocked,
 } from 'fuels';
-import { seedTestWallet } from 'fuels/test-utils';
+import { launchTestNode } from 'fuels/test-utils';
 
-import {
-  DocSnippetProjectsEnum,
-  getDocsSnippetsForcProject,
-} from '../../../test/fixtures/forc-projects';
+import { SimplePredicate, SumScript } from '../../../test/typegen';
 
 /**
  * @group node
+ * @group browser
  */
 describe('Transaction Request', () => {
-  let provider: Provider;
-  let baseAssetId: string = ZeroBytes32;
-
-  const { abiContents: scriptAbi, binHexlified: scriptBytecode } = getDocsSnippetsForcProject(
-    DocSnippetProjectsEnum.SUM_SCRIPT
-  );
-
-  const { abiContents: predicateAbi, binHexlified: predicateBytecode } = getDocsSnippetsForcProject(
-    DocSnippetProjectsEnum.SIMPLE_PREDICATE
-  );
-
   const address = Address.fromRandom();
-
-  const message = {
-    assetId: baseAssetId,
-    sender: address,
-    recipient: address,
-    nonce: '0x',
-    amount: bn(0),
-    daHeight: bn(0),
-  };
-  const coin: Coin = {
-    id: '0x',
-    assetId: baseAssetId,
-    amount: bn(0),
-    owner: address,
-    blockCreated: bn(0),
-    txCreatedIdx: bn(0),
-  };
-
-  beforeAll(async () => {
-    provider = await Provider.create(FUEL_NETWORK_URL);
-
-    const predicate = new Predicate({
-      bytecode: predicateBytecode,
-      abi: predicateAbi,
-      data: [ZeroBytes32],
-      provider,
-    });
-
-    baseAssetId = provider.getBaseAssetId();
-    await seedTestWallet(predicate, [[50_000, baseAssetId]]);
-  });
 
   it('creates a transaction request from ScriptTransactionRequest', () => {
     const scriptMainFunctionArguments = [1];
@@ -74,14 +28,14 @@ describe('Transaction Request', () => {
 
     // Instantiate the transaction request using a ScriptTransactionRequest
     const transactionRequest = new ScriptTransactionRequest({
-      script: scriptBytecode,
+      script: SumScript.bytecode,
     });
 
     // Set the script main function arguments (can also be passed in the class constructor)
-    transactionRequest.setData(scriptAbi, scriptMainFunctionArguments);
+    transactionRequest.setData(SumScript.abi, scriptMainFunctionArguments);
     // #endregion transaction-request-1
 
-    expect(transactionRequest.script).toEqual(arrayify(scriptBytecode));
+    expect(transactionRequest.script).toEqual(arrayify(SumScript.bytecode));
   });
 
   it('creates a transaction request fromm a CreateTransactionRequest', () => {
@@ -99,7 +53,26 @@ describe('Transaction Request', () => {
     expect(transactionRequest.witnesses[0]).toEqual(contractByteCode);
   });
 
-  it('modifies a transaction request', () => {
+  it('modifies a transaction request', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
+    const message = {
+      assetId: provider.getBaseAssetId(),
+      sender: address,
+      recipient: address,
+      nonce: '0x',
+      amount: bn(0),
+      daHeight: bn(0),
+    };
+    const coin: Coin = {
+      id: '0x',
+      assetId: provider.getBaseAssetId(),
+      amount: bn(0),
+      owner: address,
+      blockCreated: bn(0),
+      txCreatedIdx: bn(0),
+    };
     const recipientAddress = address;
     const resource = coin;
     const resources: Resource[] = [resource];
@@ -107,12 +80,9 @@ describe('Transaction Request', () => {
     // #region transaction-request-3
     // #import { ScriptTransactionRequest };
 
-    // Fetch the base asset ID
-    baseAssetId = provider.getBaseAssetId();
-
     // Instantiate the transaction request
     const transactionRequest = new ScriptTransactionRequest({
-      script: scriptBytecode,
+      script: SumScript.bytecode,
     });
 
     // Adding resources (coins or messages)
@@ -121,13 +91,13 @@ describe('Transaction Request', () => {
 
     // Adding coin inputs and outputs (including transfer to recipient)
     transactionRequest.addCoinInput(coin);
-    transactionRequest.addCoinOutput(recipientAddress, 1000, baseAssetId);
+    transactionRequest.addCoinOutput(recipientAddress, 1000, provider.getBaseAssetId());
 
     // Adding message inputs
     transactionRequest.addMessageInput(message);
     // #endregion transaction-request-3
 
-    expect(transactionRequest.script).toEqual(arrayify(scriptBytecode));
+    expect(transactionRequest.script).toEqual(arrayify(SumScript.bytecode));
     expect(transactionRequest.inputs.length).toEqual(4);
     expect(transactionRequest.outputs.length).toEqual(2);
     expect(transactionRequest.witnesses.length).toEqual(1);
@@ -141,7 +111,7 @@ describe('Transaction Request', () => {
 
     // Instantiate the transaction request
     const transactionRequest = new ScriptTransactionRequest({
-      script: scriptBytecode,
+      script: SumScript.bytecode,
     });
 
     // Add the contract input and output using the contract ID
@@ -153,6 +123,12 @@ describe('Transaction Request', () => {
   });
 
   it('adds a predicate to a transaction request', async () => {
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [fundedWallet],
+    } = launched;
+
     const dataToValidatePredicate = [ZeroBytes32];
 
     // #region transaction-request-5
@@ -160,20 +136,24 @@ describe('Transaction Request', () => {
 
     // Instantiate the transaction request
     const transactionRequest = new ScriptTransactionRequest({
-      script: scriptBytecode,
+      script: SumScript.bytecode,
     });
 
     // Instantiate the predicate and pass valid input data to validate
     // the predicate and unlock the funds
     const predicate = new Predicate({
-      bytecode: predicateBytecode,
-      abi: predicateAbi,
+      bytecode: SimplePredicate.bytecode,
+      abi: SimplePredicate.abi,
       data: dataToValidatePredicate,
       provider,
     });
 
+    // fund the predicate
+    const tx1 = await fundedWallet.transfer(predicate.address, bn(100_000));
+    await tx1.waitForResult();
+
     const predicateCoins = await predicate.getResourcesToSpend([
-      { amount: 2000, assetId: baseAssetId },
+      { amount: 2000, assetId: provider.getBaseAssetId() },
     ]);
 
     // Add the predicate input and resources
@@ -185,6 +165,9 @@ describe('Transaction Request', () => {
   });
 
   it('adds a witness to a transaction request', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     const witness = ZeroBytes32;
 
     // #region transaction-request-6
@@ -192,7 +175,7 @@ describe('Transaction Request', () => {
 
     // Instantiate the transaction request
     const transactionRequest = new ScriptTransactionRequest({
-      script: scriptBytecode,
+      script: SumScript.bytecode,
     });
 
     // Add a witness directly
@@ -206,13 +189,16 @@ describe('Transaction Request', () => {
     expect(transactionRequest.witnesses.length).toEqual(2);
   });
 
-  it('gets the transaction ID', () => {
+  it('gets the transaction ID', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     // #region transaction-request-7
     // #import { ScriptTransactionRequest };
 
     // Instantiate the transaction request
     const transactionRequest = new ScriptTransactionRequest({
-      script: scriptBytecode,
+      script: SumScript.bytecode,
     });
 
     // Get the chain ID

--- a/apps/docs-snippets/src/guide/types/address.test.ts
+++ b/apps/docs-snippets/src/guide/types/address.test.ts
@@ -1,9 +1,11 @@
-import { Address, FUEL_NETWORK_URL, Provider, Wallet } from 'fuels';
+import { Address, Wallet } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
+describe('Address Types', () => {
   it('should successfully create new address from bech32 string', () => {
     // #region address-2
     const ADDRESS_BECH32 = 'fuel1elnmzsav56dqnp95sx4e2pckq36cvae9ser44m5zlvgtwxw49fmqd7e42e';
@@ -16,7 +18,8 @@ describe(__filename, () => {
   });
 
   it('should successfully generate new address instance from public key', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await launchTestNode();
+    const { provider } = launched;
     // #region address-3
     const wallet = Wallet.generate({
       provider,

--- a/apps/docs-snippets/src/guide/types/conversion.test.ts
+++ b/apps/docs-snippets/src/guide/types/conversion.test.ts
@@ -1,15 +1,6 @@
 import type { WalletLocked, AssetId } from 'fuels';
-import {
-  Wallet,
-  FUEL_NETWORK_URL,
-  Provider,
-  Contract,
-  Address,
-  isBech32,
-  toBech32,
-  toB256,
-  isB256,
-} from 'fuels';
+import { Wallet, Contract, Address, isBech32, toBech32, toB256, isB256 } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 import {
   DocSnippetProjectsEnum,
@@ -19,13 +10,8 @@ import {
 /**
  * @group node
  */
-describe(__filename, () => {
+describe('Conversion Types', () => {
   const { abiContents: abi } = getDocsSnippetsForcProject(DocSnippetProjectsEnum.ECHO_VALUES);
-  let provider: Provider;
-
-  beforeAll(async () => {
-    provider = await Provider.create(FUEL_NETWORK_URL);
-  });
 
   it('converts between bech32 and b256 using address', () => {
     // #region conversion-5
@@ -88,7 +74,10 @@ describe(__filename, () => {
     expect(bech32).toBe('fuel1d5cfwekq78r0zq73g7eg0747etkaxxltrqx5tncm7lvg89awe3hswhqjhs');
   });
 
-  it('should successfully validate contract id equality', () => {
+  it('should successfully validate contract id equality', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     // #region conversion-2
     // #import { Address, Contract };
 
@@ -105,7 +94,9 @@ describe(__filename, () => {
     expect(bech32).toBe('fuel1d5cfwekq78r0zq73g7eg0747etkaxxltrqx5tncm7lvg89awe3hswhqjhs');
   });
 
-  it('should successfully validate a wallet address equality', () => {
+  it('should successfully validate a wallet address equality', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
     // #region conversion-3
     // #import { Wallet, Address };
 

--- a/apps/docs-snippets/src/guide/wallet-manager/getting-started-with-wallet-manager.test.ts
+++ b/apps/docs-snippets/src/guide/wallet-manager/getting-started-with-wallet-manager.test.ts
@@ -1,12 +1,16 @@
 import { WalletManager } from '@fuel-ts/account';
-import { FUEL_NETWORK_URL, Provider, Wallet } from 'fuels';
+import { Wallet } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
+describe('Getting started with wallet manager', () => {
   it('instantiates the WalletManager', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     // #region getting-started-with-wallet-manager-1
     const walletManager = new WalletManager();
     // #endregion getting-started-with-wallet-manager-1

--- a/apps/docs-snippets/src/guide/wallets/access.test.ts
+++ b/apps/docs-snippets/src/guide/wallets/access.test.ts
@@ -1,17 +1,16 @@
 import type { WalletLocked, WalletUnlocked } from 'fuels';
-import { FUEL_NETWORK_URL, Provider, Wallet } from 'fuels';
+import { Wallet } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
-  let provider: Provider | undefined;
+describe('Wallet Access', () => {
+  it('wallets', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
 
-  beforeAll(async () => {
-    provider = await Provider.create(FUEL_NETWORK_URL);
-  });
-
-  it('wallets', () => {
     // #region wallets
     // #import { Wallet, WalletLocked, WalletUnlocked };
 
@@ -26,7 +25,10 @@ describe(__filename, () => {
     expect(someWallet.address).toBeTruthy();
   });
 
-  it('wallet-locked-to-unlocked', () => {
+  it('wallet-locked-to-unlocked', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     const myWallet: WalletUnlocked = Wallet.generate({ provider });
     const PRIVATE_KEY = myWallet.privateKey;
 
@@ -44,7 +46,10 @@ describe(__filename, () => {
     expect(unlockedWallet.address).toEqual(myWallet.address);
   });
 
-  it('wallet-unlocked-to-locked', () => {
+  it('wallet-unlocked-to-locked', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     const unlockedWallet: WalletUnlocked = Wallet.generate({ provider });
 
     // #region wallet-unlocked-to-locked

--- a/apps/docs-snippets/src/guide/wallets/checking-balances-and-coins.test.ts
+++ b/apps/docs-snippets/src/guide/wallets/checking-balances-and-coins.test.ts
@@ -1,30 +1,31 @@
 import type { BigNumberish, WalletUnlocked } from 'fuels';
-import { Provider, Wallet, FUEL_NETWORK_URL } from 'fuels';
+import { Wallet } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
-  let provider: Provider | undefined;
-  let baseAssetId: string;
-
-  beforeAll(async () => {
-    provider = await Provider.create(FUEL_NETWORK_URL);
-  });
-
+describe('Checking balances and coins', () => {
   it('wallet-check-balance', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     const myWallet: WalletUnlocked = Wallet.generate({ provider });
 
     // #region wallet-check-balance
     // #import { BigNumberish };
 
-    const balance: BigNumberish = await myWallet.getBalance(baseAssetId);
+    const balance: BigNumberish = await myWallet.getBalance(provider.getBaseAssetId());
     // #endregion wallet-check-balance
 
     expect(balance.toNumber()).toEqual(0);
   });
 
   it('wallet-check-balances', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     const myWallet: WalletUnlocked = Wallet.generate({ provider });
 
     // #region wallet-check-balances

--- a/apps/docs-snippets/src/guide/wallets/checking-balances.test.ts
+++ b/apps/docs-snippets/src/guide/wallets/checking-balances.test.ts
@@ -1,39 +1,39 @@
 import type { CoinQuantity, BN } from 'fuels';
-import { FUEL_NETWORK_URL, Provider, Wallet } from 'fuels';
-import { generateTestWallet, ASSET_A } from 'fuels/test-utils';
+import { Wallet } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
-  let provider: Provider;
-  let privateKey: string;
-  let baseAssetId: string;
-  let assetId: string;
-
-  beforeAll(async () => {
-    provider = await Provider.create(FUEL_NETWORK_URL);
-    baseAssetId = provider.getBaseAssetId();
-    assetId = baseAssetId;
-    const wallet = await generateTestWallet(provider, [
-      [1000, baseAssetId],
-      [1000, ASSET_A],
-    ]);
-    privateKey = wallet.privateKey;
-  });
-
+describe('Checking balances', () => {
   it('should fetch specific balance just fine', async () => {
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [testWallet],
+    } = launched;
+
+    const privateKey = testWallet.privateKey;
+
     // #region checking-balances-1
     const myWallet = Wallet.fromPrivateKey(privateKey, provider);
 
     // The returned amount is a BigNumber
-    const balance: BN = await myWallet.getBalance(assetId);
+    const balance: BN = await myWallet.getBalance(provider.getBaseAssetId());
     // #endregion checking-balances-1
 
     expect(balance).toBeDefined();
   });
 
   it('should fetch all balances just fine', async () => {
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [testWallet],
+    } = launched;
+
+    const privateKey = testWallet.privateKey;
     // #region checking-balances-2
     const myWallet = Wallet.fromPrivateKey(privateKey, provider);
 

--- a/apps/docs-snippets/src/guide/wallets/encrypting-and-decrypting-json-wallets.test.ts
+++ b/apps/docs-snippets/src/guide/wallets/encrypting-and-decrypting-json-wallets.test.ts
@@ -1,12 +1,15 @@
 import fs from 'fs';
-import { FUEL_NETWORK_URL, Provider, Wallet } from 'fuels';
+import { Wallet } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
  */
-describe(__filename, () => {
+describe('Encrypting and decrypting JSON wallets', () => {
   it('should successfully encrypt wallet', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     // #region encrypting-and-decrypting-json-wallets-1
     // #import { Wallet, fs };
 
@@ -24,7 +27,9 @@ describe(__filename, () => {
   });
 
   it('should successfully decrypt a wallet', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     const jsonWallet = await Wallet.generate({
       provider,
     }).encrypt('my-password');

--- a/apps/docs-snippets/src/guide/wallets/instantiating-wallets.test.ts
+++ b/apps/docs-snippets/src/guide/wallets/instantiating-wallets.test.ts
@@ -1,16 +1,12 @@
 import type { WalletLocked, WalletUnlocked } from 'fuels';
-import { FUEL_NETWORK_URL, TESTNET_NETWORK_URL, HDWallet, Provider, Wallet } from 'fuels';
+import { HDWallet, Wallet } from 'fuels';
+import { TestAssetId, launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
-  beforeAll(async () => {
-    // Avoids using the actual network.
-    const mockProvider = await Provider.create(FUEL_NETWORK_URL);
-    vi.spyOn(Provider, 'create').mockResolvedValue(mockProvider);
-  });
-
+describe('Instantiating wallets', () => {
   it('should generate a new wallet just fine', () => {
     // #region instantiating-wallets-1
     const unlockedWallet: WalletUnlocked = Wallet.generate();
@@ -88,7 +84,8 @@ describe(__filename, () => {
   });
 
   it('should instantiate a locked wallet using a bech32 string address', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await launchTestNode();
+    const { provider } = launched;
 
     const address = `fuel14kjrdcdcp7z4l9xk0pm3cwz9qnjxxd04wx4zgnc3kknslclxzezqyeux5d`;
 
@@ -106,7 +103,8 @@ describe(__filename, () => {
     const myWallet = Wallet.fromAddress(address);
 
     // #region instantiating-wallets-9
-    const provider = await Provider.create(TESTNET_NETWORK_URL);
+    using launched = await launchTestNode();
+    const { provider } = launched;
 
     myWallet.connect(provider);
     // #endregion instantiating-wallets-9
@@ -114,8 +112,9 @@ describe(__filename, () => {
     expect(myWallet).toBeDefined();
   });
 
-  it('should instantiate wallet alreay connected to a provider', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+  it('should instantiate wallet already connected to a provider', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
 
     const address = `0xada436e1b80f855f94d678771c384504e46335f571aa244f11b5a70fe3e61644`;
 
@@ -126,5 +125,26 @@ describe(__filename, () => {
     myWallet.connect(provider);
 
     expect(myWallet).toBeDefined();
+  });
+
+  it('should instantiate multiple wallets with different configurations', async () => {
+    // #region multiple-wallets
+    using launched = await launchTestNode({
+      walletsConfig: {
+        count: 3,
+        assets: [TestAssetId.A, TestAssetId.B],
+        coinsPerAsset: 5,
+        amountPerCoin: 100_000,
+      },
+    });
+
+    const {
+      wallets: [wallet1, wallet2, wallet3],
+    } = launched;
+    // #endregion multiple-wallets
+
+    expect(wallet1).toBeDefined();
+    expect(wallet2).toBeDefined();
+    expect(wallet3).toBeDefined();
   });
 });

--- a/apps/docs-snippets/src/guide/wallets/private-keys.test.ts
+++ b/apps/docs-snippets/src/guide/wallets/private-keys.test.ts
@@ -1,22 +1,21 @@
 import type { WalletLocked, WalletUnlocked } from 'fuels';
-import { FUEL_NETWORK_URL, Provider, Signer, Wallet } from 'fuels';
+import { Signer, Wallet } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
-  let provider: Provider;
-  let wallet: WalletUnlocked;
-  let privateKey: string;
+describe('Private keys', () => {
+  it('wallet-from-private-key', async () => {
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [testWallet],
+    } = launched;
+    const privateKey = testWallet.privateKey;
 
-  beforeAll(async () => {
-    provider = await Provider.create(FUEL_NETWORK_URL);
-    wallet = Wallet.generate({ provider });
-    privateKey = wallet.privateKey;
-  });
-
-  it('wallet-from-private-key', () => {
-    const lockedWallet: WalletLocked = wallet.lock();
+    const lockedWallet: WalletLocked = testWallet.lock();
     const PRIVATE_KEY = privateKey;
 
     // #region wallet-from-private-key
@@ -26,16 +25,21 @@ describe(__filename, () => {
     unlockedWallet = Wallet.fromPrivateKey(PRIVATE_KEY, provider);
     // #endregion wallet-from-private-key
 
-    expect(unlockedWallet.address).toStrictEqual(wallet.address);
+    expect(unlockedWallet.address).toStrictEqual(testWallet.address);
   });
 
-  it('signer-address', () => {
-    const PRIVATE_KEY = privateKey;
+  it('signer-address', async () => {
+    using launched = await launchTestNode();
+    const {
+      wallets: [testWallet],
+    } = launched;
+
+    const PRIVATE_KEY = testWallet.privateKey;
 
     // #region signer-address
     const signer = new Signer(PRIVATE_KEY);
     // #endregion signer-address
 
-    expect(wallet.address).toStrictEqual(signer.address);
+    expect(testWallet.address).toStrictEqual(signer.address);
   });
 });

--- a/apps/docs-snippets/src/guide/wallets/signing.test.ts
+++ b/apps/docs-snippets/src/guide/wallets/signing.test.ts
@@ -1,27 +1,15 @@
-import {
-  Address,
-  FUEL_NETWORK_URL,
-  Provider,
-  ScriptTransactionRequest,
-  Signer,
-  WalletUnlocked,
-  hashMessage,
-} from 'fuels';
-import { seedTestWallet } from 'fuels/test-utils';
+import { Address, ScriptTransactionRequest, Signer, WalletUnlocked, hashMessage } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
 
 /**
  * @group node
+ * @group browser
  */
-describe(__filename, () => {
-  let provider: Provider;
-  let baseAssetId: string;
-
-  beforeAll(async () => {
-    provider = await Provider.create(FUEL_NETWORK_URL);
-    baseAssetId = provider.getBaseAssetId();
-  });
-
+describe('Signing', () => {
   it('should sign a message using wallet instance', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     // #region signing-1
     // #import { WalletUnlocked, hashMessage, Signer };
 
@@ -44,15 +32,18 @@ describe(__filename, () => {
   });
 
   it('should sign a transaction using wallet instance [DETAILED]', async () => {
-    const wallet = WalletUnlocked.generate({ provider });
-    await seedTestWallet(wallet, [[100_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [wallet],
+    } = launched;
 
     // #region signing-2
     const request = new ScriptTransactionRequest({
       gasLimit: 10000,
     });
 
-    request.addCoinOutput(Address.fromRandom(), 1000, baseAssetId);
+    request.addCoinOutput(Address.fromRandom(), 1000, provider.getBaseAssetId());
 
     const txCost = await wallet.getTransactionCost(request);
 
@@ -76,14 +67,17 @@ describe(__filename, () => {
   });
 
   it('should sign a transaction using wallet instance [SIMPLIFIED]', async () => {
-    const wallet = WalletUnlocked.generate({ provider });
-    await seedTestWallet(wallet, [[100_000, baseAssetId]]);
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [wallet],
+    } = launched;
 
     const request = new ScriptTransactionRequest({
       gasLimit: 10000,
     });
 
-    request.addCoinOutput(Address.fromRandom(), 1000, baseAssetId);
+    request.addCoinOutput(Address.fromRandom(), 1000, provider.getBaseAssetId());
 
     const txCost = await wallet.getTransactionCost(request);
 

--- a/apps/docs-snippets/src/guide/wallets/test-wallets.test.ts
+++ b/apps/docs-snippets/src/guide/wallets/test-wallets.test.ts
@@ -1,5 +1,5 @@
 import type { WalletUnlocked } from 'fuels';
-import { FUEL_NETWORK_URL, Provider, bn } from 'fuels';
+import { Provider, bn } from 'fuels';
 import { generateTestWallet } from 'fuels/test-utils';
 
 /**
@@ -8,8 +8,10 @@ import { generateTestWallet } from 'fuels/test-utils';
 describe(__filename, () => {
   it('wallet-setup', async () => {
     // #region wallet-setup
-    // #import { FUEL_NETWORK_URL, Provider, WalletUnlocked, CoinQuantity, generateTestWallet };
+    // #import { Provider, WalletUnlocked, CoinQuantity, generateTestWallet };
     // #context import { generateTestWallet } from 'fuels/test-utils';
+
+    const FUEL_NETWORK_URL = 'http://127.0.0.1:4000/v1/graphql';
 
     const provider = await Provider.create(FUEL_NETWORK_URL);
     const baseAssetId = provider.getBaseAssetId();

--- a/apps/docs-snippets/src/guide/wallets/wallet-transferring.test.ts
+++ b/apps/docs-snippets/src/guide/wallets/wallet-transferring.test.ts
@@ -1,63 +1,69 @@
-import type { Contract, TransferParams } from 'fuels';
-import { FUEL_NETWORK_URL, Provider, Wallet } from 'fuels';
-import { generateTestWallet, ASSET_A } from 'fuels/test-utils';
+import type { TransferParams } from 'fuels';
+import { Wallet } from 'fuels';
+import { ASSET_A, launchTestNode } from 'fuels/test-utils';
 
-import { DocSnippetProjectsEnum } from '../../../test/fixtures/forc-projects';
-import { createAndDeployContractFromProject } from '../../utils';
+import { CounterFactory } from '../../../test/typegen';
 
 /**
  * @group node
  */
-describe(__filename, () => {
-  let contract: Contract;
-  let provider: Provider;
-  let privateKey: string;
-  let baseAssetId: string;
-
-  beforeAll(async () => {
-    provider = await Provider.create(FUEL_NETWORK_URL);
-    baseAssetId = provider.getBaseAssetId();
-    const wallet = await generateTestWallet(provider, [
-      [1_000_000, baseAssetId],
-      [1_000_000, ASSET_A],
-    ]);
-    contract = await createAndDeployContractFromProject(DocSnippetProjectsEnum.COUNTER);
-    privateKey = wallet.privateKey;
-  });
-
+describe('Wallet transferring', () => {
   it('should transfer assets between wallets just fine', async () => {
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [testWallet],
+    } = launched;
+    const privateKey = testWallet.privateKey;
+
     // #region wallet-transferring-1
     const myWallet = Wallet.fromPrivateKey(privateKey, provider);
 
     const recipient = Wallet.generate({ provider });
 
-    const txResponse = await myWallet.transfer(recipient.address, 100, baseAssetId);
+    const txResponse = await myWallet.transfer(recipient.address, 100, provider.getBaseAssetId());
 
     await txResponse.waitForResult();
     // #endregion wallet-transferring-1
 
-    const newBalance = await recipient.getBalance(baseAssetId);
+    const newBalance = await recipient.getBalance(provider.getBaseAssetId());
 
     expect(newBalance.toNumber()).toBeGreaterThan(0);
   });
 
   it('should transfer assets to a recipient informing only the address string', async () => {
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [testWallet],
+    } = launched;
+    const privateKey = testWallet.privateKey;
+
     // #region wallet-transferring-2
     const myWallet = Wallet.fromPrivateKey(privateKey, provider);
 
     const address = 'fuel1zc7r2rwuzl3uskfc0w737780uqd8sn6lfm3wgqf9wa767gs3sems5d6kxj';
 
-    const txResponse = await myWallet.transfer(address, 100, baseAssetId);
+    const txResponse = await myWallet.transfer(address, 100, provider.getBaseAssetId());
     // #endregion wallet-transferring-2
 
     await txResponse.waitForResult();
 
-    const newBalance = await Wallet.fromAddress(address, provider).getBalance(baseAssetId);
+    const newBalance = await Wallet.fromAddress(address, provider).getBalance(
+      provider.getBaseAssetId()
+    );
 
     expect(newBalance.toNumber()).toBeGreaterThan(0);
   });
 
   it('should transfer base asset just fine', async () => {
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [testWallet],
+    } = launched;
+    const privateKey = testWallet.privateKey;
+
     // #region wallet-transferring-3
     const myWallet = Wallet.fromPrivateKey(privateKey, provider);
 
@@ -74,6 +80,13 @@ describe(__filename, () => {
   });
 
   it('should successfully multi transfer to more than one receiver', async () => {
+    using launched = await launchTestNode();
+    const {
+      provider,
+      wallets: [testWallet],
+    } = launched;
+    const privateKey = testWallet.privateKey;
+
     const someOtherAssetId = ASSET_A;
 
     // #region wallet-transferring-6
@@ -83,8 +96,8 @@ describe(__filename, () => {
     const recipient2 = Wallet.generate({ provider });
 
     const transfersToMake: TransferParams[] = [
-      { amount: 100, destination: recipient1.address, assetId: baseAssetId },
-      { amount: 200, destination: recipient2.address, assetId: baseAssetId },
+      { amount: 100, destination: recipient1.address, assetId: provider.getBaseAssetId() },
+      { amount: 200, destination: recipient2.address, assetId: provider.getBaseAssetId() },
       { amount: 300, destination: recipient2.address, assetId: someOtherAssetId },
     ];
 
@@ -96,31 +109,67 @@ describe(__filename, () => {
   });
 
   it('should transfer assets to a deployed contract instance just fine', async () => {
+    using launched = await launchTestNode({
+      contractsConfigs: [
+        {
+          factory: CounterFactory,
+        },
+      ],
+    });
+    const {
+      contracts: [contract],
+      provider,
+      wallets: [testWallet],
+    } = launched;
+    const privateKey = testWallet.privateKey;
+
     // #region wallet-transferring-4
     const myWallet = Wallet.fromPrivateKey(privateKey, provider);
 
-    const txResponse = await myWallet.transferToContract(contract.id, 100, baseAssetId);
+    const txResponse = await myWallet.transferToContract(
+      contract.id,
+      100,
+      provider.getBaseAssetId()
+    );
 
     await txResponse.waitForResult();
     // #endregion wallet-transferring-4
 
-    const newBalance = await contract.getBalance(baseAssetId);
+    const newBalance = await contract.getBalance(provider.getBaseAssetId());
 
     expect(newBalance.toNumber()).toBeGreaterThan(0);
   });
 
-  it('should transfer assets to a deployed contract string addess just fine', async () => {
+  it('should transfer assets to a deployed contract string address just fine', async () => {
+    using launched = await launchTestNode({
+      contractsConfigs: [
+        {
+          factory: CounterFactory,
+        },
+      ],
+    });
+    const {
+      contracts: [contract],
+      provider,
+      wallets: [testWallet],
+    } = launched;
+    const privateKey = testWallet.privateKey;
+
     // #region wallet-transferring-5
     const myWallet = Wallet.fromPrivateKey(privateKey, provider);
 
     const contractAddress = contract.id.toString();
 
-    const txResponse = await myWallet.transferToContract(contractAddress, 100, baseAssetId);
+    const txResponse = await myWallet.transferToContract(
+      contractAddress,
+      100,
+      provider.getBaseAssetId()
+    );
 
     await txResponse.waitForResult();
     // #endregion wallet-transferring-5
 
-    const newBalance = await contract.getBalance(baseAssetId);
+    const newBalance = await contract.getBalance(provider.getBaseAssetId());
 
     expect(newBalance.toNumber()).toBeGreaterThan(0);
   });

--- a/apps/docs-snippets/src/utils.ts
+++ b/apps/docs-snippets/src/utils.ts
@@ -1,6 +1,5 @@
 import type { CoinQuantityLike, Contract } from 'fuels';
 import {
-  FUEL_NETWORK_URL,
   Provider,
   ScriptTransactionRequest,
   Wallet,
@@ -13,6 +12,8 @@ import type { DocSnippetProjectsEnum } from '../test/fixtures/forc-projects';
 import { getDocsSnippetsForcProject } from '../test/fixtures/forc-projects';
 
 export const getTestWallet = async (seedQuantities?: CoinQuantityLike[]) => {
+  const FUEL_NETWORK_URL = process.env.FUEL_NETWORK_URL ?? 'http://127.0.0.1:4000/v1/graphql';
+
   // create a provider using the Fuel network URL
   const provider = await Provider.create(FUEL_NETWORK_URL);
 

--- a/internal/check-imports/src/references.ts
+++ b/internal/check-imports/src/references.ts
@@ -13,7 +13,6 @@ import {
   Predicate,
   Provider,
 } from '@fuel-ts/account';
-import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
 import { Address } from '@fuel-ts/address';
 import { ContractFactory } from '@fuel-ts/contract';
 import { encrypt, decrypt } from '@fuel-ts/crypto';
@@ -170,7 +169,6 @@ log(WalletManager);
 log(Wallet);
 log(generateTestWallet);
 log(seedTestWallet);
-log(FUEL_NETWORK_URL);
 
 /**
  * wordlists

--- a/packages/account/src/configs.test.ts
+++ b/packages/account/src/configs.test.ts
@@ -1,17 +1,8 @@
 /**
  * @group node
+ * @group browser
  */
 describe('Configs', () => {
-  it('exports FUEL_NETWORK_URL', async () => {
-    const configs = await import('./configs');
-    expect(configs.FUEL_NETWORK_URL).toBe('http://127.0.0.1:4000/v1/graphql');
-  });
-
-  it('exports LOCAL_NETWORK_URL', async () => {
-    const configs = await import('./configs');
-    expect(configs.LOCAL_NETWORK_URL).toBe('http://127.0.0.1:4000/v1/graphql');
-  });
-
   it('exports DEVNET_NETWORK_URL', async () => {
     const configs = await import('./configs');
     expect(configs.DEVNET_NETWORK_URL).toBe('https://devnet.fuel.network/v1/graphql');
@@ -20,51 +11,5 @@ describe('Configs', () => {
   it('exports TESTNET_NETWORK_URL', async () => {
     const configs = await import('./configs');
     expect(configs.TESTNET_NETWORK_URL).toBe('https://testnet.fuel.network/v1/graphql');
-  });
-});
-
-describe('Configs - undefined process', () => {
-  const originalProcess = process;
-
-  beforeEach(() => {
-    vi.resetModules();
-
-    // @ts-expect-error - test to assert undefined process
-    // eslint-disable-next-line no-global-assign
-    process = undefined;
-  });
-
-  afterEach(() => {
-    // eslint-disable-next-line no-global-assign
-    process = originalProcess;
-  });
-
-  it('exports FUEL_NETWORK_URL with undefined process', async () => {
-    expect(typeof process).toBe('undefined');
-    expect(process).toBeUndefined();
-
-    const configs = await import('./configs');
-
-    expect(configs.FUEL_NETWORK_URL).toBe('http://127.0.0.1:4000/v1/graphql');
-  });
-});
-
-describe('Configs - overridden env', () => {
-  const originalEnv = process.env;
-
-  beforeEach(() => {
-    vi.resetModules();
-
-    process.env = { ...originalEnv, FUEL_NETWORK_URL: 'some-other-network-url' };
-  });
-
-  afterEach(() => {
-    process.env = originalEnv;
-  });
-
-  it('exports FUEL_NETWORK_URL with overridden env', async () => {
-    const configs = await import('./configs');
-
-    expect(configs.FUEL_NETWORK_URL).toBe('some-other-network-url');
   });
 });

--- a/packages/account/src/configs.ts
+++ b/packages/account/src/configs.ts
@@ -1,10 +1,4 @@
-export const LOCAL_NETWORK_URL = 'http://127.0.0.1:4000/v1/graphql';
 export const DEVNET_NETWORK_URL = 'https://devnet.fuel.network/v1/graphql';
 export const TESTNET_NETWORK_URL = 'https://testnet.fuel.network/v1/graphql';
 // TODO: replace placeholder with mainnet network url
 // export const NETWORK_URL = '';
-
-export const FUEL_NETWORK_URL: string =
-  typeof process !== 'undefined'
-    ? process?.env?.FUEL_NETWORK_URL || LOCAL_NETWORK_URL
-    : LOCAL_NETWORK_URL;

--- a/packages/account/src/providers/provider.test.ts
+++ b/packages/account/src/providers/provider.test.ts
@@ -16,13 +16,7 @@ import {
   MESSAGE_PROOF_RAW_RESPONSE,
   MESSAGE_PROOF,
 } from '../../test/fixtures';
-import {
-  setupTestProviderAndWallets,
-  launchNode,
-  seedTestWallet,
-  TestMessage,
-} from '../test-utils';
-import { Wallet } from '../wallet';
+import { setupTestProviderAndWallets, launchNode, TestMessage } from '../test-utils';
 
 import type { Coin } from './coin';
 import { coinQuantityfy } from './coin-quantity';
@@ -41,10 +35,6 @@ import { TransactionResponse } from './transaction-response';
 import type { SubmittedStatus } from './transaction-summary/types';
 import * as gasMod from './utils/gas';
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
-
 const getCustomFetch =
   (expectedOperationName: string, expectedResponse: object) =>
   async (url: string, options: RequestInit | undefined) => {
@@ -61,9 +51,6 @@ const getCustomFetch =
     }
     return fetch(url, options);
   };
-
-// TODO: Figure out a way to import this constant from `@fuel-ts/account/configs`
-const FUEL_NETWORK_URL = 'http://127.0.0.1:4000/v1/graphql';
 
 /**
  * @group node
@@ -231,14 +218,18 @@ describe('Provider', () => {
   });
 
   it('gets the chain ID', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
+
     const chainId = provider.getChainId();
 
     expect(chainId).toBe(0);
   });
 
   it('gets the base asset ID', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
+
     const baseAssetId = provider.getBaseAssetId();
 
     expect(baseAssetId).toBeDefined();
@@ -753,7 +744,10 @@ describe('Provider', () => {
   it('can getMessageProof with all data', async () => {
     // Create a mock provider to return the message proof
     // It test mainly types and converstions
-    const provider = await Provider.create(FUEL_NETWORK_URL, {
+    using launched = await setupTestProviderAndWallets();
+    const { provider: nodeProvider } = launched;
+
+    const provider = await Provider.create(nodeProvider.url, {
       fetch: async (url, options) =>
         getCustomFetch('getMessageProof', { messageProof: MESSAGE_PROOF_RAW_RESPONSE })(
           url,
@@ -773,7 +767,10 @@ describe('Provider', () => {
   it('can getMessageStatus', async () => {
     // Create a mock provider to return the message proof
     // It test mainly types and converstions
-    const provider = await Provider.create(FUEL_NETWORK_URL, {
+    using launched = await setupTestProviderAndWallets();
+    const { provider: nodeProvider } = launched;
+
+    const provider = await Provider.create(nodeProvider.url, {
       fetch: async (url, options) =>
         getCustomFetch('getMessageStatus', { messageStatus: messageStatusResponse })(url, options),
     });
@@ -903,7 +900,10 @@ describe('Provider', () => {
 
     const consoleWarnSpy = vi.spyOn(console, 'warn');
 
-    await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
+
+    await Provider.create(provider.url);
 
     expect(consoleWarnSpy).toHaveBeenCalledOnce();
     expect(consoleWarnSpy).toHaveBeenCalledWith(
@@ -935,7 +935,10 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
     const consoleWarnSpy = vi.spyOn(console, 'warn');
 
-    await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
+
+    await Provider.create(provider.url);
 
     expect(consoleWarnSpy).toHaveBeenCalledOnce();
     expect(consoleWarnSpy).toHaveBeenCalledWith(
@@ -1123,7 +1126,8 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   it('subscriptions: does not throw when stream contains more than one "data:"', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
       const responseObject = {
@@ -1158,7 +1162,8 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   test('subscriptions: ignores keep-alive messages', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     const fetchSpy = vi.spyOn(global, 'fetch');
 
@@ -1190,7 +1195,8 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   it('subscriptions: does not throw when stream has two events in the same chunk', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
       const event1 = {
@@ -1242,7 +1248,8 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     expect(numberOfEvents).toEqual(2);
   });
   it('subscriptions: does not throw when an event is streamed in multiple chunks', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
       const responseObject = JSON.stringify({
@@ -1281,7 +1288,8 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   it('subscriptions: does not throw when chunk has a full and partial event in it', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
       const event1 = {
@@ -1337,7 +1345,8 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   it('subscriptions: does not throw when multiple chunks contain multiple events with a keep-alive message in-between', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
       const event1 = JSON.stringify({
@@ -1395,7 +1404,8 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   it('subscriptions: throws if the stream data string parsing fails for some reason', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     const badResponse = 'data: {f: {}\n\n';
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
@@ -1429,8 +1439,11 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   test('requestMiddleware modifies the request before being sent to the node [sync]', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
+
     const fetchSpy = vi.spyOn(global, 'fetch');
-    await Provider.create(FUEL_NETWORK_URL, {
+    await Provider.create(provider.url, {
       requestMiddleware: (request) => {
         request.headers ??= {};
         (request.headers as Record<string, string>)['x-custom-header'] = 'custom-value';
@@ -1446,8 +1459,11 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   test('requestMiddleware modifies the request before being sent to the node [async]', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
+
     const fetchSpy = vi.spyOn(global, 'fetch');
-    await Provider.create(FUEL_NETWORK_URL, {
+    await Provider.create(provider.url, {
       requestMiddleware: (request) => {
         request.headers ??= {};
         (request.headers as Record<string, string>)['x-custom-header'] = 'custom-value';
@@ -1463,8 +1479,11 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   test('requestMiddleware works for subscriptions', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const { provider: nodeProvider } = launched;
+
     const fetchSpy = vi.spyOn(global, 'fetch');
-    const provider = await Provider.create(FUEL_NETWORK_URL, {
+    const provider = await Provider.create(nodeProvider.url, {
       requestMiddleware: (request) => {
         request.headers ??= {};
         (request.headers as Record<string, string>)['x-custom-header'] = 'custom-value';
@@ -1491,8 +1510,11 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   test('custom fetch works with requestMiddleware', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
+
     let requestHeaders: HeadersInit | undefined;
-    await Provider.create(FUEL_NETWORK_URL, {
+    await Provider.create(provider.url, {
       fetch: async (url, requestInit) => {
         requestHeaders = requestInit?.headers;
         return fetch(url, requestInit);
@@ -1510,8 +1532,11 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   test('custom fetch works with timeout', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const { provider: nodeProvider } = launched;
+
     const timeout = 500;
-    const provider = await Provider.create(FUEL_NETWORK_URL, {
+    const provider = await Provider.create(nodeProvider.url, {
       fetch: async (url, requestInit) => fetch(url, requestInit),
       timeout,
     });
@@ -1533,7 +1558,8 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   test('getMessageByNonce', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     const nonce = '0x381de90750098776c71544527fd253412908dec3d07ce9a7367bd1ba975908a0';
     const message = await provider.getMessageByNonce(nonce);
@@ -1791,23 +1817,27 @@ Supported fuel-core version: ${mock.supportedVersion}.`
   });
 
   test('can properly use getBalances', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const baseAssetId = provider.getBaseAssetId();
-    const wallet = Wallet.generate({ provider });
-
     const fundAmount = 10_000;
 
-    await seedTestWallet(wallet, [
-      [fundAmount, baseAssetId],
-      [fundAmount, ASSET_A],
-    ]);
+    using launched = await setupTestProviderAndWallets({
+      walletsConfig: {
+        amountPerCoin: fundAmount,
+      },
+    });
+    const {
+      provider,
+      wallets: [wallet],
+    } = launched;
+
+    const baseAssetId = provider.getBaseAssetId();
 
     const { balances } = await provider.getBalances(wallet.address);
 
-    expect(balances.length).toBe(2);
+    expect(balances.length).toBe(3);
+
     balances.forEach((balance) => {
       expect(balance.amount.toNumber()).toBe(fundAmount);
-      expect([baseAssetId, ASSET_A].includes(balance.assetId)).toBeTruthy();
+      expect([baseAssetId, ASSET_A, ASSET_B].includes(balance.assetId)).toBeTruthy();
     });
   });
 });

--- a/packages/account/test/auto-retry-fetch.test.ts
+++ b/packages/account/test/auto-retry-fetch.test.ts
@@ -1,11 +1,9 @@
-import { FUEL_NETWORK_URL } from '../src/configs';
-import Provider from '../src/providers/provider';
 import * as autoRetryFetchMod from '../src/providers/utils/auto-retry-fetch';
 import type { RetryOptions } from '../src/providers/utils/auto-retry-fetch';
+import { setupTestProviderAndWallets } from '../src/test-utils';
 
 /**
  * @group node
- * TODO: add browser group as well (https://github.com/FuelLabs/fuels-ts/pull/1654#discussion_r1456501593)
  */
 describe('Provider correctly', () => {
   afterEach(() => {
@@ -21,7 +19,12 @@ describe('Provider correctly', () => {
       backoff: 'exponential',
     };
 
-    const provider = await Provider.create(FUEL_NETWORK_URL, { retryOptions });
+    using launched = await setupTestProviderAndWallets({
+      providerOptions: {
+        retryOptions,
+      },
+    });
+    const { provider } = launched;
 
     expect(provider).toBeTruthy();
     expect(autoRetryFetchFn).toHaveBeenCalledTimes(1);

--- a/packages/account/test/fixtures/mocked-connector.ts
+++ b/packages/account/test/fixtures/mocked-connector.ts
@@ -9,7 +9,6 @@ import type {
   ConnectorMetadata,
   Network,
 } from '../../src';
-import { FUEL_NETWORK_URL } from '../../src/configs';
 import { FuelConnector } from '../../src/connectors/fuel-connector';
 import { FuelConnectorEventTypes } from '../../src/connectors/types';
 import type { Asset } from '../../src/providers/assets/types';
@@ -51,7 +50,7 @@ export class MockConnector extends FuelConnector {
     this._networks = options.networks ?? [
       {
         chainId: 0,
-        url: FUEL_NETWORK_URL,
+        url: 'http://127.0.0.1/v1/graphql',
       },
     ];
     // Time should be under 1 second

--- a/packages/account/test/fixtures/wallet-spec.ts
+++ b/packages/account/test/fixtures/wallet-spec.ts
@@ -1,5 +1,3 @@
-import { FUEL_NETWORK_URL } from '../../src/configs';
-
 export default {
   mnemonic:
     'fragile silver alley worth float lizard memory amazing fee race escape rotate evil mystery coyote',
@@ -18,5 +16,4 @@ export default {
     privateKey: '0x679e1dd21644ec892d1db655ff857ac0af179f077c4682636fea03ac7a46d94a',
     xprv: 'xprvA2avFD3xMpA5MLaGYTp5eS4yAp39e5Tu6jcjxPN2vh9xhq6rM9i6LPa6q6AU6MBoS7m1Y1fNLbXHg5P8GpVNPkjcJN9bkSBweYuxBpwZgxL',
   },
-  providerUrl: FUEL_NETWORK_URL,
 };

--- a/packages/account/test/fuel-wallet-connector.test.ts
+++ b/packages/account/test/fuel-wallet-connector.test.ts
@@ -8,10 +8,10 @@ import { bn } from '@fuel-ts/math';
 import { EventEmitter } from 'events';
 
 import type { ProviderOptions } from '../src';
-import { FUEL_NETWORK_URL } from '../src/configs';
 import { Fuel } from '../src/connectors/fuel';
 import { FuelConnectorEventType } from '../src/connectors/types';
 import { Provider, TransactionStatus } from '../src/providers';
+import { setupTestProviderAndWallets } from '../src/test-utils';
 import { Wallet } from '../src/wallet';
 
 import { MockConnector } from './fixtures/mocked-connector';
@@ -323,8 +323,8 @@ describe('Fuel Connector', () => {
   });
 
   it('should ensure getWallet return an wallet', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const baseAssetId = provider.getBaseAssetId();
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     const wallets = [
       Wallet.fromPrivateKey(
@@ -352,7 +352,7 @@ describe('Fuel Connector', () => {
     const wallet = await fuel.getWallet(account);
     expect(wallet.provider.url).toEqual(network.url);
     const receiver = Wallet.fromAddress(Address.fromRandom(), provider);
-    const response = await wallet.transfer(receiver.address, bn(1000), baseAssetId, {
+    const response = await wallet.transfer(receiver.address, bn(1000), provider.getBaseAssetId(), {
       tip: bn(1),
       gasLimit: bn(100_000),
     });
@@ -508,10 +508,11 @@ describe('Fuel Connector', () => {
   });
 
   it('should be able to getWallet with custom provider', async () => {
-    const defaultProvider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider: nodeProvider } = launched;
 
     const defaultWallet = Wallet.generate({
-      provider: defaultProvider,
+      provider: nodeProvider,
     });
     const connector = new MockConnector({
       wallets: [defaultWallet],
@@ -522,7 +523,7 @@ describe('Fuel Connector', () => {
 
     class CustomProvider extends Provider {
       static async create(_url: string, opts?: ProviderOptions) {
-        const provider = new CustomProvider(FUEL_NETWORK_URL, opts);
+        const provider = new CustomProvider(nodeProvider.url, opts);
         await provider.fetchChainAndNodeInfo();
         return provider;
       }
@@ -538,17 +539,18 @@ describe('Fuel Connector', () => {
       throw new Error('Account not found');
     }
 
-    const provider = await CustomProvider.create(FUEL_NETWORK_URL);
+    const provider = await CustomProvider.create(nodeProvider.url);
     const wallet = await fuel.getWallet(currentAccount, provider);
     expect(wallet.provider).toBeInstanceOf(CustomProvider);
     expect(await wallet.getBalance()).toEqual(bn(1234));
   });
 
   it('should ensure hasWallet works just fine', async () => {
-    const defaultProvider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     const defaultWallet = Wallet.generate({
-      provider: defaultProvider,
+      provider,
     });
 
     const connector = new MockConnector({
@@ -567,7 +569,8 @@ describe('Fuel Connector', () => {
   });
 
   it('should ensure getProvider works just fine', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
 
     const defaultWallet = Wallet.generate({
       provider,

--- a/packages/account/test/predicate-functions.test.ts
+++ b/packages/account/test/predicate-functions.test.ts
@@ -1,6 +1,5 @@
-import { FUEL_NETWORK_URL } from '../src/configs';
 import { Predicate } from '../src/predicate';
-import { Provider } from '../src/providers';
+import { setupTestProviderAndWallets } from '../src/test-utils';
 
 import { predicateAbi } from './fixtures/predicate-abi';
 import { predicateBytecode } from './fixtures/predicate-bytecode';
@@ -12,13 +11,11 @@ import { predicateBytecode } from './fixtures/predicate-bytecode';
 describe('Predicate', () => {
   describe('Functions', () => {
     const predicateAddress = '0x6b6ef590390f0a7de75f8275ab5d7877c17236caba2514039c6565ec15f79111';
-    let provider: Provider;
 
-    beforeAll(async () => {
-      provider = await Provider.create(FUEL_NETWORK_URL);
-    });
+    it('sets predicate address for given byte code', async () => {
+      using launched = await setupTestProviderAndWallets();
+      const { provider } = launched;
 
-    it('sets predicate address for given byte code', () => {
       const predicate = new Predicate({
         bytecode: predicateBytecode,
         provider,
@@ -26,7 +23,10 @@ describe('Predicate', () => {
       expect(predicate.address.toB256()).toEqual(predicateAddress);
     });
 
-    it('sets predicate data for given ABI', () => {
+    it('sets predicate data for given ABI', async () => {
+      using launched = await setupTestProviderAndWallets();
+      const { provider } = launched;
+
       const b256 = '0x0101010101010101010101010101010101010101010101010101010101010101';
       const predicate = new Predicate({
         bytecode: predicateBytecode,
@@ -38,7 +38,10 @@ describe('Predicate', () => {
       expect(predicate.predicateData).not.toBeUndefined();
     });
 
-    it('throws when predicate ABI has no main function', () => {
+    it('throws when predicate ABI has no main function', async () => {
+      using launched = await setupTestProviderAndWallets();
+      const { provider } = launched;
+
       const abiWithNoMain = {
         ...predicateAbi,
         functions: [

--- a/packages/fuels/src/cli/commands/deploy/createWallet.test.ts
+++ b/packages/fuels/src/cli/commands/deploy/createWallet.test.ts
@@ -1,7 +1,6 @@
-import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
 import { ErrorCode } from '@fuel-ts/errors';
 
-import { expectToThrowFuelError, safeExec } from '../../../test-utils';
+import { expectToThrowFuelError, launchTestNode, safeExec } from '../../../test-utils';
 
 import { createWallet } from './createWallet';
 
@@ -12,21 +11,32 @@ describe('createWallet', () => {
   const privateKey = '0xa449b1ffee0e2205fa924c6740cc48b3b473aa28587df6dab12abc245d1f5298';
 
   test('create wallet using `privateKey` variable', async () => {
-    const wallet = await createWallet(FUEL_NETWORK_URL, privateKey);
+    using launched = await launchTestNode();
+
+    const { provider } = launched;
+
+    const wallet = await createWallet(provider.url, privateKey);
     expect(wallet.privateKey).toEqual(privateKey);
   });
 
   test('create wallet using `PRIVATE_KEY` env variable', async () => {
     process.env.PRIVATE_KEY = privateKey;
-    const wallet = await createWallet(FUEL_NETWORK_URL);
+
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
+    const wallet = await createWallet(provider.url);
     expect(wallet.privateKey).toEqual(process.env.PRIVATE_KEY);
     process.env.PRIVATE_KEY = undefined;
     delete process.env.PRIVATE_KEY;
   });
 
   test('warn about missing private key', async () => {
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     const { error, result } = await safeExec(async () => {
-      await createWallet(FUEL_NETWORK_URL);
+      await createWallet(provider.url);
     });
     expect(result).not.toBeTruthy();
     expect(error).toBeTruthy();

--- a/packages/fuels/src/cli/commands/deploy/index.test.ts
+++ b/packages/fuels/src/cli/commands/deploy/index.test.ts
@@ -1,8 +1,7 @@
-import type { Provider } from '@fuel-ts/account';
 import { Wallet } from '@fuel-ts/account';
-import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
 
 import { fuelsConfig } from '../../../../test/fixtures/fuels.config';
+import { launchTestNode } from '../../../test-utils';
 import type { DeployedContract } from '../../types';
 
 import { deploy } from '.';
@@ -13,10 +12,12 @@ import * as saveContractIdsMod from './saveContractIds';
  * @group node
  */
 describe('deploy', () => {
-  const mockAll = () => {
+  const mockAll = async () => {
     const onDeploy = vi.fn();
 
-    const provider = { url: FUEL_NETWORK_URL } as Provider;
+    using launched = await launchTestNode();
+    const { provider } = launched;
+
     const wallet = Wallet.fromPrivateKey('0x01', provider);
     const createWallet = vi.spyOn(createWalletMod, 'createWallet').mockResolvedValue(wallet);
 
@@ -29,7 +30,7 @@ describe('deploy', () => {
   };
 
   test('should call onDeploy callback', async () => {
-    const { onDeploy } = mockAll();
+    const { onDeploy } = await mockAll();
     const expectedContracts: DeployedContract[] = [];
     const config = { ...fuelsConfig, contracts: [], onDeploy };
 

--- a/packages/fuels/src/cli/commands/dev/autoStartFuelCore.test.ts
+++ b/packages/fuels/src/cli/commands/dev/autoStartFuelCore.test.ts
@@ -34,6 +34,7 @@ describe('autoStartFuelCore', () => {
         port: '4000',
         url: 'http://127.0.0.1:4000/v1/graphql',
         snapshotDir: '/some/path',
+        pid: 1234,
       })
     );
     return { launchNode };

--- a/packages/fuels/src/cli/config/loadConfig.ts
+++ b/packages/fuels/src/cli/config/loadConfig.ts
@@ -1,3 +1,4 @@
+import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
 import { FuelError } from '@fuel-ts/errors';
 import { defaultConsensusKey } from '@fuel-ts/utils';
 import { bundleRequire } from 'bundle-require';
@@ -63,7 +64,7 @@ export async function loadConfig(cwd: string): Promise<FuelsConfig> {
     deployConfig: {},
     autoStartFuelCore: true,
     fuelCorePort: 4000,
-    providerUrl: process.env.FUEL_NETWORK_URL ?? 'http://127.0.0.1:4000/v1/graphql',
+    providerUrl: FUEL_NETWORK_URL,
     privateKey: defaultConsensusKey,
     ...userConfig,
     basePath: cwd,

--- a/packages/fuels/src/cli/config/loadConfig.ts
+++ b/packages/fuels/src/cli/config/loadConfig.ts
@@ -1,4 +1,3 @@
-import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
 import { FuelError } from '@fuel-ts/errors';
 import { defaultConsensusKey } from '@fuel-ts/utils';
 import { bundleRequire } from 'bundle-require';
@@ -64,7 +63,7 @@ export async function loadConfig(cwd: string): Promise<FuelsConfig> {
     deployConfig: {},
     autoStartFuelCore: true,
     fuelCorePort: 4000,
-    providerUrl: FUEL_NETWORK_URL,
+    providerUrl: process.env.FUEL_NETWORK_URL ?? 'http://127.0.0.1:4000/v1/graphql',
     privateKey: defaultConsensusKey,
     ...userConfig,
     basePath: cwd,

--- a/packages/fuels/test/fixtures/fuels.config.ts
+++ b/packages/fuels/test/fixtures/fuels.config.ts
@@ -1,4 +1,3 @@
-import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
 import { join } from 'path';
 
 import type { FuelsConfig } from '../../src';
@@ -21,7 +20,7 @@ export const fuelsConfig: FuelsConfig = {
   deployConfig: {},
   autoStartFuelCore: true,
   fuelCorePort: 4000,
-  providerUrl: FUEL_NETWORK_URL,
+  providerUrl: 'http://127.0.0.1:4000/v1/graphql',
   configPath: __filename,
   forcBuildFlags: [],
   buildMode: 'debug',

--- a/packages/fuels/test/utils/mockAutoStartFuelCore.ts
+++ b/packages/fuels/test/utils/mockAutoStartFuelCore.ts
@@ -1,4 +1,3 @@
-import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
 import type { SpyInstance } from 'vitest';
 
 import * as autoStartFuelCoreMod from '../../src/cli/commands/dev/autoStartFuelCore';
@@ -14,7 +13,7 @@ export const mockStartFuelCore = (): {
     bindIp: '0.0.0.0',
     accessIp: '127.0.0.1',
     port: 4000,
-    providerUrl: FUEL_NETWORK_URL,
+    providerUrl: 'http://127.0.0.1:4000/v1/graphql',
     killChildProcess,
     snapshotDir: '/some/path',
   };

--- a/packages/program/src/contract.test.ts
+++ b/packages/program/src/contract.test.ts
@@ -1,6 +1,6 @@
 import type { JsonAbi } from '@fuel-ts/abi-coder';
-import { Account, Wallet, Provider } from '@fuel-ts/account';
-import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
+import { Account } from '@fuel-ts/account';
+import { setupTestProviderAndWallets } from '@fuel-ts/account/test-utils';
 
 import Contract from './contract';
 
@@ -39,30 +39,35 @@ const ABI: JsonAbi = {
 
 /**
  * @group node
+ * @group browser
  */
 describe('Contract', () => {
   test('Create contract instance with provider', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
+
     const contract = new Contract(CONTRACT_ID, ABI, provider);
     expect(contract.provider).toBe(provider);
     expect(contract.account).toBe(null);
   });
 
   test('Create contract instance with wallet', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const wallet = Wallet.generate({
-      provider,
-    });
+    using launched = await setupTestProviderAndWallets();
+    const {
+      wallets: [wallet],
+    } = launched;
+
     const contract = new Contract(CONTRACT_ID, ABI, wallet);
     expect(contract.provider).toBe(wallet.provider);
     expect(contract.account).toBe(wallet);
   });
 
   test('Create contract instance with custom wallet', async () => {
-    const provider = await Provider.create(FUEL_NETWORK_URL);
-    const generatedWallet = Wallet.generate({
-      provider,
-    });
+    using launched = await setupTestProviderAndWallets();
+    const {
+      wallets: [generatedWallet],
+    } = launched;
+
     // Create a custom wallet that extends BaseWalletLocked
     // but without reference to the BaseWalletLocked class
     const BaseWalletLockedCustom = Object.assign(Account);

--- a/packages/script/src/script.test.ts
+++ b/packages/script/src/script.test.ts
@@ -2,9 +2,8 @@
 import type { JsonAbi } from '@fuel-ts/abi-coder';
 import { Interface } from '@fuel-ts/abi-coder';
 import type { Account, TransactionResponse, TransactionResult } from '@fuel-ts/account';
-import { Provider, ScriptTransactionRequest } from '@fuel-ts/account';
-import { FUEL_NETWORK_URL } from '@fuel-ts/account/configs';
-import { generateTestWallet } from '@fuel-ts/account/test-utils';
+import { ScriptTransactionRequest } from '@fuel-ts/account';
+import { setupTestProviderAndWallets } from '@fuel-ts/account/test-utils';
 import { FuelError } from '@fuel-ts/errors';
 import { expectToThrowFuelError } from '@fuel-ts/errors/test-utils';
 import type { BigNumberish } from '@fuel-ts/math';
@@ -18,19 +17,10 @@ import { jsonAbiMock, jsonAbiFragmentMock } from '../test/mocks';
 
 import { Script } from './index';
 
+// #TODO: we should refactor this to use Script Instance, need to do typegen here
 const { abiContents: scriptJsonAbi, binHexlified: scriptBin } = getScriptForcProject(
   ScriptProjectsEnum.CALL_TEST_SCRIPT
 );
-
-const setup = async () => {
-  const provider = await Provider.create(FUEL_NETWORK_URL);
-  const baseAssetId = provider.getBaseAssetId();
-
-  // Create wallet
-  const wallet = await generateTestWallet(provider, [[5_000_000, baseAssetId]]);
-
-  return wallet;
-};
 
 const callScript = async <TData, TResult>(
   account: Account,
@@ -99,7 +89,12 @@ describe('Script', () => {
   // #endregion script-init
 
   it('can call a script', async () => {
-    const wallet = await setup();
+    using launched = await setupTestProviderAndWallets();
+
+    const {
+      wallets: [wallet],
+    } = launched;
+
     const input = {
       arg_one: true,
       arg_two: 1337,
@@ -114,7 +109,12 @@ describe('Script', () => {
   });
 
   it('should TransactionResponse fetch return graphql transaction and also decoded transaction', async () => {
-    const wallet = await setup();
+    using launched = await setupTestProviderAndWallets();
+
+    const {
+      wallets: [wallet],
+    } = launched;
+
     const input = {
       arg_one: true,
       arg_two: 1337,
@@ -126,7 +126,11 @@ describe('Script', () => {
   });
 
   it('should throw if script has no configurable to be set', async () => {
-    const wallet = await setup();
+    using launched = await setupTestProviderAndWallets();
+
+    const {
+      wallets: [wallet],
+    } = launched;
 
     const newScript = new Script(scriptBin, jsonAbiFragmentMock, wallet);
 
@@ -140,7 +144,11 @@ describe('Script', () => {
   });
 
   it('should throw when setting configurable with wrong name', async () => {
-    const wallet = await setup();
+    using launched = await setupTestProviderAndWallets();
+
+    const {
+      wallets: [wallet],
+    } = launched;
 
     const jsonAbiWithConfigurablesMock: JsonAbi = {
       ...jsonAbiMock,


### PR DESCRIPTION
- Closes #2644 

# Release notes

In this release, we:

- Deprecated `FUEL_NETWORK_URL` and `LOCAL_NETWORK_URL` constants

# Breaking Changes

- Deprecated `FUEL_NETWORK_URL`

```ts
// Before
import { FUEL_NETWORK_URL } from 'fuels';

const provider = await Provider.create(FUEL_NETWORK_URL);
```

```ts
// After
const provider = await Provider.create('https://127.0.0.1:4000/v1/graphql');
```

- Deprecated `LOCAL_NETWORK_URL`

```ts
// Before
import { LOCAL_NETWORK_URL } from 'fuels';

const provider = await Provider.create(LOCAL_NETWORK_URL);
```

```ts
// After
const provider = await Provider.create('https://127.0.0.1:4000/v1/graphql');
```

# Checklist

- [ ] I **_added_** — `tests` to prove my changes
- [X] I **_updated_** — all the necessary `docs`
- [X] I **_reviewed_** — the entire PR myself, using the GitHub UI
- [X] I **_described_** — all breaking changes and the Migration Guide
