### PR TITLE
feat: add missing matcher

### DIFF
--- a/packages/abi/src/matchers/sway-type-matchers.test.ts
+++ b/packages/abi/src/matchers/sway-type-matchers.test.ts
@@ -245,4 +245,23 @@ describe('sway type matchers', () => {
     expect(matcher({ swayType })).toEqual(`${key}-matched`);
     verifyOtherMatchersDontMatch(key, swayType);
   });
+
+  test('str', () => {
+    const key = 'str';
+    const swayType = 'str';
+
+    expect(matcher({ swayType })).toEqual(`${key}-matched`);
+    verifyOtherMatchersDontMatch(key, swayType);
+  });
+
+  test('matcher without mapping for valid sway type throws', () => {
+    const swayType = 'str';
+
+    // @ts-expect-error intentionally missing key for valid swayType
+    const matcherWithoutMappings = createMatcher({});
+
+    expect(() => matcherWithoutMappings({ swayType })).toThrow(
+      `Matcher not found for sway type ${swayType}.`
+    );
+  });
 });

--- a/packages/abi/src/matchers/sway-type-matchers.test.ts
+++ b/packages/abi/src/matchers/sway-type-matchers.test.ts
@@ -26,6 +26,7 @@ const testMappings: Record<keyof typeof swayTypeMatchers, `${string}-matched`> =
   evmAddress: 'evmAddress-matched',
   rawUntypedPtr: 'rawUntypedPtr-matched',
   rawUntypedSlice: 'rawUntypedSlice-matched',
+  str: 'str-matched',
 };
 
 const matcher = createMatcher(testMappings);

--- a/packages/abi/src/matchers/sway-type-matchers.ts
+++ b/packages/abi/src/matchers/sway-type-matchers.ts
@@ -111,8 +111,8 @@ export function createMatcher<T>(mappings: Record<SwayType, T>) {
     for (const [key, matcher] of swayTypeMatcherEntries) {
       if (matcher(swayType)) {
         const mapping = mappings[key as SwayType];
-        if (mapping !== undefined) {
-          return mapping;
+        if (key in mappings) {
+          return mappings[key as SwayType];
         }
         break;
       }

--- a/packages/abi/src/matchers/sway-type-matchers.ts
+++ b/packages/abi/src/matchers/sway-type-matchers.ts
@@ -47,7 +47,7 @@ const str: Matcher = (type) => type === 'str';
 export const TUPLE_REGEX = /^\((?<items>.+)\)$/m;
 const tuple: Matcher = (type) => TUPLE_REGEX.test(type);
 
-export const ARRAY_REGEX = /\^[(?<item>[\w\s\\[\]]+);\s*(?<length>[0-9]+)\]/;
+export const ARRAY_REGEX = /^\[(?<item>[\w\s\\[\]]+);\s*(?<length>[0-9]+)\]/;
 const array: Matcher = (type) => ARRAY_REGEX.test(type);
 
 export const STRUCT_REGEX = /^struct (.+::)?(?<name>.+)$/m;
@@ -110,7 +110,6 @@ export function createMatcher<T>(mappings: Record<SwayType, T>) {
 
     for (const [key, matcher] of swayTypeMatcherEntries) {
       if (matcher(swayType)) {
-        const mapping = mappings[key as SwayType];
         if (key in mappings) {
           return mappings[key as SwayType];
         }

--- a/packages/abi/src/matchers/sway-type-matchers.ts
+++ b/packages/abi/src/matchers/sway-type-matchers.ts
@@ -47,7 +47,7 @@ const str: Matcher = (type) => type === 'str';
 export const TUPLE_REGEX = /^\((?<items>.+)\)$/m;
 const tuple: Matcher = (type) => TUPLE_REGEX.test(type);
 
-export const ARRAY_REGEX = /\[(?<item>[\w\s\\[\]]+);\s*(?<length>[0-9]+)\]/;
+export const ARRAY_REGEX = /\^[(?<item>[\w\s\\[\]]+);\s*(?<length>[0-9]+)\]/;
 const array: Matcher = (type) => ARRAY_REGEX.test(type);
 
 export const STRUCT_REGEX = /^struct (.+::)?(?<name>.+)$/m;

--- a/packages/abi/src/matchers/sway-type-matchers.ts
+++ b/packages/abi/src/matchers/sway-type-matchers.ts
@@ -22,7 +22,7 @@ export type SwayType =
   | 'array'
   | 'assetId'
   | 'evmAddress'
-  | 'rawUntypedPtr' // might not need it
+  | 'rawUntypedPtr'
   | 'rawUntypedSlice';
 
 type Matcher = (type: string) => boolean;


### PR DESCRIPTION
# Summary

- Adds missing `str` matcher to the sway type matchers.
- Enables `name` to be extracted from the `Struct` and `Enum` regex.
- Fixed issue whereby if a matcher was `undefined`, then it wouldn't be found.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
