### PR TITLE
ci: temporarily disable benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   benchmarks:
     runs-on: ubuntu-latest
+    # remove if:false after fine-tuning benchmarks
+    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Summary

Temporarily disabled the benchmark workflow until it is fine-tuned.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
