### PR TITLE
chore: deprecate `BaseTransactionRequest.fundWithFakeUtxos`

### DIFF
--- a/.changeset/gentle-files-pay.md
+++ b/.changeset/gentle-files-pay.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/contract": patch
+"@fuel-ts/account": patch
+---
+
+chore: deprecate `BaseTransactionRequest.fundWithFakeUtxos`

--- a/packages/account/src/providers/transaction-request/transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/transaction-request.ts
@@ -579,6 +579,8 @@ export abstract class BaseTransactionRequest implements BaseTransactionRequestLi
    *
    * @param quantities - CoinQuantity Array.
    * @param baseAssetId - The base asset to fund the transaction.
+   * @deprecated - This method is deprecated and will be removed in future versions.
+   * Please use `Account.generateFakeResources` along with `this.addResources` instead.
    */
   fundWithFakeUtxos(
     quantities: CoinQuantity[],

--- a/packages/contract/src/contract-factory.ts
+++ b/packages/contract/src/contract-factory.ts
@@ -465,8 +465,8 @@ export default class ContractFactory {
       );
     }
 
-    const { provider } = this.getAccount();
-    const { consensusParameters } = provider.getChain();
+    const account = this.getAccount();
+    const { consensusParameters } = account.provider.getChain();
     const contractSizeLimit = consensusParameters.contractParameters.contractMaxSize.toNumber();
     const transactionSizeLimit = consensusParameters.txParameters.maxSize.toNumber();
     const maxLimit = 64000;
@@ -475,10 +475,13 @@ export default class ContractFactory {
     const sizeLimit = chainLimit < maxLimit ? chainLimit : maxLimit;
 
     // Get an estimate base tx length
+
     const blobTx = this.blobTransactionRequest({
       ...deployOptions,
       bytecode: randomBytes(32),
-    }).fundWithFakeUtxos([], provider.getBaseAssetId());
+    }).addResources(
+      account.generateFakeResources([{ assetId: account.provider.getBaseAssetId(), amount: bn(1) }])
+    );
     // Given above, calculate the maximum chunk size
     const maxChunkSize = (sizeLimit - blobTx.byteLength() - WORD_SIZE) * chunkSizeMultiplier;
 


### PR DESCRIPTION
# Release notes

In this release, we:

- Deprecate the method `BaseTransactionRequest.fundWithFakeUtxos`

# Summary

The method `BaseTransactionRequest.fundWithFakeUtxos` is being deprecated in favor of `Account.generateFakeResources`

```ts
// before
const baseAssetId = provider.getBaseAssetId();
const quantities = [{ amount: 100, assetId: baseAssetId }];

transactionRequest.fundWithFakeUtxos(quantities, baseAssetId, account.address);
```

```ts
// after
const baseAssetId = provider.getBaseAssetId();
const quantities = [{ amount: 100, assetId: baseAssetId }];

const fakeResources = account.generateFakeResources(quantities);
transactionRequest.addResources(fakeResources);
```


# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
