### PR TITLE
feat: add pagination limit to `getTransactions`

### DIFF
--- a/.changeset/thick-rocks-hammer.md
+++ b/.changeset/thick-rocks-hammer.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+feat: add pagination limit to `getTransactions`

--- a/apps/docs-snippets/src/guide/provider/querying-the-chain.test.ts
+++ b/apps/docs-snippets/src/guide/provider/querying-the-chain.test.ts
@@ -289,4 +289,28 @@ describe('querying the chain', () => {
     expect(messageProof?.amount.toNumber()).toEqual(100);
     expect(messageProof?.sender.toHexString()).toEqual(result.id);
   });
+
+  it('get transactions', async () => {
+    using launched = await launchTestNode();
+    const {
+      provider: testProvider,
+      wallets: [wallet, receiver],
+    } = launched;
+
+    const tx = await wallet.transfer(receiver.address, 100);
+    await tx.waitForResult();
+    const FUEL_NETWORK_URL = testProvider.url;
+
+    // #region get-transactions
+    // #import { Provider };
+
+    const provider = await Provider.create(FUEL_NETWORK_URL);
+
+    const { transactions } = await provider.getTransactions();
+    // #endregion get-transactions
+
+    expect(transactions).toBeDefined();
+    expect(transactions.length).toBe(2);
+    // Includes base asset minting tx
+  });
 });

--- a/apps/docs/src/guide/provider/querying-the-chain.md
+++ b/apps/docs/src/guide/provider/querying-the-chain.md
@@ -74,3 +74,9 @@ You can retrieve a message proof by either using it's block ID:
 Or by it's block height:
 
 <<< @/../../docs-snippets/src/guide/provider/querying-the-chain.test.ts#Message-getMessageProof-blockHeight{ts:line-numbers}
+
+## `getTransactions`
+
+You can use the `getTransactions` method to retrieve a list of transactions from the blockchain. This is limited to 30 transactions per page.
+
+<<< @/../../docs-snippets/src/guide/provider/querying-the-chain.test.ts#get-transactions{ts:line-numbers}

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -66,6 +66,7 @@ import { handleGqlErrorMessage } from './utils/handle-gql-error-message';
 const MAX_RETRIES = 10;
 
 export const RESOURCES_PAGE_SIZE_LIMIT = 512;
+export const TRANSACTIONS_PAGE_SIZE_LIMIT = 30;
 export const BLOCKS_PAGE_SIZE_LIMIT = 5;
 export const DEFAULT_RESOURCE_CACHE_TTL = 20_000; // 20 seconds
 
@@ -1627,7 +1628,12 @@ Supported fuel-core version: ${supportedVersion}.`
   async getTransactions(paginationArgs?: CursorPaginationArgs): Promise<GetTransactionsResponse> {
     const {
       transactions: { edges, pageInfo },
-    } = await this.operations.getTransactions(paginationArgs);
+    } = await this.operations.getTransactions({
+      ...this.validatePaginationArgs({
+        inputArgs: paginationArgs,
+        paginationLimit: TRANSACTIONS_PAGE_SIZE_LIMIT,
+      }),
+    });
 
     const coder = new TransactionCoder();
     const transactions = edges


### PR DESCRIPTION
<!-- LINEAR: closes TS-676 -->
<!-- LINEAR: relates to  -->
- Closes #3245 

# Release notes

In this release, we:

- Added a limit of 30 transactions to the `provider.getTransactions()` method.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
