### PR TITLE
chore: add some e2e tests for transaction summary operations

### DIFF
--- a/packages/fuel-gauge/src/transaction-summary.test.ts
+++ b/packages/fuel-gauge/src/transaction-summary.test.ts
@@ -15,6 +15,11 @@ import {
   Wallet,
   AddressType,
   OperationName,
+  Address,
+  ChainName,
+  bn,
+  ZeroBytes32,
+  TransactionType,
 } from 'fuels';
 import { ASSET_A, ASSET_B, launchTestNode, TestMessage } from 'fuels/test-utils';
 
@@ -619,6 +624,102 @@ describe('TransactionSummary', () => {
           { address: contract.id, quantities: [{ amount, assetId: provider.getBaseAssetId() }] },
         ],
       });
+    });
+
+    it('should ensure contract call operations are correctly assembled [WITHDRAW TO BASE LAYER]', async () => {
+      using launched = await launchTestNode();
+
+      const {
+        provider,
+        wallets: [sender],
+      } = launched;
+
+      const recipient = Address.fromB256(
+        '0x00000000000000000000000047ba61eec8e5e65247d717ff236f504cf3b0a263'
+      );
+
+      const tx = await sender.withdrawToBaseLayer(recipient, 10);
+      const result = await tx.waitForResult();
+
+      const { operations } = result;
+
+      expect(operations[0].name).toEqual(OperationName.withdrawFromFuel);
+      expect(operations[0].from?.type).toEqual(1);
+      expect(operations[0].from?.address).toEqual(sender.address.toB256());
+      expect(operations[0].to?.type).toEqual(1);
+      expect(operations[0].to?.address).toEqual(recipient.toB256());
+      expect(operations[0].to?.chain).toEqual(ChainName.ethereum);
+      expect(operations[0].assetsSent).toHaveLength(1);
+      expect(operations[0].assetsSent?.[0].amount).toEqual(bn('10'));
+      expect(operations[0].assetsSent?.[0].assetId).toEqual(provider.getBaseAssetId());
+    });
+
+    it('Should return contract created operations', async () => {
+      using launched = await launchTestNode();
+
+      const {
+        wallets: [wallet],
+      } = launched;
+
+      const tx = await MultiTokenContractFactory.deploy(wallet);
+      const result = await tx.waitForResult();
+
+      expect(result.transactionResult.operations).toHaveLength(1);
+      expect(result.transactionResult.operations[0].name).toEqual(OperationName.contractCreated);
+      expect(result.transactionResult.operations[0].from?.type).toEqual(1);
+      expect(result.transactionResult.operations[0].from?.address).toEqual(wallet.address.toB256());
+      expect(result.transactionResult.operations[0].to?.type).toEqual(0);
+      expect(result.transactionResult.isTypeCreate).toEqual(true);
+    });
+
+    it('should have no assets returned for contract call operations', async () => {
+      using launched = await launchTestNode({
+        contractsConfigs: [
+          {
+            factory: TokenContractFactory,
+          },
+        ],
+      });
+
+      const {
+        wallets: [wallet],
+        contracts: [contract],
+      } = launched;
+
+      const tx = await contract.functions.mint_coins(100).call();
+      const result = await tx.waitForResult();
+
+      expect(result.transactionResult.operations).toHaveLength(1);
+      expect(result.transactionResult.operations[0].name).toEqual(OperationName.contractCall);
+      expect(result.transactionResult.operations[0].from?.type).toEqual(1);
+      expect(result.transactionResult.operations[0].from?.address).toEqual(wallet.address.toB256());
+      expect(result.transactionResult.operations[0].to?.address).toEqual(contract.id.toB256());
+      expect(result.transactionResult.operations[0].to?.type).toEqual(0);
+      expect(result.transactionResult.operations[0].assetsSent).toBeUndefined();
+    });
+
+    it('should return the correct operations for a mint transaction', async () => {
+      using launched = await launchTestNode({
+        nodeOptions: {
+          args: ['--poa-instant', 'false', '--poa-interval-period', '1ms'],
+          loggingEnabled: false,
+        },
+      });
+      const { provider } = launched;
+
+      const txnInfo = await provider.getTransactions({ first: 1 });
+
+      const transactions = txnInfo.transactions[0];
+
+      expect(transactions.type).toEqual(TransactionType.Mint);
+      expect(transactions.txPointer?.blockHeight).toEqual(1);
+      expect(transactions.txPointer?.txIndex).toEqual(0);
+      expect(transactions.inputContract?.txID).toEqual(ZeroBytes32);
+      expect(transactions.inputContract?.balanceRoot).toEqual(ZeroBytes32);
+      expect(transactions.inputContract?.stateRoot).toEqual(ZeroBytes32);
+      expect(transactions.inputContract?.type).toEqual(TransactionType.Create);
+      expect(transactions.mintAmount?.eq(bn(0))).toBe(true);
+      expect(transactions.mintAssetId).toEqual(provider.getBaseAssetId());
     });
   });
 });


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

- Closes https://github.com/FuelLabs/fuels-ts/issues/2836

# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

Introduces some e2e tests in the `fuel-gauge` test suite to ensure the operations and transaction summaries are correctly assembled for various types of transactions.

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
