### PR TITLE
feat: bump transaction pagination limit to 60

### DIFF
--- a/.changeset/fluffy-pears-search.md
+++ b/.changeset/fluffy-pears-search.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+feat: bump transaction pagination limit to 60

--- a/packages/account/src/providers/provider.test.ts
+++ b/packages/account/src/providers/provider.test.ts
@@ -1986,21 +1986,21 @@ Supported fuel-core version: ${mock.supportedVersion}.`
       using launched = await setupTestProviderAndWallets();
       const { provider } = launched;
 
-      await provider.produceBlocks(50);
+      await provider.produceBlocks(70);
 
       await expectToThrowFuelError(
-        () => provider.getTransactions({ first: 40 }),
+        () => provider.getTransactions({ first: 80 }),
         new FuelError(
           ErrorCode.INVALID_INPUT_PARAMETERS,
-          'Pagination limit for this query cannot exceed 30 items'
+          'Pagination limit for this query cannot exceed 60 items'
         )
       );
 
       let { transactions, pageInfo } = await provider.getTransactions({
-        first: 30,
+        first: 60,
       });
 
-      expect(transactions.length).toBe(30);
+      expect(transactions.length).toBe(60);
       expect(pageInfo.hasNextPage).toBeTruthy();
       expect(pageInfo.hasPreviousPage).toBeFalsy();
       expect(pageInfo.startCursor).toBeDefined();
@@ -2010,7 +2010,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
         after: pageInfo.endCursor,
       }));
 
-      expect(transactions.length).toBe(20);
+      expect(transactions.length).toBe(10);
       expect(pageInfo.hasNextPage).toBeFalsy();
       expect(pageInfo.hasPreviousPage).toBeTruthy();
       expect(pageInfo.startCursor).toBeDefined();
@@ -2018,10 +2018,10 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
       ({ transactions, pageInfo } = await provider.getTransactions({
         before: pageInfo.startCursor,
-        last: 20,
+        last: 10,
       }));
 
-      expect(transactions.length).toBe(20);
+      expect(transactions.length).toBe(10);
       expect(pageInfo.hasNextPage).toBeTruthy();
       expect(pageInfo.hasPreviousPage).toBeTruthy();
       expect(pageInfo.startCursor).toBeDefined();

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -66,7 +66,7 @@ import { handleGqlErrorMessage } from './utils/handle-gql-error-message';
 const MAX_RETRIES = 10;
 
 export const RESOURCES_PAGE_SIZE_LIMIT = 512;
-export const TRANSACTIONS_PAGE_SIZE_LIMIT = 30;
+export const TRANSACTIONS_PAGE_SIZE_LIMIT = 60;
 export const BLOCKS_PAGE_SIZE_LIMIT = 5;
 export const DEFAULT_RESOURCE_CACHE_TTL = 20_000; // 20 seconds
 


### PR DESCRIPTION
# Summary

Bumps the transaction pagination limit. I should've used this value in #3304.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
