### PR TITLE
chore: make `nextjs` the default `create fuels` template

### DIFF
--- a/.changeset/great-boxes-scream.md
+++ b/.changeset/great-boxes-scream.md
@@ -1,0 +1,5 @@
+---
+"create-fuels": patch
+---
+
+chore: make 'nextjs' the default template

--- a/.changeset/great-boxes-scream.md
+++ b/.changeset/great-boxes-scream.md
@@ -2,4 +2,4 @@
 "create-fuels": patch
 ---
 
-chore: make 'nextjs' the default template
+chore: make `nextjs` the default `create fuels` template

--- a/packages/create-fuels/src/lib/setupProgram.ts
+++ b/packages/create-fuels/src/lib/setupProgram.ts
@@ -4,7 +4,7 @@ import packageJson from '../../package.json';
 
 export type Template = 'nextjs' | 'vite';
 export const templates: Set<Template> = new Set(['nextjs', 'vite']);
-export const defaultTemplate: Template = 'vite';
+export const defaultTemplate: Template = 'nextjs';
 
 export interface ProgramOptions {
   contract?: boolean;


### PR DESCRIPTION
- Relates to #3004

# Summary

We recently supported `vite` as a template for `create fuels`. Before making it the default template, we should also complete everything in #3004. This will fix the [failing integration test](https://github.com/FuelLabs/fuels-ts/actions/runs/10498760224/job/29099978488?pr=2991) in CI.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
