### PR TITLE
fix: added missing dependencies for templates

### DIFF
--- a/.changeset/strong-pears-walk.md
+++ b/.changeset/strong-pears-walk.md
@@ -1,0 +1,5 @@
+---
+"create-fuels": patch
+---
+
+fix: added missing dependencies for templates


### PR DESCRIPTION
# Summary

- Adds the missing changeset from #3035

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
