### PR TITLE
fix: stop building `typegen` on `pretest` script

### DIFF
--- a/packages/abi-typegen/package.json
+++ b/packages/abi-typegen/package.json
@@ -43,7 +43,7 @@
     "dist"
   ],
   "scripts": {
-    "pretest": "run-s build build:forc",
+    "pretest": "pnpm build:forc",
     "test": "cd ../.. && pnpm run test:filter packages/abi-typegen",
     "test:update-fixtures": "UPDATE_FIXTURES=true pnpm run test",
     "build": "tsup",


### PR DESCRIPTION
# Summary

It was a miss on my part during #2856.



# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
