### PR TITLE
chore!: made Address `toString` and `valueOf` returns checksum

### DIFF
--- a/.changeset/good-pants-chew.md
+++ b/.changeset/good-pants-chew.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/address": minor
+---
+
+chore!: made Address `toString` and `valueOf` returns checksum

--- a/apps/docs-snippets/src/guide/types/address.test.ts
+++ b/apps/docs-snippets/src/guide/types/address.test.ts
@@ -9,10 +9,11 @@ describe('Address Types', () => {
   it('should successfully create new address from bech32 string', () => {
     // #region address-2
     const ADDRESS_BECH32 = 'fuel1elnmzsav56dqnp95sx4e2pckq36cvae9ser44m5zlvgtwxw49fmqd7e42e';
+    const ADDRESS_CHECKSUM = '0xcfE7B143aCa69A0984b481aB950716047586772586475aee82fB10B719D52A76';
 
     const address = new Address(ADDRESS_BECH32);
 
-    expect(address.toString()).toEqual(ADDRESS_BECH32);
+    expect(address.toString()).toEqual(ADDRESS_CHECKSUM);
     expect(address.bech32Address).toEqual(ADDRESS_BECH32);
     // #endregion address-2
   });

--- a/packages/address/src/address.test.ts
+++ b/packages/address/src/address.test.ts
@@ -13,6 +13,7 @@ const ADDRESS_B256_EVM_PADDED: B256AddressEvm =
 const ADDRESS_EVM = '0x07a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a';
 const ADDRESS_BECH32: Bech32Address =
   'fuel1a7r2l2tfdncdccu9utzq0fhptxs3q080kl32up3klvea8je2ne9qrqnt6n';
+const ADDRESS_CHECKSUM = '0xEf86aFa9696Cf0dc6385e2C407A6e159A1103cEfB7E2Ae0636FB33d3cb2A9E4A';
 const ADDRESS_WORDS = [
   29, 30, 3, 10, 31, 10, 11, 9, 13, 19, 24, 13, 24, 24, 28, 5, 28, 11, 2, 0, 15, 9, 23, 1, 11, 6,
   16, 17, 0, 15, 7, 15, 22, 31, 17, 10, 28, 1, 17, 22, 31, 12, 25, 29, 7, 18, 25, 10, 19, 25, 5, 0,
@@ -239,8 +240,8 @@ describe('Address class', () => {
     const result = new Address(ADDRESS_BECH32.toUpperCase() as Bech32Address);
 
     expect(result.toAddress()).toEqual(ADDRESS_BECH32);
-    expect(result.toString()).toEqual(ADDRESS_BECH32);
-    expect(`cast as string${result}`).toEqual(`cast as string${ADDRESS_BECH32}`);
+    expect(result.toString()).toEqual(ADDRESS_CHECKSUM);
+    expect(`cast as string${result}`).toEqual(`cast as string${ADDRESS_CHECKSUM}`);
     expect(result.toB256()).toEqual(ADDRESS_B256);
     expect(result.toBytes()).toEqual(new Uint8Array(ADDRESS_BYTES));
   });

--- a/packages/address/src/address.ts
+++ b/packages/address/src/address.ts
@@ -95,12 +95,12 @@ export default class Address extends AbstractAddress {
   }
 
   /**
-   * Converts and returns the `bech32Address` property as a string
+   * returns the address `checksum` as a string
    *
    * @returns The `bech32Address` property as a string
    */
   toString(): string {
-    return this.bech32Address;
+    return this.toChecksum();
   }
 
   /**
@@ -137,12 +137,12 @@ export default class Address extends AbstractAddress {
   }
 
   /**
-   * Returns the value of the `bech32Address` property
+   * returns the address `checksum` as a string
    *
    * @returns The value of `bech32Address` property
    */
   valueOf(): string {
-    return this.bech32Address;
+    return this.toChecksum();
   }
 
   /**


### PR DESCRIPTION
# Release notes

In this release, we:

- Made `Address.toString` and `Address.valueOf` returns the Address checksum


# Breaking Changes

The return of both `Address.toString()` and `Address.valueOf` was modified to return the address checksum instead of the Bech32 string

```ts
// before
const address = new Address('fuel1elnmzsav56dqnp95sx4e2pckq36cvae9ser44m5zlvgtwxw49fmqd7e42e');

address.toString()
// fuel1elnmzsav56dqnp95sx4e2pckq36cvae9ser44m5zlvgtwxw49fmqd7e42e

address.valueOf()
// fuel1elnmzsav56dqnp95sx4e2pckq36cvae9ser44m5zlvgtwxw49fmqd7e42e
```

```ts
// after
const address = new Address('fuel1elnmzsav56dqnp95sx4e2pckq36cvae9ser44m5zlvgtwxw49fmqd7e42e');

address.toString()
// 0xEf86aFa9696Cf0dc6385e2C407A6e159A1103cEfB7E2Ae0636FB33d3cb2A9E4A

address.valueOf()
// 0xEf86aFa9696Cf0dc6385e2C407A6e159A1103cEfB7E2Ae0636FB33d3cb2A9E4A
```

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
