### PR TITLE
ci(release): `v0.96.0` @ `master`

### DIFF
--- a/.changeset/pink-walls-greet.md
+++ b/.changeset/pink-walls-greet.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/address": minor
----
-
-fix!: checksum method to remove `0x` before hashing

--- a/internal/benchmarks/CHANGELOG.md
+++ b/internal/benchmarks/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @internal/benchmarks
 
+## 1.0.6
+
+### Patch Changes
+
+- fuels@0.96.0
+
 ## 1.0.5
 
 ### Patch Changes

--- a/internal/benchmarks/package.json
+++ b/internal/benchmarks/package.json
@@ -14,5 +14,5 @@
     "fuels": "workspace:*",
     "@internal/utils": "workspace:*"
   },
-  "version": "1.0.5"
+  "version": "1.0.6"
 }

--- a/internal/check-imports/CHANGELOG.md
+++ b/internal/check-imports/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @internal/check-imports
 
+## 0.0.13
+
+### Patch Changes
+
+- Updated dependencies [5bf6621]
+  - @fuel-ts/address@0.96.0
+  - @fuel-ts/account@0.96.0
+  - fuels@0.96.0
+  - @fuel-ts/program@0.96.0
+  - @fuel-ts/script@0.96.0
+  - @fuel-ts/transactions@0.96.0
+  - @fuel-ts/contract@0.96.0
+  - @fuel-ts/abi-coder@0.96.0
+  - @fuel-ts/abi-typegen@0.96.0
+  - @fuel-ts/crypto@0.96.0
+  - @fuel-ts/errors@0.96.0
+  - @fuel-ts/hasher@0.96.0
+  - @fuel-ts/interfaces@0.96.0
+  - @fuel-ts/math@0.96.0
+  - @fuel-ts/merkle@0.96.0
+  - @fuel-ts/utils@0.96.0
+  - @fuel-ts/versions@0.96.0
+
 ## 0.0.12
 
 ### Patch Changes

--- a/internal/check-imports/package.json
+++ b/internal/check-imports/package.json
@@ -27,5 +27,5 @@
     "@fuel-ts/account": "workspace:*",
     "fuels": "workspace:*"
   },
-  "version": "0.0.12"
+  "version": "0.0.13"
 }

--- a/packages/abi-coder/CHANGELOG.md
+++ b/packages/abi-coder/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- @fuel-ts/crypto@0.96.0
+- @fuel-ts/errors@0.96.0
+- @fuel-ts/hasher@0.96.0
+- @fuel-ts/interfaces@0.96.0
+- @fuel-ts/math@0.96.0
+- @fuel-ts/utils@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/abi-coder/package.json
+++ b/packages/abi-coder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/abi-coder",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/abi-typegen/CHANGELOG.md
+++ b/packages/abi-typegen/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @fuel-ts/abi-typegen
 
+## 0.96.0
+
+### Patch Changes
+
+- @fuel-ts/errors@0.96.0
+- @fuel-ts/interfaces@0.96.0
+- @fuel-ts/utils@0.96.0
+- @fuel-ts/versions@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/abi-typegen/package.json
+++ b/packages/abi-typegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/abi-typegen",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Generates Typescript definitions from Sway ABI Json files",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/account/CHANGELOG.md
+++ b/packages/account/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- Updated dependencies [5bf6621]
+  - @fuel-ts/address@0.96.0
+  - @fuel-ts/transactions@0.96.0
+  - @fuel-ts/abi-coder@0.96.0
+  - @fuel-ts/crypto@0.96.0
+  - @fuel-ts/errors@0.96.0
+  - @fuel-ts/hasher@0.96.0
+  - @fuel-ts/interfaces@0.96.0
+  - @fuel-ts/math@0.96.0
+  - @fuel-ts/merkle@0.96.0
+  - @fuel-ts/utils@0.96.0
+  - @fuel-ts/versions@0.96.0
+
 ## 0.95.0
 
 ### Minor Changes

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/account",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/address/CHANGELOG.md
+++ b/packages/address/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 0.96.0
+
+### Minor Changes
+
+- 5bf6621: fix!: checksum method to remove `0x` before hashing
+
+### Patch Changes
+
+- @fuel-ts/crypto@0.96.0
+- @fuel-ts/errors@0.96.0
+- @fuel-ts/interfaces@0.96.0
+- @fuel-ts/utils@0.96.0
+
 ## 0.95.0
 
 ### Minor Changes

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/address",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Utilities for encoding and decoding addresses",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/contract/CHANGELOG.md
+++ b/packages/contract/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- @fuel-ts/account@0.96.0
+- @fuel-ts/program@0.96.0
+- @fuel-ts/transactions@0.96.0
+- @fuel-ts/abi-coder@0.96.0
+- @fuel-ts/crypto@0.96.0
+- @fuel-ts/errors@0.96.0
+- @fuel-ts/hasher@0.96.0
+- @fuel-ts/interfaces@0.96.0
+- @fuel-ts/math@0.96.0
+- @fuel-ts/merkle@0.96.0
+- @fuel-ts/utils@0.96.0
+- @fuel-ts/versions@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/contract",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/create-fuels/CHANGELOG.md
+++ b/packages/create-fuels/CHANGELOG.md
@@ -1,5 +1,7 @@
 # create-fuels
 
+## 0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/create-fuels/package.json
+++ b/packages/create-fuels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-fuels",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/crypto/CHANGELOG.md
+++ b/packages/crypto/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- @fuel-ts/errors@0.96.0
+- @fuel-ts/interfaces@0.96.0
+- @fuel-ts/math@0.96.0
+- @fuel-ts/utils@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/crypto",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Utilities for encrypting and decrypting data",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fuel-ts/errors
 
+## 0.96.0
+
+### Patch Changes
+
+- @fuel-ts/versions@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/errors",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Error class and error codes that the fuels-ts library throws",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/fuels/CHANGELOG.md
+++ b/packages/fuels/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- Updated dependencies [5bf6621]
+  - @fuel-ts/address@0.96.0
+  - @fuel-ts/account@0.96.0
+  - @fuel-ts/program@0.96.0
+  - @fuel-ts/script@0.96.0
+  - @fuel-ts/transactions@0.96.0
+  - @fuel-ts/contract@0.96.0
+  - @fuel-ts/abi-coder@0.96.0
+  - @fuel-ts/abi-typegen@0.96.0
+  - @fuel-ts/crypto@0.96.0
+  - @fuel-ts/errors@0.96.0
+  - @fuel-ts/hasher@0.96.0
+  - @fuel-ts/interfaces@0.96.0
+  - @fuel-ts/math@0.96.0
+  - @fuel-ts/merkle@0.96.0
+  - @fuel-ts/utils@0.96.0
+  - @fuel-ts/versions@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuels",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Fuel TS SDK",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/fuels/src/cli/commands/deploy/proxy/types/Src14OwnedProxy.ts
+++ b/packages/fuels/src/cli/commands/deploy/proxy/types/Src14OwnedProxy.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
 /*
-  Fuels version: 0.94.9
+  Fuels version: 0.95.0
 */
 
 import { Contract, Interface } from "../../../../..";

--- a/packages/fuels/src/cli/commands/deploy/proxy/types/Src14OwnedProxyFactory.ts
+++ b/packages/fuels/src/cli/commands/deploy/proxy/types/Src14OwnedProxyFactory.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
 /*
-  Fuels version: 0.94.9
+  Fuels version: 0.95.0
 */
 
 import { Contract, ContractFactory, decompressBytecode } from "../../../../..";

--- a/packages/fuels/src/cli/commands/deploy/proxy/types/common.d.ts
+++ b/packages/fuels/src/cli/commands/deploy/proxy/types/common.d.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
 /*
-  Fuels version: 0.94.9
+  Fuels version: 0.95.0
 */
 
 /**

--- a/packages/fuels/src/cli/commands/deploy/proxy/types/index.ts
+++ b/packages/fuels/src/cli/commands/deploy/proxy/types/index.ts
@@ -5,7 +5,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
 /*
-  Fuels version: 0.94.9
+  Fuels version: 0.95.0
 */
 
 export { Src14OwnedProxy } from './Src14OwnedProxy';

--- a/packages/hasher/CHANGELOG.md
+++ b/packages/hasher/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- @fuel-ts/crypto@0.96.0
+- @fuel-ts/interfaces@0.96.0
+- @fuel-ts/utils@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/hasher",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Sha256 hash utility for Fuel",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## 0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/interfaces",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @fuel-ts/logger
 
+## 0.96.0
+
+### Patch Changes
+
+- Updated dependencies [5bf6621]
+  - @fuel-ts/address@0.96.0
+  - @fuel-ts/interfaces@0.96.0
+  - @fuel-ts/math@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/logger",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "description": "A logger for the Fuel-TS ecosystem",
   "main": "dist/index.js",

--- a/packages/math/CHANGELOG.md
+++ b/packages/math/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- @fuel-ts/errors@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/math",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/merkle/CHANGELOG.md
+++ b/packages/merkle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- @fuel-ts/hasher@0.96.0
+- @fuel-ts/math@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/merkle/package.json
+++ b/packages/merkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/merkle",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/program/CHANGELOG.md
+++ b/packages/program/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- Updated dependencies [5bf6621]
+  - @fuel-ts/address@0.96.0
+  - @fuel-ts/account@0.96.0
+  - @fuel-ts/transactions@0.96.0
+  - @fuel-ts/abi-coder@0.96.0
+  - @fuel-ts/errors@0.96.0
+  - @fuel-ts/interfaces@0.96.0
+  - @fuel-ts/math@0.96.0
+  - @fuel-ts/utils@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/program/package.json
+++ b/packages/program/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/program",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/script/CHANGELOG.md
+++ b/packages/script/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- Updated dependencies [5bf6621]
+  - @fuel-ts/address@0.96.0
+  - @fuel-ts/account@0.96.0
+  - @fuel-ts/program@0.96.0
+  - @fuel-ts/transactions@0.96.0
+  - @fuel-ts/abi-coder@0.96.0
+  - @fuel-ts/errors@0.96.0
+  - @fuel-ts/interfaces@0.96.0
+  - @fuel-ts/math@0.96.0
+  - @fuel-ts/utils@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/script",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/transactions/CHANGELOG.md
+++ b/packages/transactions/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## 0.96.0
+
+### Patch Changes
+
+- Updated dependencies [5bf6621]
+  - @fuel-ts/address@0.96.0
+  - @fuel-ts/abi-coder@0.96.0
+  - @fuel-ts/errors@0.96.0
+  - @fuel-ts/hasher@0.96.0
+  - @fuel-ts/interfaces@0.96.0
+  - @fuel-ts/math@0.96.0
+  - @fuel-ts/utils@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/transactions",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @fuel-ts/utils
 
+## 0.96.0
+
+### Patch Changes
+
+- @fuel-ts/errors@0.96.0
+- @fuel-ts/interfaces@0.96.0
+- @fuel-ts/math@0.96.0
+- @fuel-ts/versions@0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/utils",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Utilities (and test utilities) collection",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/versions/CHANGELOG.md
+++ b/packages/versions/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fuel-ts/versions
 
+## 0.96.0
+
 ## 0.95.0
 
 ### Patch Changes

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/versions",
-  "version": "0.95.0",
+  "version": "0.96.0",
   "description": "Validates supported versions of the Fuel toolchain",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/versions/src/lib/getBuiltinVersions.ts
+++ b/packages/versions/src/lib/getBuiltinVersions.ts
@@ -4,6 +4,6 @@ export function getBuiltinVersions(): Versions {
   return {
     FORC: '0.65.2',
     FUEL_CORE: '0.38.0',
-    FUELS: '0.95.0',
+    FUELS: '0.96.0',
   };
 }


### PR DESCRIPTION
# Summary

In this release, we:
- Fixed checksum utility to correctly remove `0x` before hashing

# Breaking

- Fixes
    - [#3313](https://github.com/FuelLabs/fuels-ts/pull/3313) - Checksum method to remove `0x` before hashing, by [@luizstacio](https://github.com/luizstacio)

---

# Migration Notes

## Fixes
### [#3313 - Checksum method to remove `0x` before hashing](https://github.com/FuelLabs/fuels-ts/pull/3313)

  We fixed the checksum utilities:
 - `Address.toChecksum()`
 - `Address.isChecksumValid()`

Now, we correctly remove the leading `0x` before hashing the address.

Because of this, previous values were invalid, and the update is required.