### PR TITLE
fix: error handling in `Provider` for when a node is offline

### DIFF
--- a/.changeset/hot-cats-happen.md
+++ b/.changeset/hot-cats-happen.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+fix: error handling in `Provider` for when a node is offline

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -504,7 +504,7 @@ export default class Provider {
     const provider = new Provider(urlToUse, {
       ...options,
       requestMiddleware: async (request) => {
-        if (auth) {
+        if (auth && request) {
           request.headers ??= {};
           (request.headers as Record<string, string>).Authorization = auth;
         }


### PR DESCRIPTION
# Release notes

In this release, we:

- Fixed error handling in Provider for when a node is offline

# Summary

If a node is offline, the Provider middleware throws an exception when it tries to inject the auth headers into an `undefined` request object, so we check if the `request` object is valid before injecting auth headers.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
