### PR TITLE
chore: revert add `signTransaction` to `FuelConnectorMethods` enum

### DIFF
--- a/.changeset/long-ravens-explain.md
+++ b/.changeset/long-ravens-explain.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": patch
----
-
-feat: add `signTransaction` to `FuelConnectorMethods` enum

--- a/.changeset/tasty-geckos-train.md
+++ b/.changeset/tasty-geckos-train.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+chore: revert add `signTransaction` to `FuelConnectorMethods` enum

--- a/packages/account/src/connectors/types/connector-types.ts
+++ b/packages/account/src/connectors/types/connector-types.ts
@@ -11,7 +11,6 @@ export enum FuelConnectorMethods {
   currentAccount = 'currentAccount',
   // Signature methods
   signMessage = 'signMessage',
-  signTransaction = 'signTransaction',
   sendTransaction = 'sendTransaction',
   // Assets metadata methods
   assets = 'assets',


### PR DESCRIPTION
- Closes #3148
- Closes TS-645

# Release notes

In this release, we:

- Removed `signTransaction` method from `FuelConnectorMethods` enum

# Summary

This PR reverts https://github.com/FuelLabs/fuels-ts/pull/3128.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
