### PR TITLE
fix!: checksum method to remove `0x` before hashing

### DIFF
--- a/.changeset/pink-walls-greet.md
+++ b/.changeset/pink-walls-greet.md
@@ -1,6 +1,5 @@
 ---
-"@fuel-ts/address": patch
-"fuels": patch
+"@fuel-ts/address": minor
 ---
 
 fix!: checksum method to remove `0x` before hashing

--- a/.changeset/pink-walls-greet.md
+++ b/.changeset/pink-walls-greet.md
@@ -3,4 +3,4 @@
 "fuels": patch
 ---
 
-Fix checksum to not consider 0x before sha256
+fix!: checksum method to remove `0x` before hashing

--- a/.changeset/pink-walls-greet.md
+++ b/.changeset/pink-walls-greet.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/address": patch
+"fuels": patch
+---
+
+Fix checksum to not consider 0x before sha256

--- a/apps/docs-snippets/src/guide/types/address.test.ts
+++ b/apps/docs-snippets/src/guide/types/address.test.ts
@@ -9,7 +9,7 @@ describe('Address Types', () => {
   it('should successfully create new address from bech32 string', () => {
     // #region address-2
     const ADDRESS_BECH32 = 'fuel1elnmzsav56dqnp95sx4e2pckq36cvae9ser44m5zlvgtwxw49fmqd7e42e';
-    const ADDRESS_CHECKSUM = '0xcfE7B143aCa69A0984b481aB950716047586772586475aee82fB10B719D52A76';
+    const ADDRESS_CHECKSUM = '0xcfe7b143Aca69a0984b481ab950716047586772586475AEE82fb10B719d52A76';
 
     const address = new Address(ADDRESS_BECH32);
 

--- a/packages/address/src/address.test.ts
+++ b/packages/address/src/address.test.ts
@@ -13,7 +13,7 @@ const ADDRESS_B256_EVM_PADDED: B256AddressEvm =
 const ADDRESS_EVM = '0x07a6e159a1103cefb7e2ae0636fb33d3cb2a9e4a';
 const ADDRESS_BECH32: Bech32Address =
   'fuel1a7r2l2tfdncdccu9utzq0fhptxs3q080kl32up3klvea8je2ne9qrqnt6n';
-const ADDRESS_CHECKSUM = '0xEf86aFa9696Cf0dc6385e2C407A6e159A1103cEfB7E2Ae0636FB33d3cb2A9E4A';
+const ADDRESS_CHECKSUM = '0xEf86Afa9696cF0Dc6385E2c407a6E159A1103CEfb7e2Ae0636fb33D3cb2A9e4a';
 const ADDRESS_WORDS = [
   29, 30, 3, 10, 31, 10, 11, 9, 13, 19, 24, 13, 24, 24, 28, 5, 28, 11, 2, 0, 15, 9, 23, 1, 11, 6,
   16, 17, 0, 15, 7, 15, 22, 31, 17, 10, 28, 1, 17, 22, 31, 12, 25, 29, 7, 18, 25, 10, 19, 25, 5, 0,
@@ -381,7 +381,7 @@ describe('Address class', () => {
 
   test('validate checksum address', () => {
     const address = Address.fromRandom();
-    const addressMock = '0x9cFB2Cad509d417eC40B70eBe1DD72a3624d46fDD1EA5420DbD755Ce7f4dC897';
+    const addressMock = '0x9cfB2CAd509D417ec40b70ebE1DD72a3624D46fdD1Ea5420dBD755CE7f4Dc897';
     expect(Address.isChecksumValid(address.toChecksum())).toBeTruthy();
     expect(Address.fromB256(addressMock).toChecksum()).toBe(addressMock);
     expect(Address.isChecksumValid(addressMock)).toBeTruthy();
@@ -392,7 +392,7 @@ describe('Address class', () => {
     const address = Address.fromRandom();
     expect(Address.isChecksumValid(address.toB256())).toBeFalsy();
     expect(
-      Address.isChecksumValid('0x9cFB2Cad509d417eC40B70eBe1DD72a3624d46fDD1EA5420DbD755Ce7f4dc897')
+      Address.isChecksumValid('0x9cfB2CAd509D417ec40b70ebE1DD72a3624D46fdD1Ea5420dBD755CE7f4dc897')
     ).toBeFalsy();
     expect(
       Address.isChecksumValid('9cFB2Cad509d417eC40B70eBe1DD72a3624d46fDD1EA5420DbD755Ce7f4dc897')

--- a/packages/address/src/address.ts
+++ b/packages/address/src/address.ts
@@ -292,6 +292,7 @@ export default class Address extends AbstractAddress {
     if (!isB256(address)) {
       throw new Error('Invalid B256 Address');
     }
+
     const addressHex = hexlify(address).toLowerCase().slice(2);
     const checksum = sha256(addressHex);
 

--- a/packages/address/src/address.ts
+++ b/packages/address/src/address.ts
@@ -289,8 +289,11 @@ export default class Address extends AbstractAddress {
 
   /** @hidden */
   private static toChecksum(address: string) {
+    if (!isB256(address)) {
+      throw new Error('Invalid B256 Address');
+    }
     const addressHex = hexlify(address).toLowerCase().slice(2);
-    const checksum = sha256(address);
+    const checksum = sha256(addressHex);
 
     let ret = '0x';
     for (let i = 0; i < 32; ++i) {


### PR DESCRIPTION
# Release notes
In this release, we:

- Fixed checksum utility to correctly remove `0x` before hashing

# Breaking Changes

We fixed the checksum utilities:
 - `Address.toChecksum()`
 - `Address.isChecksumValid()`

Now, we correctly remove the leading `0x` before hashing the address.

Because of this, previous values were invalid, and the update is required.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
