### PR TITLE
chore: update block explorer url

### DIFF
--- a/.changeset/warm-snails-cough.md
+++ b/.changeset/warm-snails-cough.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+chore: update block explorer url

--- a/packages/account/src/providers/utils/block-explorer.test.ts
+++ b/packages/account/src/providers/utils/block-explorer.test.ts
@@ -1,6 +1,6 @@
 import { buildBlockExplorerUrl } from './block-explorer';
 
-const DEFAULT_BLOCK_EXPLORER_URL = 'https://fuellabs.github.io/block-explorer-v2';
+const DEFAULT_BLOCK_EXPLORER_URL = 'https://app.fuel.network';
 const trimSlashes = /^\/|\/$/gm;
 
 const testBlockExplorerUrlWithInputs = ({

--- a/packages/account/src/providers/utils/block-explorer.ts
+++ b/packages/account/src/providers/utils/block-explorer.ts
@@ -1,6 +1,8 @@
 import { ErrorCode, FuelError } from '@fuel-ts/errors';
 
-const DEFAULT_BLOCK_EXPLORER_URL = 'https://fuellabs.github.io/block-explorer-v2';
+import { CHAIN_IDS } from '../chains';
+
+const DEFAULT_BLOCK_EXPLORER_URL = 'https://app.fuel.network';
 
 /** @hidden */
 const getPathFromInput = (
@@ -34,6 +36,7 @@ export const buildBlockExplorerUrl = (
   } = {}
 ) => {
   const { blockExplorerUrl, path, providerUrl, address, txId, blockNumber } = options;
+
   const explorerUrl = blockExplorerUrl || DEFAULT_BLOCK_EXPLORER_URL;
 
   // make sure that only ONE or none of the following is defined: address, txId, blockNumber


### PR DESCRIPTION
> TS-642

- Closes #3141

# Summary

Updates the block explorer URL.

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
