### PR TITLE
chore: link PRs with Linear issues

### DIFF
--- a/.github/workflows/linear-pr-integration.yaml
+++ b/.github/workflows/linear-pr-integration.yaml
@@ -1,0 +1,17 @@
+name: Linear Issue To PR Linker
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  link-pr-to-linear-issues:
+    name: "Link PR to Linear issues"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: FuelLabs/github-actions/linear/link-pr-to-linear-issue@master
+        with:
+          pull_number: ${{ github.event.pull_request.number }}
+          linear_api_key: ${{ secrets.LINEAR_TOKEN }}
+          github_token: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/linear-pr-integration.yaml
+++ b/.github/workflows/linear-pr-integration.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: FuelLabs/github-actions/linear/link-pr-to-linear-issue@ns/fix/pr-linear-integration
+      - uses: FuelLabs/github-actions/linear/link-pr-to-linear-issue@master
         with:
           pull_number: ${{ github.event.pull_request.number }}
           linear_api_key: ${{ secrets.LINEAR_TOKEN }}

--- a/.github/workflows/linear-pr-integration.yaml
+++ b/.github/workflows/linear-pr-integration.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: FuelLabs/github-actions/linear/link-pr-to-linear-issue@master
+      - uses: FuelLabs/github-actions/linear/link-pr-to-linear-issue@ns/fix/pr-linear-integration
         with:
           pull_number: ${{ github.event.pull_request.number }}
           linear_api_key: ${{ secrets.LINEAR_TOKEN }}


### PR DESCRIPTION
<!-- LINEAR: closes TS-648 -->
<!-- LINEAR: relates to  -->
- Closes #3157 

# Summary

This PR uses our [link-pr-to-linear-issues](https://github.com/FuelLabs/github-actions/tree/master/linear/link-pr-to-linear-issue) to... link PRs to Linear issues.

To review this, open up this PR's description to edit it and you'll see that the action added markdown comments at the beginning which do the deed. 

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
