### PR TITLE
ci(release): `v0.94.8` @ `master`

### DIFF
--- a/.changeset/odd-starfishes-flash.md
+++ b/.changeset/odd-starfishes-flash.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": patch
----
-
-fix: reduce flakiness by favoring port `0` over `portfinder` dependency

--- a/.changeset/popular-bikes-allow.md
+++ b/.changeset/popular-bikes-allow.md
@@ -1,5 +1,0 @@
----
-"fuels": patch
----
-
-chore: regenerate proxy artifacts during release

--- a/.changeset/serious-crabs-begin.md
+++ b/.changeset/serious-crabs-begin.md
@@ -1,4 +1,0 @@
----
----
-
-chore: make `build:schema` script self-sufficient

--- a/.changeset/tame-moons-clean.md
+++ b/.changeset/tame-moons-clean.md
@@ -1,5 +1,0 @@
----
-"create-fuels": patch
----
-
-feat: `create fuels` template revamp

--- a/internal/benchmarks/CHANGELOG.md
+++ b/internal/benchmarks/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @internal/benchmarks
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies [ebd82b0]
+  - fuels@0.94.8
+
 ## 1.0.2
 
 ### Patch Changes

--- a/internal/benchmarks/package.json
+++ b/internal/benchmarks/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "fuels": "workspace:*"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/internal/check-imports/CHANGELOG.md
+++ b/internal/check-imports/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @internal/check-imports
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [f02fa88]
+- Updated dependencies [ebd82b0]
+  - @fuel-ts/account@0.94.8
+  - fuels@0.94.8
+  - @fuel-ts/contract@0.94.8
+  - @fuel-ts/program@0.94.8
+  - @fuel-ts/script@0.94.8
+  - @fuel-ts/abi-coder@0.94.8
+  - @fuel-ts/abi-typegen@0.94.8
+  - @fuel-ts/address@0.94.8
+  - @fuel-ts/crypto@0.94.8
+  - @fuel-ts/errors@0.94.8
+  - @fuel-ts/hasher@0.94.8
+  - @fuel-ts/interfaces@0.94.8
+  - @fuel-ts/math@0.94.8
+  - @fuel-ts/merkle@0.94.8
+  - @fuel-ts/transactions@0.94.8
+  - @fuel-ts/utils@0.94.8
+  - @fuel-ts/versions@0.94.8
+
 ## 0.0.9
 
 ### Patch Changes

--- a/internal/check-imports/package.json
+++ b/internal/check-imports/package.json
@@ -27,5 +27,5 @@
     "@fuel-ts/account": "workspace:*",
     "fuels": "workspace:*"
   },
-  "version": "0.0.9"
+  "version": "0.0.10"
 }

--- a/packages/abi-coder/CHANGELOG.md
+++ b/packages/abi-coder/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/crypto@0.94.8
+- @fuel-ts/errors@0.94.8
+- @fuel-ts/hasher@0.94.8
+- @fuel-ts/interfaces@0.94.8
+- @fuel-ts/math@0.94.8
+- @fuel-ts/utils@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/abi-coder/package.json
+++ b/packages/abi-coder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/abi-coder",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/abi-typegen/CHANGELOG.md
+++ b/packages/abi-typegen/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @fuel-ts/abi-typegen
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/errors@0.94.8
+- @fuel-ts/interfaces@0.94.8
+- @fuel-ts/utils@0.94.8
+- @fuel-ts/versions@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/abi-typegen/package.json
+++ b/packages/abi-typegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/abi-typegen",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "Generates Typescript definitions from Sway ABI Json files",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/account/CHANGELOG.md
+++ b/packages/account/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- f02fa88: fix: reduce flakiness by favoring port `0` over `portfinder` dependency
+  - @fuel-ts/abi-coder@0.94.8
+  - @fuel-ts/address@0.94.8
+  - @fuel-ts/crypto@0.94.8
+  - @fuel-ts/errors@0.94.8
+  - @fuel-ts/hasher@0.94.8
+  - @fuel-ts/interfaces@0.94.8
+  - @fuel-ts/math@0.94.8
+  - @fuel-ts/merkle@0.94.8
+  - @fuel-ts/transactions@0.94.8
+  - @fuel-ts/utils@0.94.8
+  - @fuel-ts/versions@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/account",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/address/CHANGELOG.md
+++ b/packages/address/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/crypto@0.94.8
+- @fuel-ts/errors@0.94.8
+- @fuel-ts/interfaces@0.94.8
+- @fuel-ts/utils@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/address",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "Utilities for encoding and decoding addresses",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/contract/CHANGELOG.md
+++ b/packages/contract/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- Updated dependencies [f02fa88]
+  - @fuel-ts/account@0.94.8
+  - @fuel-ts/program@0.94.8
+  - @fuel-ts/abi-coder@0.94.8
+  - @fuel-ts/crypto@0.94.8
+  - @fuel-ts/errors@0.94.8
+  - @fuel-ts/hasher@0.94.8
+  - @fuel-ts/interfaces@0.94.8
+  - @fuel-ts/math@0.94.8
+  - @fuel-ts/merkle@0.94.8
+  - @fuel-ts/transactions@0.94.8
+  - @fuel-ts/utils@0.94.8
+  - @fuel-ts/versions@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/contract",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/create-fuels/CHANGELOG.md
+++ b/packages/create-fuels/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-fuels
 
+## 0.94.8
+
+### Patch Changes
+
+- f7bacd1: feat: `create fuels` template revamp
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/create-fuels/package.json
+++ b/packages/create-fuels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-fuels",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/crypto/CHANGELOG.md
+++ b/packages/crypto/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/errors@0.94.8
+- @fuel-ts/interfaces@0.94.8
+- @fuel-ts/math@0.94.8
+- @fuel-ts/utils@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/crypto",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "Utilities for encrypting and decrypting data",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fuel-ts/errors
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/versions@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/errors",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "Error class and error codes that the fuels-ts library throws",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/fuels/CHANGELOG.md
+++ b/packages/fuels/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- ebd82b0: chore: regenerate proxy artifacts during release
+- Updated dependencies [f02fa88]
+  - @fuel-ts/account@0.94.8
+  - @fuel-ts/contract@0.94.8
+  - @fuel-ts/program@0.94.8
+  - @fuel-ts/script@0.94.8
+  - @fuel-ts/abi-coder@0.94.8
+  - @fuel-ts/abi-typegen@0.94.8
+  - @fuel-ts/address@0.94.8
+  - @fuel-ts/crypto@0.94.8
+  - @fuel-ts/errors@0.94.8
+  - @fuel-ts/hasher@0.94.8
+  - @fuel-ts/interfaces@0.94.8
+  - @fuel-ts/math@0.94.8
+  - @fuel-ts/merkle@0.94.8
+  - @fuel-ts/transactions@0.94.8
+  - @fuel-ts/utils@0.94.8
+  - @fuel-ts/versions@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuels",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "Fuel TS SDK",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/hasher/CHANGELOG.md
+++ b/packages/hasher/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/crypto@0.94.8
+- @fuel-ts/interfaces@0.94.8
+- @fuel-ts/utils@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/hasher",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "Sha256 hash utility for Fuel",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## 0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/interfaces",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @fuel-ts/logger
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/address@0.94.8
+- @fuel-ts/interfaces@0.94.8
+- @fuel-ts/math@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/logger",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "description": "A logger for the Fuel-TS ecosystem",
   "main": "dist/index.js",

--- a/packages/math/CHANGELOG.md
+++ b/packages/math/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/errors@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/math",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/merkle/CHANGELOG.md
+++ b/packages/merkle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/hasher@0.94.8
+- @fuel-ts/math@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/merkle/package.json
+++ b/packages/merkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/merkle",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/program/CHANGELOG.md
+++ b/packages/program/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- Updated dependencies [f02fa88]
+  - @fuel-ts/account@0.94.8
+  - @fuel-ts/abi-coder@0.94.8
+  - @fuel-ts/address@0.94.8
+  - @fuel-ts/errors@0.94.8
+  - @fuel-ts/interfaces@0.94.8
+  - @fuel-ts/math@0.94.8
+  - @fuel-ts/transactions@0.94.8
+  - @fuel-ts/utils@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/program/package.json
+++ b/packages/program/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/program",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/script/CHANGELOG.md
+++ b/packages/script/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- Updated dependencies [f02fa88]
+  - @fuel-ts/account@0.94.8
+  - @fuel-ts/program@0.94.8
+  - @fuel-ts/abi-coder@0.94.8
+  - @fuel-ts/address@0.94.8
+  - @fuel-ts/errors@0.94.8
+  - @fuel-ts/interfaces@0.94.8
+  - @fuel-ts/math@0.94.8
+  - @fuel-ts/transactions@0.94.8
+  - @fuel-ts/utils@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/script",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/transactions/CHANGELOG.md
+++ b/packages/transactions/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/abi-coder@0.94.8
+- @fuel-ts/address@0.94.8
+- @fuel-ts/errors@0.94.8
+- @fuel-ts/hasher@0.94.8
+- @fuel-ts/interfaces@0.94.8
+- @fuel-ts/math@0.94.8
+- @fuel-ts/utils@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/transactions",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @fuel-ts/utils
 
+## 0.94.8
+
+### Patch Changes
+
+- @fuel-ts/errors@0.94.8
+- @fuel-ts/interfaces@0.94.8
+- @fuel-ts/math@0.94.8
+- @fuel-ts/versions@0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/utils",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "Utilities (and test utilities) collection",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/versions/CHANGELOG.md
+++ b/packages/versions/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fuel-ts/versions
 
+## 0.94.8
+
 ## 0.94.7
 
 ### Patch Changes

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/versions",
-  "version": "0.94.7",
+  "version": "0.94.8",
   "description": "Validates supported versions of the Fuel toolchain",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/versions/src/lib/getBuiltinVersions.ts
+++ b/packages/versions/src/lib/getBuiltinVersions.ts
@@ -4,6 +4,6 @@ export function getBuiltinVersions(): Versions {
   return {
     FORC: '0.64.0',
     FUEL_CORE: '0.36.0',
-    FUELS: '0.94.7',
+    FUELS: '0.94.8',
   };
 }


### PR DESCRIPTION
# Summary

In this release, we:
- Updated the style and UX of the `create fuels` templates

# Features
- [#3125](https://github.com/FuelLabs/fuels-ts/pull/3125) - `create fuels` template revamp, by [@danielbate](https://github.com/danielbate)

# Fixes
- [#3219](https://github.com/FuelLabs/fuels-ts/pull/3219) - Reduce flakiness by favoring port `0` over `portfinder` dependency, by [@nedsalk](https://github.com/nedsalk)

# Chores
- [#3221](https://github.com/FuelLabs/fuels-ts/pull/3221) - Regenerate proxy artifacts during release, by [@arboleya](https://github.com/arboleya)