### PR TITLE
fix: assemble of transaction revert error message

### DIFF
--- a/.changeset/tall-rivers-rest.md
+++ b/.changeset/tall-rivers-rest.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+fix: assemble of transaction revert error message

--- a/packages/account/src/providers/utils/extract-tx-error.ts
+++ b/packages/account/src/providers/utils/extract-tx-error.ts
@@ -56,19 +56,23 @@ export const assembleRevertError = (
 
   if (revertReceipt) {
     const reasonHex = bn(revertReceipt.val).toHex();
+    const lastLog = logs[logs.length - 1];
+    const lastButOneLog = logs[logs.length - 2];
 
     switch (reasonHex) {
       case FAILED_REQUIRE_SIGNAL: {
         reason = 'require';
         errorMessage = `The transaction reverted because a "require" statement has thrown ${
-          logs.length ? stringify(logs[0]) : 'an error.'
+          logs.length ? stringify(lastLog) : 'an error.'
         }.`;
         break;
       }
 
       case FAILED_ASSERT_EQ_SIGNAL: {
         const sufix =
-          logs.length >= 2 ? ` comparing ${stringify(logs[1])} and ${stringify(logs[0])}.` : '.';
+          logs.length >= 2
+            ? ` comparing ${stringify(lastLog)} and ${stringify(lastButOneLog)}.`
+            : '.';
 
         reason = 'assert_eq';
         errorMessage = `The transaction reverted because of an "assert_eq" statement${sufix}`;
@@ -77,7 +81,9 @@ export const assembleRevertError = (
 
       case FAILED_ASSERT_NE_SIGNAL: {
         const sufix =
-          logs.length >= 2 ? ` comparing ${stringify(logs[1])} and ${stringify(logs[0])}.` : '.';
+          logs.length >= 2
+            ? ` comparing ${stringify(lastButOneLog)} and ${stringify(lastLog)}.`
+            : '.';
 
         reason = 'assert_ne';
         errorMessage = `The transaction reverted because of an "assert_ne" statement${sufix}`;

--- a/packages/fuel-gauge/src/revert-error.test.ts
+++ b/packages/fuel-gauge/src/revert-error.test.ts
@@ -30,15 +30,14 @@ describe('Revert Error Testing', () => {
       .call();
 
     const { logs } = await waitForResult();
+    const lastLog = logs[logs.length - 1];
 
-    expect(
-      logs.map((d) => ({ token_id: d.token_id?.toString(), price: d.price?.toString() }))
-    ).toEqual([
-      {
-        token_id: INPUT_TOKEN_ID.toString(),
-        price: INPUT_PRICE.toString(),
-      },
-    ]);
+    expect(JSON.stringify(lastLog)).toEqual(
+      JSON.stringify({
+        token_id: INPUT_TOKEN_ID,
+        price: INPUT_PRICE,
+      })
+    );
   });
 
   it('should throw for "require" revert TX [PriceCantBeZero]', async () => {
@@ -53,7 +52,7 @@ describe('Revert Error Testing', () => {
         ErrorCode.SCRIPT_REVERTED,
         `The transaction reverted because a "require" statement has thrown "PriceCantBeZero".`,
         {
-          logs: ['PriceCantBeZero'],
+          logs: [1, 'FOO', 'PriceCantBeZero'],
           receipts: expect.any(Array<TransactionResultReceipt>),
           reason: 'require',
           panic: false,
@@ -80,7 +79,7 @@ describe('Revert Error Testing', () => {
         ErrorCode.SCRIPT_REVERTED,
         `The transaction reverted because a "require" statement has thrown "InvalidTokenId".`,
         {
-          logs: ['InvalidTokenId'],
+          logs: [1, 'FOO', 'BAR', 'BAZ', 99, 'InvalidTokenId'],
           receipts: expect.any(Array<TransactionResultReceipt>),
           reason: 'require',
           panic: false,
@@ -121,7 +120,7 @@ describe('Revert Error Testing', () => {
         ErrorCode.SCRIPT_REVERTED,
         'The transaction reverted because an "assert" statement failed to evaluate to true.',
         {
-          logs: [],
+          logs: [1, 'FOO', 'BAR', 'BAZ', 99, 100],
           receipts: expect.any(Array<TransactionResultReceipt>),
           panic: false,
           revert: true,
@@ -159,7 +158,7 @@ describe('Revert Error Testing', () => {
         ErrorCode.SCRIPT_REVERTED,
         `The transaction reverted because of an "assert_eq" statement comparing 10 and 9.`,
         {
-          logs: [9, 10],
+          logs: ['FOO', 9, 10],
           receipts: expect.any(Array<TransactionResultReceipt>),
           panic: false,
           revert: true,
@@ -178,7 +177,7 @@ describe('Revert Error Testing', () => {
         ErrorCode.SCRIPT_REVERTED,
         `The transaction reverted because of an "assert_ne" statement comparing 5 and 5.`,
         {
-          logs: [5, 5],
+          logs: ['BAZ', 10, 5, 5],
           receipts: expect.any(Array<TransactionResultReceipt>),
           panic: false,
           revert: true,
@@ -263,7 +262,7 @@ describe('Revert Error Testing', () => {
         ErrorCode.SCRIPT_REVERTED,
         `The transaction reverted because of an "assert_ne" statement comparing 5 and 5.`,
         {
-          logs: [5, 5],
+          logs: ['BAZ', 10, 5, 5],
           receipts: expect.any(Array<TransactionResultReceipt>),
           panic: false,
           revert: true,

--- a/packages/fuel-gauge/test/fixtures/forc-projects/revert-error/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/revert-error/src/main.sw
@@ -23,9 +23,15 @@ pub struct ValidInputsEvent {
 
 impl RevertError for Contract {
     fn validate_inputs(token_id: u64, price: u64) {
+        log(1u8);
+        log("FOO");
         require(price != 0, InputError::PriceCantBeZero);
+        log("BAR");
         require(token_id != 0, AccessError::TokenIdCantBeZero);
+        log("BAZ");
+        log(99u8);
         require(token_id == 100u64, AccessError::InvalidTokenId);
+        log(100u8);
 
         assert(price != token_id);
 
@@ -62,11 +68,15 @@ impl RevertError for Contract {
     }
 
     fn assert_value_eq_10(value: u8) {
+        log("FOO");
         assert_eq(value, 10);
     }
 
     fn assert_value_ne_5(value: u8) {
+        log("BAZ");
+        log(10u8);
         assert_ne(value, 5);
+        log(27u8);
     }
 
     fn revert_with_0() {


### PR DESCRIPTION
- Closes #3099

# Summary

This PR ensures that the correct Sway program logs are used whenever a transaction is reverted by the following validations:  `require`, `assert_eq`, and `assert_ne`.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
