### PR TITLE
chore: optimize `block` gql queries

### DIFF
--- a/.changeset/lovely-stingrays-walk.md
+++ b/.changeset/lovely-stingrays-walk.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/account": patch
+"fuels": patch
+---
+
+chore: optimize `block` gql queries

--- a/packages/account/src/providers/operations.graphql
+++ b/packages/account/src/providers/operations.graphql
@@ -734,7 +734,22 @@ query getBlocks($after: String, $before: String, $first: Int, $last: Int) {
     }
     edges {
       node {
-        ...blockFragment
+        id
+        height
+        header {
+          time
+          applicationHash
+          daHeight
+          eventInboxRoot
+          messageOutboxRoot
+          prevRoot
+          stateTransitionBytecodeVersion
+          transactionsCount
+          transactionsRoot
+        }
+        transactions {
+          id
+        }
       }
     }
   }

--- a/packages/account/src/providers/operations.graphql
+++ b/packages/account/src/providers/operations.graphql
@@ -686,7 +686,22 @@ query estimatePredicates($encodedTransaction: HexString!) {
 
 query getBlock($blockId: BlockId, $height: U32) {
   block(id: $blockId, height: $height) {
-    ...blockFragment
+    height
+    id
+    transactions {
+      id
+    }
+    header {
+      time
+      applicationHash
+      daHeight
+      eventInboxRoot
+      messageOutboxRoot
+      prevRoot
+      stateTransitionBytecodeVersion
+      transactionsCount
+      transactionsRoot
+    }
   }
 }
 

--- a/packages/account/src/providers/operations.graphql
+++ b/packages/account/src/providers/operations.graphql
@@ -707,9 +707,22 @@ query getBlock($blockId: BlockId, $height: U32) {
 
 query getBlockWithTransactions($blockId: BlockId, $blockHeight: U32) {
   block(id: $blockId, height: $blockHeight) {
-    ...blockFragment
+    id
+    height
+    header {
+      time
+      applicationHash
+      daHeight
+      eventInboxRoot
+      messageOutboxRoot
+      prevRoot
+      stateTransitionBytecodeVersion
+      transactionsCount
+      transactionsRoot
+    }
     transactions {
-      ...transactionFragment
+      id
+      rawPayload
     }
   }
 }


### PR DESCRIPTION
- Closes #3290 

# Release notes

In this release, we:

- Optimized `block`-related GraphQL queries

# Summary

This PR updates the GQL schemas so that we only request the data that we are using in the methods to eventually return to the user.

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
