### PR TITLE
chore!: wrap subscriptions in promise

### DIFF
--- a/.changeset/smart-seals-care.md
+++ b/.changeset/smart-seals-care.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": minor
+---
+
+chore!: wrap subscriptions in promise

--- a/packages/account/src/providers/provider.test.ts
+++ b/packages/account/src/providers/provider.test.ts
@@ -955,7 +955,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
     await expectToThrowFuelError(
       async () => {
-        for await (const value of provider.operations.statusChange({
+        for await (const value of await provider.operations.statusChange({
           transactionId: 'invalid transaction id',
         })) {
           // shouldn't be reached and should fail if reached
@@ -1012,7 +1012,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     );
 
     const { error } = await safeExec(async () => {
-      for await (const iterator of provider.operations.statusChange({
+      for await (const iterator of await provider.operations.statusChange({
         transactionId: 'doesnt matter, will be aborted',
       })) {
         // shouldn't be reached and should fail if reached
@@ -1153,7 +1153,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
       );
     });
 
-    for await (const { submitAndAwait } of provider.operations.submitAndAwait({
+    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
       expect(submitAndAwait.type).toEqual('SuccessStatus');
@@ -1185,7 +1185,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
     let numberOfEvents = 0;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for await (const { submitAndAwait } of provider.operations.submitAndAwait({
+    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
       numberOfEvents += 1;
@@ -1232,7 +1232,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
     let numberOfEvents = 0;
 
-    for await (const { submitAndAwait } of provider.operations.submitAndAwait({
+    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
       numberOfEvents += 1;
@@ -1280,7 +1280,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
       );
     });
 
-    for await (const { submitAndAwait } of provider.operations.submitAndAwait({
+    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
       expect(submitAndAwait.type).toEqual('SuccessStatus');
@@ -1328,7 +1328,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
     let numberOfEvents = 0;
 
-    for await (const { submitAndAwait } of provider.operations.submitAndAwait({
+    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
       numberOfEvents += 1;
@@ -1387,7 +1387,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
     let numberOfEvents = 0;
 
-    for await (const { submitAndAwait } of provider.operations.submitAndAwait({
+    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
       numberOfEvents += 1;
@@ -1425,7 +1425,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     await expectToThrowFuelError(
       async () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for await (const { submitAndAwait } of provider.operations.submitAndAwait({
+        for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
           encodedTransaction: "it's mocked so doesn't matter",
         })) {
           // shouldn't be reached!
@@ -1492,7 +1492,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     });
 
     await safeExec(async () => {
-      for await (const iterator of provider.operations.statusChange({
+      for await (const iterator of await provider.operations.statusChange({
         transactionId: 'doesnt matter, will be aborted',
       })) {
         // Just running a subscription to trigger the middleware

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -367,11 +367,22 @@ type ChainInfoCache = Record<string, ChainInfo>;
  */
 type NodeInfoCache = Record<string, NodeInfo>;
 
+type Operations = ReturnType<typeof getOperationsSdk>;
+
+type SdkOperations = Omit<Operations, 'submitAndAwait' | 'statusChange'> & {
+  submitAndAwait: (
+    ...args: Parameters<Operations['submitAndAwait']>
+  ) => Promise<ReturnType<Operations['submitAndAwait']>>;
+  statusChange: (
+    ...args: Parameters<Operations['statusChange']>
+  ) => Promise<ReturnType<Operations['statusChange']>>;
+};
+
 /**
  * A provider for connecting to a node
  */
 export default class Provider {
-  operations: ReturnType<typeof getOperationsSdk>;
+  operations: SdkOperations;
   cache?: ResourceCache;
 
   /** @hidden */
@@ -559,7 +570,7 @@ Supported fuel-core version: ${supportedVersion}.`
    * @returns The operation SDK object
    * @hidden
    */
-  private createOperations() {
+  private createOperations(): SdkOperations {
     const fetchFn = Provider.getFetchFn(this.options);
     const gqlClient = new GraphQLClient(this.url, {
       fetch: (url: string, requestInit: RequestInit) => fetchFn(url, requestInit, this.options),
@@ -583,7 +594,7 @@ Supported fuel-core version: ${supportedVersion}.`
       const isSubscription = opDefinition?.operation === 'subscription';
 
       if (isSubscription) {
-        return new FuelGraphqlSubscriber({
+        return FuelGraphqlSubscriber.create({
           url: this.url,
           query,
           fetchFn: (url, requestInit) => fetchFn(url as string, requestInit, this.options),

--- a/packages/account/src/providers/transaction-response/transaction-response.ts
+++ b/packages/account/src/providers/transaction-response/transaction-response.ts
@@ -140,7 +140,7 @@ export class TransactionResponse {
     });
 
     if (!response.transaction) {
-      const subscription = this.provider.operations.statusChange({
+      const subscription = await this.provider.operations.statusChange({
         transactionId: this.id,
       });
 
@@ -236,7 +236,7 @@ export class TransactionResponse {
       return;
     }
 
-    const subscription = this.provider.operations.statusChange({
+    const subscription = await this.provider.operations.statusChange({
       transactionId: this.id,
     });
 

--- a/packages/fuel-gauge/src/edge-cases.test.ts
+++ b/packages/fuel-gauge/src/edge-cases.test.ts
@@ -46,7 +46,7 @@ describe('Edge Cases', () => {
 
     await response.waitForResult();
 
-    const subsciption = provider.operations.statusChange({ transactionId });
+    const subsciption = await provider.operations.statusChange({ transactionId });
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for await (const iterator of subsciption) {


### PR DESCRIPTION
# Summary

I moved `FuelGraphqlSubcriber` instantiation to be async as a preparatory step for #2936. I tried introducing the solution for that issue in #2962, commit https://github.com/FuelLabs/fuels-ts/pull/2962/commits/80511131b68754288f7e686fc040413e8ea14141, but I wasn't happy with the solution so I reverted it and created this to give myself room to figure out a solution.

This change is necessary for the usage of `submitAndAwait` endpoint because the transaction can fail when submitted, but the failure isn't manifested until a call to the `FuelGraphqlSubscriber.next` method is done. With this async instantiation, the subscription can be made to fail _before_ the actual subscription iterator is returned. I will add this failure handling in a subsequent PR that will tackle #2936, after I sync with the `fuel-core` team. We currently aren't using `submitAndAwait` anywhere so it's not a problem to leave it unhandled as-is.

# Breaking Changes

```ts
// before
const subscription = provider.operations.statusChange({ transactionId });
for await (const response of subscription) { ... }

const submittedTxSubscription = this.operations.submitAndAwait({ encodedTransaction: '0x' });
```

```ts
// after
const subscription = await provider.operations.statusChange({ transactionId });
for await (const response of subscription) { ... }

const submittedTxSubscription = await this.operations.submitAndAwait({ encodedTransaction: '0x' });
```

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
