### PR TITLE
feat: return deep clone on transaction request `from` method

### DIFF
--- a/.changeset/curvy-melons-itch.md
+++ b/.changeset/curvy-melons-itch.md
@@ -2,4 +2,4 @@
 "@fuel-ts/account": patch
 ---
 
-fix: return deep clone on transaction request `from` method
+feat: return deep clone on transaction request `from` method

--- a/.changeset/curvy-melons-itch.md
+++ b/.changeset/curvy-melons-itch.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+fix: return deep clone on transaction request `from` method

--- a/packages/account/src/providers/transaction-request/blob-transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/blob-transaction-request.ts
@@ -18,9 +18,9 @@ export interface BlobTransactionRequestLike extends BaseTransactionRequestLike {
 export class BlobTransactionRequest extends BaseTransactionRequest {
   static from(obj: BlobTransactionRequestLike) {
     if (obj instanceof this) {
-      return obj;
+      return structuredClone(obj);
     }
-    return new this(obj);
+    return structuredClone(obj);
   }
 
   /** Type of the transaction */

--- a/packages/account/src/providers/transaction-request/blob-transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/blob-transaction-request.ts
@@ -17,10 +17,7 @@ export interface BlobTransactionRequestLike extends BaseTransactionRequestLike {
 
 export class BlobTransactionRequest extends BaseTransactionRequest {
   static from(obj: BlobTransactionRequestLike) {
-    if (obj instanceof this) {
-      return structuredClone(obj);
-    }
-    return structuredClone(obj);
+    return new this(structuredClone(obj));
   }
 
   /** Type of the transaction */

--- a/packages/account/src/providers/transaction-request/blob-transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/blob-transaction-request.ts
@@ -1,5 +1,6 @@
 import type { BN } from '@fuel-ts/math';
 import type { TransactionBlob } from '@fuel-ts/transactions';
+import { clone } from 'ramda';
 
 import type { GasCosts } from '../provider';
 import { calculateMetadataGasForTxBlob } from '../utils';
@@ -17,7 +18,7 @@ export interface BlobTransactionRequestLike extends BaseTransactionRequestLike {
 
 export class BlobTransactionRequest extends BaseTransactionRequest {
   static from(obj: BlobTransactionRequestLike) {
-    return new this(structuredClone(obj));
+    return new this(clone(obj));
   }
 
   /** Type of the transaction */

--- a/packages/account/src/providers/transaction-request/create-transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/create-transaction-request.ts
@@ -4,6 +4,7 @@ import { bn, type BN } from '@fuel-ts/math';
 import type { TransactionCreate } from '@fuel-ts/transactions';
 import { TransactionType, OutputType } from '@fuel-ts/transactions';
 import { arrayify, hexlify } from '@fuel-ts/utils';
+import { clone } from 'ramda';
 
 import type { GqlGasCosts } from '../__generated__/operations';
 import { calculateMetadataGasForTxCreate } from '../utils/gas';
@@ -32,7 +33,7 @@ export interface CreateTransactionRequestLike extends BaseTransactionRequestLike
  */
 export class CreateTransactionRequest extends BaseTransactionRequest {
   static from(obj: CreateTransactionRequestLike) {
-    return new this(structuredClone(obj));
+    return new this(clone(obj));
   }
 
   /** Type of the transaction */

--- a/packages/account/src/providers/transaction-request/create-transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/create-transaction-request.ts
@@ -32,10 +32,7 @@ export interface CreateTransactionRequestLike extends BaseTransactionRequestLike
  */
 export class CreateTransactionRequest extends BaseTransactionRequest {
   static from(obj: CreateTransactionRequestLike) {
-    if (obj instanceof this) {
-      return structuredClone(obj);
-    }
-    return structuredClone(obj);
+    return new this(structuredClone(obj));
   }
 
   /** Type of the transaction */

--- a/packages/account/src/providers/transaction-request/create-transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/create-transaction-request.ts
@@ -33,9 +33,9 @@ export interface CreateTransactionRequestLike extends BaseTransactionRequestLike
 export class CreateTransactionRequest extends BaseTransactionRequest {
   static from(obj: CreateTransactionRequestLike) {
     if (obj instanceof this) {
-      return obj;
+      return structuredClone(obj);
     }
-    return new this(obj);
+    return structuredClone(obj);
   }
 
   /** Type of the transaction */

--- a/packages/account/src/providers/transaction-request/script-transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/script-transaction-request.ts
@@ -40,9 +40,9 @@ export interface ScriptTransactionRequestLike extends BaseTransactionRequestLike
 export class ScriptTransactionRequest extends BaseTransactionRequest {
   static from(obj: ScriptTransactionRequestLike) {
     if (obj instanceof this) {
-      return obj;
+      return structuredClone(obj);
     }
-    return new this(obj);
+    return structuredClone(obj);
   }
 
   /** Type of the transaction */

--- a/packages/account/src/providers/transaction-request/script-transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/script-transaction-request.ts
@@ -39,10 +39,7 @@ export interface ScriptTransactionRequestLike extends BaseTransactionRequestLike
  */
 export class ScriptTransactionRequest extends BaseTransactionRequest {
   static from(obj: ScriptTransactionRequestLike) {
-    if (obj instanceof this) {
-      return structuredClone(obj);
-    }
-    return structuredClone(obj);
+    return new this(structuredClone(obj));
   }
 
   /** Type of the transaction */

--- a/packages/account/src/providers/transaction-request/script-transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/script-transaction-request.ts
@@ -8,6 +8,7 @@ import type { BN, BigNumberish } from '@fuel-ts/math';
 import type { TransactionScript } from '@fuel-ts/transactions';
 import { InputType, OutputType, TransactionType } from '@fuel-ts/transactions';
 import { arrayify, hexlify } from '@fuel-ts/utils';
+import { clone } from 'ramda';
 
 import type { ChainInfo, GasCosts } from '../provider';
 import { calculateMetadataGasForTxScript, getMaxGas } from '../utils/gas';
@@ -39,7 +40,7 @@ export interface ScriptTransactionRequestLike extends BaseTransactionRequestLike
  */
 export class ScriptTransactionRequest extends BaseTransactionRequest {
   static from(obj: ScriptTransactionRequestLike) {
-    return new this(structuredClone(obj));
+    return new this(clone(obj));
   }
 
   /** Type of the transaction */

--- a/packages/account/src/providers/transaction-request/utils.test.ts
+++ b/packages/account/src/providers/transaction-request/utils.test.ts
@@ -1,3 +1,6 @@
+import { bn } from '@fuel-ts/math';
+import { InputType } from '@fuel-ts/transactions';
+
 import { BlobTransactionRequest } from './blob-transaction-request';
 import { CreateTransactionRequest } from './create-transaction-request';
 import { ScriptTransactionRequest } from './script-transaction-request';
@@ -40,5 +43,90 @@ describe('isTransactionTypeBlob', () => {
   it('should return false if the request is not a blob transaction', () => {
     const request = new ScriptTransactionRequest();
     expect(isTransactionTypeCreate(request)).toBe(false);
+  });
+});
+
+describe('transactionRequestify', () => {
+  it('from method should return a cloned script transaction request', () => {
+    const baseRequest = new ScriptTransactionRequest();
+    const newRequest = ScriptTransactionRequest.from(baseRequest);
+    newRequest.inputs.push({
+      amount: bn(1),
+      id: '0x',
+      owner: '0x',
+      txPointer: '0x',
+      witnessIndex: 0,
+      type: InputType.Coin,
+      assetId: '0x',
+    });
+    baseRequest.inputs.push({
+      amount: bn(10),
+      id: '0x123',
+      owner: '0x456',
+      txPointer: '0x789',
+      witnessIndex: 1,
+      type: InputType.Coin,
+      assetId: '0xabc',
+    });
+    expect(newRequest).to.not.equal(baseRequest);
+    expect(newRequest.inputs).to.not.equal(baseRequest.inputs);
+    expect(newRequest.inputs).toHaveLength(1);
+    expect(baseRequest.inputs).toHaveLength(1);
+  });
+
+  it('from method should return a cloned create transaction request', () => {
+    const baseRequest = new CreateTransactionRequest({});
+    const newRequest = CreateTransactionRequest.from(baseRequest);
+    newRequest.inputs.push({
+      amount: bn(1),
+      id: '0x',
+      owner: '0x',
+      txPointer: '0x',
+      witnessIndex: 0,
+      type: InputType.Coin,
+      assetId: '0x',
+    });
+    baseRequest.inputs.push({
+      amount: bn(10),
+      id: '0x123',
+      owner: '0x456',
+      txPointer: '0x789',
+      witnessIndex: 1,
+      type: InputType.Coin,
+      assetId: '0xabc',
+    });
+
+    expect(newRequest).to.not.equal(baseRequest);
+    expect(newRequest.inputs).to.not.equal(baseRequest.inputs);
+    expect(newRequest.inputs).toHaveLength(1);
+    expect(baseRequest.inputs).toHaveLength(1);
+  });
+
+  it('from method should return a cloned blob transaction request', () => {
+    const baseRequest = new BlobTransactionRequest({ blobId: '0x' });
+    const newRequest = BlobTransactionRequest.from(baseRequest);
+    newRequest.inputs.push({
+      amount: bn(1),
+      id: '0x',
+      owner: '0x',
+      txPointer: '0x',
+      witnessIndex: 0,
+      type: InputType.Coin,
+      assetId: '0x',
+    });
+    baseRequest.inputs.push({
+      amount: bn(10),
+      id: '0x123',
+      owner: '0x456',
+      txPointer: '0x789',
+      witnessIndex: 1,
+      type: InputType.Coin,
+      assetId: '0xabc',
+    });
+
+    expect(newRequest).to.not.equal(baseRequest);
+    expect(newRequest.inputs).to.not.equal(baseRequest.inputs);
+    expect(newRequest.inputs).toHaveLength(1);
+    expect(baseRequest.inputs).toHaveLength(1);
   });
 });


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

- Closes https://github.com/FuelLabs/fuels-ts/issues/3076

# Release notes

<!--
Use this only if this PR requires a mention in the Release
Notes Summary. Valuable features and critical fixes are good
examples. For everything else, please delete the whole section.
-->

In this release, we:

- We now return a deep clone of the transaction request in the static `from` method

# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

I've applied this feat to the other `from` methods on the other `BaseTransactionRequest` subclasses

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
