### PR TITLE
fix: storage slots auto-load from typegen

### DIFF
--- a/.changeset/witty-terms-swim.md
+++ b/.changeset/witty-terms-swim.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-typegen": patch
+---
+
+fix: storage slots auto-load from typegen

--- a/packages/abi-typegen/src/templates/contract/factory.hbs
+++ b/packages/abi-typegen/src/templates/contract/factory.hbs
@@ -1,6 +1,6 @@
 {{header}}
 
-import { ContractFactory, decompressBytecode } from "fuels";
+import { Contract, ContractFactory, decompressBytecode } from "fuels";
 import type { Provider, Account, DeployContractOptions, DeployContractResult } from "fuels";
 
 import { {{capitalizedName}} } from "./{{capitalizedName}}";
@@ -15,15 +15,20 @@ export class {{capitalizedName}}Factory extends ContractFactory {
     super(bytecode, {{capitalizedName}}.abi, accountOrProvider);
   }
 
+  deploy<TContract extends Contract = Contract>(
+    deployOptions?: DeployContractOptions
+  ): Promise<DeployContractResult<TContract>> {
+    return super.deploy({
+      storageSlots: {{capitalizedName}}.storageSlots,
+      ...deployOptions,
+    });
+  }
+
   static async deploy (
     wallet: Account,
     options: DeployContractOptions = {}
   ): Promise<DeployContractResult<{{capitalizedName}}>> {
     const factory = new {{capitalizedName}}Factory(wallet);
-
-    return factory.deploy({
-      storageSlots: {{capitalizedName}}.storageSlots,
-      ...options,
-    });
+    return factory.deploy(options);
   }
 }

--- a/packages/abi-typegen/test/fixtures/templates/contract/factory.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/contract/factory.hbs
@@ -10,7 +10,7 @@
   Fuel-Core version: 33.33.33
 */
 
-import { ContractFactory, decompressBytecode } from "fuels";
+import { Contract, ContractFactory, decompressBytecode } from "fuels";
 import type { Provider, Account, DeployContractOptions, DeployContractResult } from "fuels";
 
 import { MyContract } from "./MyContract";
@@ -25,15 +25,20 @@ export class MyContractFactory extends ContractFactory {
     super(bytecode, MyContract.abi, accountOrProvider);
   }
 
+  deploy<TContract extends Contract = Contract>(
+    deployOptions?: DeployContractOptions
+  ): Promise<DeployContractResult<TContract>> {
+    return super.deploy({
+      storageSlots: MyContract.storageSlots,
+      ...deployOptions,
+    });
+  }
+
   static async deploy (
     wallet: Account,
     options: DeployContractOptions = {}
   ): Promise<DeployContractResult<MyContract>> {
     const factory = new MyContractFactory(wallet);
-
-    return factory.deploy({
-      storageSlots: MyContract.storageSlots,
-      ...options,
-    });
+    return factory.deploy(options);
   }
 }


### PR DESCRIPTION
- Closes #3130

# Release notes

In this release, we:

- Fixed issue with storage slots not being auto-loaded when deploying a contract. 

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
