### PR TITLE
feat: add checksum utils for address

### DIFF
--- a/.changeset/hip-files-protect.md
+++ b/.changeset/hip-files-protect.md
@@ -3,4 +3,4 @@
 "@fuel-ts/address": patch
 ---
 
-Add checksum address
+feat: add checksum utils for address

--- a/.changeset/hip-files-protect.md
+++ b/.changeset/hip-files-protect.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/interfaces": patch
+"@fuel-ts/address": patch
+---
+
+Add checksum address

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    # if: false
+    if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    if: false
+    # if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/packages/address/src/address.test.ts
+++ b/packages/address/src/address.test.ts
@@ -390,8 +390,12 @@ describe('Address class', () => {
   test('validate checksum address for invalid types', () => {
     const address = Address.fromRandom();
     expect(Address.isChecksumValid(address.toB256())).toBeFalsy();
-    expect(Address.isChecksumValid('0x9cFB2Cad509d417eC40B70eBe1DD72a3624d46fDD1EA5420DbD755Ce7f4dc897')).toBeFalsy();
-    expect(Address.isChecksumValid('9cFB2Cad509d417eC40B70eBe1DD72a3624d46fDD1EA5420DbD755Ce7f4dc897')).toBeFalsy();
+    expect(
+      Address.isChecksumValid('0x9cFB2Cad509d417eC40B70eBe1DD72a3624d46fDD1EA5420DbD755Ce7f4dc897')
+    ).toBeFalsy();
+    expect(
+      Address.isChecksumValid('9cFB2Cad509d417eC40B70eBe1DD72a3624d46fDD1EA5420DbD755Ce7f4dc897')
+    ).toBeFalsy();
     expect(Address.isChecksumValid('9cFB2Cad509d417eC40B70eBe1DD72')).toBeFalsy();
   });
 });

--- a/packages/address/src/address.test.ts
+++ b/packages/address/src/address.test.ts
@@ -377,4 +377,21 @@ describe('Address class', () => {
     );
     await expectToThrowFuelError(() => Address.fromEvmAddress(address), expectedError);
   });
+
+  test('validate checksum address', () => {
+    const address = Address.fromRandom();
+    const addressMock = '0x9cFB2Cad509d417eC40B70eBe1DD72a3624d46fDD1EA5420DbD755Ce7f4dC897';
+    expect(Address.isChecksumValid(address.toChecksum())).toBeTruthy();
+    expect(Address.fromB256(addressMock).toChecksum()).toBe(addressMock);
+    expect(Address.isChecksumValid(addressMock)).toBeTruthy();
+    expect(Address.isChecksumValid(addressMock.slice(2))).toBeTruthy();
+  });
+
+  test('validate checksum address for invalid types', () => {
+    const address = Address.fromRandom();
+    expect(Address.isChecksumValid(address.toB256())).toBeFalsy();
+    expect(Address.isChecksumValid('0x9cFB2Cad509d417eC40B70eBe1DD72a3624d46fDD1EA5420DbD755Ce7f4dc897')).toBeFalsy();
+    expect(Address.isChecksumValid('9cFB2Cad509d417eC40B70eBe1DD72a3624d46fDD1EA5420DbD755Ce7f4dc897')).toBeFalsy();
+    expect(Address.isChecksumValid('9cFB2Cad509d417eC40B70eBe1DD72')).toBeFalsy();
+  });
 });

--- a/packages/address/src/address.ts
+++ b/packages/address/src/address.ts
@@ -1,6 +1,12 @@
 import { FuelError } from '@fuel-ts/errors';
 import { AbstractAddress } from '@fuel-ts/interfaces';
-import type { Bech32Address, B256Address, EvmAddress, AssetId, ChecksumAddress } from '@fuel-ts/interfaces';
+import type {
+  Bech32Address,
+  B256Address,
+  EvmAddress,
+  AssetId,
+  ChecksumAddress,
+} from '@fuel-ts/interfaces';
 import { arrayify, hexlify } from '@fuel-ts/utils';
 import { sha256 } from '@noble/hashes/sha256';
 
@@ -49,7 +55,7 @@ export default class Address extends AbstractAddress {
    * @returns A new `ChecksumAddress` instance
    */
   toChecksum(): ChecksumAddress {
-    return Address.toChecksum(this.toB256())
+    return Address.toChecksum(this.toB256());
   }
 
   /**
@@ -272,7 +278,7 @@ export default class Address extends AbstractAddress {
     let addressParsed = address;
 
     if (!address.startsWith('0x')) {
-      addressParsed = `0x${address}`
+      addressParsed = `0x${address}`;
     }
     if (addressParsed.trim().length !== 66) {
       return false;
@@ -286,13 +292,13 @@ export default class Address extends AbstractAddress {
     const addressHex = hexlify(address).toLowerCase().slice(2);
     const checksum = sha256(address);
 
-    let ret = '0x'
+    let ret = '0x';
     for (let i = 0; i < 32; ++i) {
-      const byte = checksum[i]
-      const ha = addressHex.charAt(i * 2)
-      const hb = addressHex.charAt(i * 2 + 1)
-      ret += (byte & 0xf0) >= 0x80 ? ha.toUpperCase() : ha
-      ret += (byte & 0x0f) >= 0x08 ? hb.toUpperCase() : hb
+      const byte = checksum[i];
+      const ha = addressHex.charAt(i * 2);
+      const hb = addressHex.charAt(i * 2 + 1);
+      ret += (byte & 0xf0) >= 0x80 ? ha.toUpperCase() : ha;
+      ret += (byte & 0x0f) >= 0x08 ? hb.toUpperCase() : hb;
     }
 
     return ret;

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -12,6 +12,8 @@ export type Bech32Address = `fuel${string}`;
 // #endregion bech32-1
 export type B256Address = string;
 
+export type ChecksumAddress = string;
+
 export type B256AddressEvm = `0x000000000000000000000000${string}`;
 
 export type Bytes = Uint8Array | number[];


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

# Release notes

<!--
Use this only if this PR requires a mention in the Release
Notes Summary. Valuable features and critical fixes are good
examples. For everything else, please delete the whole section.
-->

In this release, we:

- We add a checksum utils to the Address class that provides the ability to encode an address into a valid checksum HEX address and add a verification function to validate the encoded checksum HEX address.

```ts
import { Address } from 'fuels';

const address = Address.fromRandom();
const checksumAddress = address.toChecksum();

console.log(Address.isChecksumValid(address));
```

# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

# Breaking Changes

<!--
If the PR has breaking changes, please detail them in this section
and remove this comment.

Remove this section if there are no breaking changes.
-->

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
