### PR TITLE
fix: consistent typegen outputs

### DIFF
--- a/.changeset/fast-ties-crash.md
+++ b/.changeset/fast-ties-crash.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/utils": patch
+---
+
+fix: consistent typegen outputs

--- a/packages/utils/src/utils/bytecode.test.ts
+++ b/packages/utils/src/utils/bytecode.test.ts
@@ -1,5 +1,6 @@
 import { arrayify } from './arrayify';
 import { compressBytecode, decompressBytecode } from './bytecode';
+import { sleep } from './sleep';
 
 /**
  * We are using a base64 encoded bytecode here to avoid having to
@@ -18,6 +19,13 @@ describe('bytecode utils', () => {
   test('should compress bytecode', () => {
     const compressedBytecode = compressBytecode(bytecodeBinary);
     expect(compressedBytecode.length).toBeLessThan(bytecodeBinary.length);
+  });
+
+  test('should compress to the same value', async () => {
+    const compressedBytecode = compressBytecode(bytecodeBinary);
+    await sleep(1000);
+    const compressedBytecode2 = compressBytecode(bytecodeBinary);
+    expect(compressedBytecode).toEqual(compressedBytecode2);
   });
 
   test('should decompress bytecode', () => {

--- a/packages/utils/src/utils/bytecode.ts
+++ b/packages/utils/src/utils/bytecode.ts
@@ -9,7 +9,7 @@ export const compressBytecode = (bytecodeAsBinary?: BytesLike) => {
   }
 
   const bytecodeCompressBytes = arrayify(bytecodeAsBinary);
-  const bytecodeCompressGzipped = gzipSync(bytecodeCompressBytes);
+  const bytecodeCompressGzipped = gzipSync(bytecodeCompressBytes, { mtime: 0 });
   const bytecodeCompressBinary = String.fromCharCode.apply(
     null,
     new Uint8Array(bytecodeCompressGzipped) as unknown as number[]


### PR DESCRIPTION
- Closes #3039

# Summary

- The compression of our bytecode is including a modified timestamp so the output of typegen is different in sequential runs. This PR fixes the modified timestamp to ensure the results of compression are equal.
- Showcase of [failure](https://github.com/FuelLabs/fuels-ts/actions/runs/10582459539/job/29322202973?pr=3040#step:6:1030) and success.

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
