### PR TITLE
chore: merge `chain` and `nodeInfo` queries into one

### DIFF
--- a/.changeset/filthy-bacteria-multiply.md
+++ b/.changeset/filthy-bacteria-multiply.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+chore: merge chain and nodeInfo query into one

--- a/.changeset/filthy-bacteria-multiply.md
+++ b/.changeset/filthy-bacteria-multiply.md
@@ -2,4 +2,4 @@
 "@fuel-ts/account": patch
 ---
 
-chore: merge chain and nodeInfo query into one
+chore: merge `chain` and `nodeInfo` queries into one

--- a/packages/account/src/providers/operations.graphql
+++ b/packages/account/src/providers/operations.graphql
@@ -623,6 +623,15 @@ query getChain {
   }
 }
 
+query getChainAndNodeInfo {
+  chain {
+    ...chainInfoFragment
+  }
+  nodeInfo {
+    ...nodeInfoFragment
+  }
+}
+
 query getTransaction($transactionId: TransactionId!) {
   transaction(id: $transactionId) {
     ...transactionFragment

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -612,13 +612,26 @@ export default class Provider {
    * @returns A promise that resolves to the Chain and NodeInfo.
    */
   async fetchChainAndNodeInfo() {
-    const nodeInfo = await this.fetchNode();
-    Provider.ensureClientVersionIsSupported(nodeInfo);
-    const chain = await this.fetchChain();
+    const { nodeInfo, chain } = await this.operations.getChainAndNodeInfo();
+
+    const processedNodeInfo: NodeInfo = {
+      maxDepth: bn(nodeInfo.maxDepth),
+      maxTx: bn(nodeInfo.maxTx),
+      nodeVersion: nodeInfo.nodeVersion,
+      utxoValidation: nodeInfo.utxoValidation,
+      vmBacktrace: nodeInfo.vmBacktrace,
+    };
+
+    Provider.ensureClientVersionIsSupported(processedNodeInfo);
+
+    const processedChain = processGqlChain(chain);
+
+    Provider.chainInfoCache[this.urlWithoutAuth] = processedChain;
+    Provider.nodeInfoCache[this.urlWithoutAuth] = processedNodeInfo;
 
     return {
-      chain,
-      nodeInfo,
+      chain: processedChain,
+      nodeInfo: processedNodeInfo,
     };
   }
 


### PR DESCRIPTION
<!-- LINEAR: closes  -->
<!-- LINEAR: relates to TS-686 -->
- Part of #3281 

# Summary

This PR adds a new `getChainAndNodeInfo` query which returns the `chain` and `nodeInfo` data in one request, as opposed to the way we've been doing up until now where we've been sending them separately.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
