### PR TITLE
chore: use `FuelError` instead of JS `Error`

### DIFF
--- a/.changeset/ten-dryers-search.md
+++ b/.changeset/ten-dryers-search.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/address": patch
+---
+
+chore: use `FuelError` instead of JS `Error`

--- a/packages/address/src/address.ts
+++ b/packages/address/src/address.ts
@@ -290,7 +290,10 @@ export default class Address extends AbstractAddress {
   /** @hidden */
   private static toChecksum(address: string) {
     if (!isB256(address)) {
-      throw new Error('Invalid B256 Address');
+      throw new FuelError(
+        FuelError.CODES.INVALID_B256_ADDRESS,
+        `Invalid B256 Address: ${address}.`
+      );
     }
 
     const addressHex = hexlify(address).toLowerCase().slice(2);


### PR DESCRIPTION
# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
