### PR TITLE
chore!: optimize balance queries

### DIFF
--- a/.changeset/tame-gorillas-shave.md
+++ b/.changeset/tame-gorillas-shave.md
@@ -1,5 +1,5 @@
 ---
-"@fuel-ts/account": patch
+"@fuel-ts/account": minor
 ---
 
 chore!: optimize balance queries

--- a/.changeset/tame-gorillas-shave.md
+++ b/.changeset/tame-gorillas-shave.md
@@ -2,4 +2,4 @@
 "@fuel-ts/account": patch
 ---
 
-feat!: optimise balance queries
+chore!: optimise balance queries

--- a/.changeset/tame-gorillas-shave.md
+++ b/.changeset/tame-gorillas-shave.md
@@ -2,4 +2,4 @@
 "@fuel-ts/account": patch
 ---
 
-chore!: optimise balance queries
+chore!: optimize balance queries

--- a/.changeset/tame-gorillas-shave.md
+++ b/.changeset/tame-gorillas-shave.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+feat!: optimise balance queries

--- a/packages/account/src/providers/operations.graphql
+++ b/packages/account/src/providers/operations.graphql
@@ -312,12 +312,6 @@ fragment messageProofFragment on MessageProof {
   data
 }
 
-fragment balanceFragment on Balance {
-  owner
-  amount
-  assetId
-}
-
 fragment TxParametersFragment on TxParameters {
   version
   maxInputs
@@ -773,7 +767,7 @@ query getContractBalance($contract: ContractId!, $asset: AssetId!) {
 
 query getBalance($owner: Address!, $assetId: AssetId!) {
   balance(owner: $owner, assetId: $assetId) {
-    ...balanceFragment
+    amount
   }
 }
 
@@ -808,7 +802,8 @@ query getBalances(
     }
     edges {
       node {
-        ...balanceFragment
+        assetId
+        amount
       }
     }
   }


### PR DESCRIPTION
<!-- LINEAR: closes TS-694 -->
<!-- LINEAR: relates to  -->
- Closes #3293

# Release notes

In this release, we:

- Optimised the provider balance queries

# Breaking Changes

- Removed the `owner` and `assetId` properties from the response of `Provider.operations.getBalance()`. These properties are also required arguments to execute the function so are redundant in the response. Should you require these values, you should take them from the values that you passed to the function.
- Removed the `owner` property from the response of `Provider.operations.getBalances()`. This property is a required argument to execute the function so is redundant in the response. Should you require this value, you should take it from the value that you passed to the function.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
