### PR TITLE
ci: re-introduce benchmarks on PRs

### DIFF
--- a/.changeset/angry-buses-jam.md
+++ b/.changeset/angry-buses-jam.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: re-introduce benchmarks on PRs

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,12 +5,11 @@ on:
   push:
     branches:
       - master
+      - next
 
 jobs:
   benchmarks:
     runs-on: ubuntu-latest
-    # remove if:false after fine-tuning benchmarks
-    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

Post-merge of https://github.com/FuelLabs/fuels-ts/pull/3166 we should get more reliable benchmark runs given we have more iterations to reduce variance. The PR re-enables the benchmarks so that we can track those runs against local nodes.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
