### PR TITLE
fix: `parseUnits` bug with 0 units

### DIFF
--- a/.changeset/tidy-scissors-sip.md
+++ b/.changeset/tidy-scissors-sip.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/math": patch
+---
+
+fix: `parseUnits` bug with 0 units

--- a/packages/math/src/bn.test.ts
+++ b/packages/math/src/bn.test.ts
@@ -475,6 +475,7 @@ describe('Math - BN', () => {
     expect(bn.parseUnits('100,100,100.00002', 5).toHex()).toEqual(bn('10010010000002').toHex());
     expect(bn.parseUnits('.').toHex()).toEqual(bn('0').toHex());
     expect(bn.parseUnits('.', 5).toHex()).toEqual(bn('0').toHex());
+    expect(bn.parseUnits('1', 0).toHex()).toEqual(bn('1').toHex());
 
     expect(() => {
       bn.parseUnits('100,100.000002', 5);

--- a/packages/math/src/bn.test.ts
+++ b/packages/math/src/bn.test.ts
@@ -476,6 +476,9 @@ describe('Math - BN', () => {
     expect(bn.parseUnits('.').toHex()).toEqual(bn('0').toHex());
     expect(bn.parseUnits('.', 5).toHex()).toEqual(bn('0').toHex());
     expect(bn.parseUnits('1', 0).toHex()).toEqual(bn('1').toHex());
+    expect(bn.parseUnits('0.000000001', 0).toHex()).toEqual(bn('0').toHex());
+    expect(bn.parseUnits('100.00002', 0).toHex()).toEqual(bn('100').toHex());
+    expect(bn.parseUnits('100,100.00002', 0).toHex()).toEqual(bn('100100').toHex());
 
     expect(() => {
       bn.parseUnits('100,100.000002', 5);

--- a/packages/math/src/bn.ts
+++ b/packages/math/src/bn.ts
@@ -322,6 +322,11 @@ bn.parseUnits = (value: string, units: number = DEFAULT_DECIMAL_UNITS): BN => {
   const [valueUnits = '0', valueDecimals = '0'] = valueToParse.split('.');
   const length = valueDecimals.length;
 
+  if (units === 0) {
+    const valueWithoutDecimals = valueToParse.replace(',', '').split('.')[0];
+    return bn(valueWithoutDecimals);
+  }
+
   if (length > units) {
     throw new FuelError(
       ErrorCode.CONVERTING_FAILED,


### PR DESCRIPTION
<!-- LINEAR: closes TS-699 -->
<!-- LINEAR: relates to  -->
- Closes #3316

# Release notes

In this release, we:

- Fixed a bug where `bn.parseUnits` wouldn't work as expected with `units = 0`

# Summary

This PR fixes a bug in `bn.parseUnits`, as a follow-up of #3300.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
