### PR TITLE
fix: loader contract being called via proxy

### DIFF
--- a/.changeset/grumpy-flies-sleep.md
+++ b/.changeset/grumpy-flies-sleep.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/contract": patch
+---
+
+fix: loader contract being called via proxy

--- a/packages/contract/src/loader/loader-script.test.ts
+++ b/packages/contract/src/loader/loader-script.test.ts
@@ -13,7 +13,7 @@ describe('Loader Script', () => {
     const actual = getLoaderInstructions(blobIds);
 
     const expected = new Uint8Array([
-      26, 64, 192, 0, 80, 65, 0, 48, 26, 88, 80, 0, 114, 76, 0, 3, 186, 69, 0, 0, 50, 64, 4, 65, 80,
+      26, 64, 48, 0, 80, 65, 0, 48, 26, 88, 80, 0, 114, 76, 0, 3, 186, 69, 0, 0, 50, 64, 4, 65, 80,
       65, 0, 32, 89, 77, 48, 1, 119, 76, 0, 3, 32, 89, 99, 0, 82, 89, 96, 4, 74, 88, 0, 0, 1, 2, 3,
     ]);
     expect(actual).toStrictEqual(expected);

--- a/packages/contract/src/loader/loader-script.ts
+++ b/packages/contract/src/loader/loader-script.ts
@@ -22,7 +22,7 @@ export const getLoaderInstructions = (blobIds: string[]): Uint8Array => {
   const instructionBytes = new InstructionSet(
     // 1. load the blob contents into memory
     // find the start of the hardcoded blob ids, which are located after the code ends
-    asm.move_(0x10, RegId.is().to_u8()),
+    asm.move_(0x10, RegId.pc().to_u8()),
     // 0x10 to hold the address of the current blob id
     asm.addi(0x10, 0x10, numberOfInstructions * Instruction.size()),
     // The contract is going to be loaded from the current value of SP onwards, save

--- a/packages/contract/src/loader/loader-script.ts
+++ b/packages/contract/src/loader/loader-script.ts
@@ -13,7 +13,7 @@ export const getLoaderInstructions = (blobIds: string[]): Uint8Array => {
   // Bytes for the Blob Ids
   const blobIdBytes = concat(blobIds.map((b) => arrayify(b)));
 
-  // Reference: https://github.com/FuelLabs/fuels-ts/issues/2741#issuecomment-2260364179
+  // Reference: https://github.com/FuelLabs/fuels-rs/blob/master/packages/fuels-programs/src/contract/loader.rs
   // There are 2 main steps:
   // 1. Load the blob contents into memory
   // 2. Jump to the beginning of the memory where the blobs were loaded

--- a/packages/fuel-gauge/src/contract-factory.test.ts
+++ b/packages/fuel-gauge/src/contract-factory.test.ts
@@ -11,7 +11,6 @@ import {
   ConfigurableContractFactory,
   LargeContract,
   ConfigurableContract,
-  ProxyContract,
   ProxyContractFactory,
 } from '../test/typegen';
 
@@ -587,5 +586,5 @@ describe('Contract Factory', () => {
       .call();
     const { value: proxyValue } = await proxyCall.waitForResult();
     expect(proxyValue.toNumber()).toBe(1001);
-  });
+  }, 25000);
 });

--- a/packages/fuel-gauge/test/fixtures/forc-projects/Forc.toml
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/Forc.toml
@@ -39,6 +39,7 @@ members = [
   "predicate-validate-transfer",
   "predicate-vector-types",
   "predicate-with-configurable",
+  "proxy-contract",
   "raw-slice-contract",
   "reentrant-bar",
   "reentrant-foo",

--- a/packages/fuel-gauge/test/fixtures/forc-projects/proxy-contract/Forc.toml
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/proxy-contract/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "proxy-contract"
+
+[dependencies]

--- a/packages/fuel-gauge/test/fixtures/forc-projects/proxy-contract/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/proxy-contract/src/main.sw
@@ -1,0 +1,29 @@
+contract;
+
+use std::execution::run_external;
+
+abi Proxy {
+    #[storage(write)]
+    fn set_target_contract(id: ContractId);
+
+    // this targets the method of the `large_contract project
+    #[storage(read)]
+    fn something() -> u64;
+}
+
+storage {
+    target_contract: Option<ContractId> = None,
+}
+
+impl Proxy for Contract {
+    #[storage(write)]
+    fn set_target_contract(id: ContractId) {
+        storage.target_contract.write(Some(id));
+    }
+
+    #[storage(read)]
+    fn something() -> u64 {
+        let target = storage.target_contract.read().unwrap();
+        run_external(target)
+    }
+}


### PR DESCRIPTION
- Closes #3121

# Release notes

In this release, we:

- Fixed an issue where you couldn't call a loader contract via a proxy contract

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
