### PR TITLE
chore: make `build:schema` script self-sufficient

### DIFF
--- a/.changeset/serious-crabs-begin.md
+++ b/.changeset/serious-crabs-begin.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: make `build:schema` script self-sufficient

--- a/.knip.json
+++ b/.knip.json
@@ -20,6 +20,7 @@
     "@types/rimraf",
     "@graphql-codegen*",
     "graphql-tag",
+    "get-graphql-schema",
     "events",
     "eslint-plugin-jsdoc",
     "eslint-plugin-jsx-a11y",

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "build": "tsup",
     "prebuild": "pnpm build:operations",
-    "build:schema": "get-graphql-schema http://127.0.0.1:4000/v1/graphql > src/providers/fuel-core-schema.graphql && prettier --write src/providers/fuel-core-schema.graphql",
+    "build:schema": "tsx ./scripts/generate-fuel-core-schema.mts",
     "build:operations": "pnpm graphql-codegen",
     "postbuild": "tsx ../../scripts/postbuild.ts"
   },

--- a/packages/account/scripts/generate-fuel-core-schema.mts
+++ b/packages/account/scripts/generate-fuel-core-schema.mts
@@ -1,0 +1,15 @@
+import { execSync } from "child_process";
+import { join } from "path";
+
+import { setupTestProviderAndWallets } from "../src/test-utils/setup-test-provider-and-wallets";
+
+using launched = await setupTestProviderAndWallets();
+
+const accountPackageDir = join(process.cwd(), "packages/account");
+const schemaPath = join(
+  accountPackageDir,
+  "src/providers/fuel-core-schema.graphql",
+);
+execSync(
+  `cd ${accountPackageDir} && pnpm get-graphql-schema ${launched.provider.url} > ${schemaPath} && prettier --write ${schemaPath}`,
+);

--- a/packages/account/test/fuel-core-schema.test.ts
+++ b/packages/account/test/fuel-core-schema.test.ts
@@ -4,8 +4,6 @@ import type { BinaryToTextEncoding } from 'crypto';
 import { createHash } from 'crypto';
 import { readFile } from 'fs/promises';
 
-import { setupTestProviderAndWallets } from '../src/test-utils';
-
 const FUEL_CORE_SCHEMA_FILE_PATH = 'packages/account/src/providers/fuel-core-schema.graphql';
 const FUEL_CORE_SCHEMA_SYNC_COMMAND = 'pnpm --filter @fuel-ts/account build:schema';
 
@@ -23,21 +21,6 @@ function generateChecksum(
  * @group node
  */
 describe('fuel-core-schema.graphql', () => {
-  let destroy: () => void;
-
-  beforeEach(async () => {
-    const { cleanup } = await setupTestProviderAndWallets({
-      nodeOptions: {
-        port: '4000',
-      },
-    });
-    destroy = cleanup;
-  });
-
-  afterEach(() => {
-    destroy();
-  });
-
   it('should not change on schema build', async () => {
     const preSyncChecksum = await readFile(FUEL_CORE_SCHEMA_FILE_PATH).then(generateChecksum);
 


### PR DESCRIPTION
<!-- LINEAR: closes TS-1 -->
<!-- LINEAR: relates to  -->
- Closes #2938 

# Summary

The `build:schema` script now starts and kills its own node, thereby not depending on a node running on port `4000`.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
