### PR TITLE
fix: transaction estimation for `InputMessage` containing `data`

### DIFF
--- a/.changeset/rotten-stingrays-appear.md
+++ b/.changeset/rotten-stingrays-appear.md
@@ -2,4 +2,4 @@
 "@fuel-ts/account": patch
 ---
 
-fix: adjust tx estimation for `InputMessage` containing `data`
+fix: transaction estimation for `InputMessage` containing `data`

--- a/.changeset/rotten-stingrays-appear.md
+++ b/.changeset/rotten-stingrays-appear.md
@@ -2,4 +2,4 @@
 "@fuel-ts/account": patch
 ---
 
-chore: fix transaction estimation
+fix: adjust tx estimation for `InputMessage` containing `data`

--- a/.changeset/rotten-stingrays-appear.md
+++ b/.changeset/rotten-stingrays-appear.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+chore: fix transaction estimation

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    # if: false
+    if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    if: false
+    # if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -558,13 +558,10 @@ export class Account extends AbstractAccount {
     const updateAssetInput = (assetId: string, quantity: BN) => {
       const assetInput = findAssetInput(assetId);
 
-      console.log(`asd assetInput`, assetInput);
       if (assetInput && 'amount' in assetInput) {
-        console.log(`asd changing assetInput.amount to`, quantity, assetId);
         assetInput.amount = quantity;
 
       } else {
-        console.log(`asd generating fake resources for amunt`, quantity, assetId);
         txRequestClone.addResources(
           this.generateFakeResources([
             {
@@ -577,9 +574,6 @@ export class Account extends AbstractAccount {
     };
 
     const merged = mergeQuantities(requiredQuantities, transactionFeeForDryRun);
-
-    console.log(`asd txRequestClone.inputs`, txRequestClone.inputs);
-    console.log(`asd merged`, merged);
 
     merged.forEach(({ amount, assetId }) =>
       updateAssetInput(assetId, amount)

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -546,7 +546,9 @@ export class Account extends AbstractAccount {
         if (input.type === InputType.Coin) {
           return input.assetId === assetId;
         }
-        // we only consider the message input if it has no data. messages with `data` cannot fund the gas of transaction
+
+        // We only consider the message input if it has no data.
+        // Messages with `data` cannot fund the gas of a transaction.
         if (input.type === InputType.Message && bn(input.data).isZero()) {
           return baseAssetId === assetId;
         }

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -6,6 +6,7 @@ import { AbstractAccount } from '@fuel-ts/interfaces';
 import type { AbstractAddress, BytesLike } from '@fuel-ts/interfaces';
 import type { BigNumberish, BN } from '@fuel-ts/math';
 import { bn } from '@fuel-ts/math';
+import { InputType } from '@fuel-ts/transactions';
 import { arrayify, hexlify, isDefined } from '@fuel-ts/utils';
 import { clone } from 'ramda';
 
@@ -45,7 +46,6 @@ import {
 } from './providers/transaction-request/helpers';
 import { mergeQuantities } from './providers/utils/merge-quantities';
 import { assembleTransferToContractScript } from './utils/formatTransferToContractScriptData';
-import { InputType } from '@fuel-ts/transactions';
 
 export type TxParamsType = Pick<
   ScriptTransactionRequestLike,
@@ -530,7 +530,6 @@ export class Account extends AbstractAccount {
     transactionRequestLike: TransactionRequestLike,
     { signatureCallback, quantities = [] }: TransactionCostParams = {}
   ): Promise<TransactionCost> {
-    console.warn('asd TEST TEST TEST');
     const txRequestClone = clone(transactionRequestify(transactionRequestLike));
     const baseAssetId = this.provider.getBaseAssetId();
 
@@ -560,7 +559,6 @@ export class Account extends AbstractAccount {
 
       if (assetInput && 'amount' in assetInput) {
         assetInput.amount = quantity;
-
       } else {
         txRequestClone.addResources(
           this.generateFakeResources([
@@ -575,9 +573,7 @@ export class Account extends AbstractAccount {
 
     const merged = mergeQuantities(requiredQuantities, transactionFeeForDryRun);
 
-    merged.forEach(({ amount, assetId }) =>
-      updateAssetInput(assetId, amount)
-    );
+    merged.forEach(({ amount, assetId }) => updateAssetInput(assetId, amount));
 
     const txCost = await this.provider.getTransactionCost(txRequestClone, {
       signatureCallback,


### PR DESCRIPTION
 - Closes #3053

# Release notes

In this release, we:
 - Fixed tx estimation when `InputMessage` contains `data`

# Summary

Messages with `data` cannot fund transactions.

This would happen in Fuel accounts that received a deposit from an `ERC20` token (like in the Bridge).

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
