### PR TITLE
chore: regenerate proxy artifacts during release

### DIFF
--- a/.changeset/popular-bikes-allow.md
+++ b/.changeset/popular-bikes-allow.md
@@ -1,0 +1,5 @@
+---
+"fuels": patch
+---
+
+chore: regenerate proxy artifacts during release

--- a/packages/fuels/src/cli/commands/deploy/proxy/types/Src14OwnedProxy.ts
+++ b/packages/fuels/src/cli/commands/deploy/proxy/types/Src14OwnedProxy.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
 /*
-  Fuels version: 0.94.6
+  Fuels version: 0.94.7
 */
 
 import { Contract, Interface } from "../../../../..";

--- a/packages/fuels/src/cli/commands/deploy/proxy/types/Src14OwnedProxyFactory.ts
+++ b/packages/fuels/src/cli/commands/deploy/proxy/types/Src14OwnedProxyFactory.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
 /*
-  Fuels version: 0.94.6
+  Fuels version: 0.94.7
 */
 
 import { Contract, ContractFactory, decompressBytecode } from "../../../../..";

--- a/packages/fuels/src/cli/commands/deploy/proxy/types/common.d.ts
+++ b/packages/fuels/src/cli/commands/deploy/proxy/types/common.d.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
 /*
-  Fuels version: 0.94.6
+  Fuels version: 0.94.7
 */
 
 /**

--- a/packages/fuels/src/cli/commands/deploy/proxy/types/index.ts
+++ b/packages/fuels/src/cli/commands/deploy/proxy/types/index.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
 /*
-  Fuels version: 0.94.6
+  Fuels version: 0.94.7
 */
 
 export { Src14OwnedProxy } from './Src14OwnedProxy';

--- a/scripts/changeset/changeset-version-with-docs.ts
+++ b/scripts/changeset/changeset-version-with-docs.ts
@@ -34,7 +34,7 @@ import { error } from 'console';
 
     // If they did, add and commit the changes
     if (versionsChanged || proxyChanged) {
-      execSync(`git add ${versionsFilePath}`);
+      execSync(`git add ${versionsFilePath} ${proxyDirPath}`);
       execSync(`git commit -m"ci(scripts): update versions"`);
     }
   } catch (err) {

--- a/scripts/changeset/changeset-version-with-docs.ts
+++ b/scripts/changeset/changeset-version-with-docs.ts
@@ -7,21 +7,33 @@ import { error } from 'console';
   try {
     /**
      * This is the base command that has to run always.
-     * Release CIs were failing when there were only empty changesets because we weren't running this command.
-     * See more here: https://github.com/FuelLabs/fuels-ts/pull/1847
+     *
+     * Release CIs were failing when there were only empty changesets
+     * because we weren't running this command.
+     *
+     * See more here:
+     *  https://github.com/FuelLabs/fuels-ts/pull/1847
      */
     execSync(`changeset version`);
 
     // Invoke versions' prebuild script (will rewrite version files if needed)
     execSync(`pnpm -C packages/versions prebuild`);
 
+    // Invoke fuels' build:proxy script (will rewrite header versions in generated files)
+    execSync(`pnpm -C packages/fuels build:proxy`);
+
+    // Checks if the commands above generated git changes
     const versionsFilePath = `packages/versions/src/lib/getBuiltinVersions.ts`;
+    const proxyDirPath = `packages/fuels/src/cli/commands/deploy/proxy`;
 
     const versionsChanged = !!execSync(`git status --porcelain ${versionsFilePath}`)
       .toString()
       .trim();
 
-    if (versionsChanged) {
+    const proxyChanged = !!execSync(`git status --porcelain ${proxyDirPath}`).toString().trim();
+
+    // If they did, add and commit the changes
+    if (versionsChanged || proxyChanged) {
       execSync(`git add ${versionsFilePath}`);
       execSync(`git commit -m"ci(scripts): update versions"`);
     }


### PR DESCRIPTION
# Summary

The last release [failed silently](https://github.com/FuelLabs/fuels-ts/actions/runs/11061528093/job/30734321051#step:11:33) halfway — packages were published, but the GitHub tag/release wasn't created.

This happened because some new `typegen` generated files were added during `build` (via https://github.com/FuelLabs/fuels-ts/pull/3190).

This PR accounts for these files.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
