### PR TITLE
feat: cache latest fuels version

### DIFF
--- a/.changeset/kind-chairs-move.md
+++ b/.changeset/kind-chairs-move.md
@@ -1,0 +1,5 @@
+---
+"fuels": patch
+---
+
+feat: cache latest `fuels` version

--- a/packages/fuels/src/cli.test.ts
+++ b/packages/fuels/src/cli.test.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 
 import * as cliMod from './cli';
 import { Commands } from './cli/types';
+import * as checkForUpdatesMod from './cli/utils/checkForAndDisplayUpdates';
 import * as loggingMod from './cli/utils/logger';
 import { run } from './run';
 
@@ -77,6 +78,9 @@ describe('cli.js', () => {
       .mockReturnValue(Promise.resolve(command));
 
     const configureCli = vi.spyOn(cliMod, 'configureCli').mockImplementation(() => new Command());
+    vi.spyOn(checkForUpdatesMod, 'checkForAndDisplayUpdates').mockImplementation(() =>
+      Promise.resolve()
+    );
 
     await run([]);
 

--- a/packages/fuels/src/cli.test.ts
+++ b/packages/fuels/src/cli.test.ts
@@ -1,8 +1,9 @@
 import { Command } from 'commander';
 
+import { mockCheckForUpdates } from '../test/utils/mockCheckForUpdates';
+
 import * as cliMod from './cli';
 import { Commands } from './cli/types';
-import * as checkForUpdatesMod from './cli/utils/checkForAndDisplayUpdates';
 import * as loggingMod from './cli/utils/logger';
 import { run } from './run';
 
@@ -78,9 +79,7 @@ describe('cli.js', () => {
       .mockReturnValue(Promise.resolve(command));
 
     const configureCli = vi.spyOn(cliMod, 'configureCli').mockImplementation(() => new Command());
-    vi.spyOn(checkForUpdatesMod, 'checkForAndDisplayUpdates').mockImplementation(() =>
-      Promise.resolve()
-    );
+    mockCheckForUpdates();
 
     await run([]);
 

--- a/packages/fuels/src/cli/config/loadConfig.test.ts
+++ b/packages/fuels/src/cli/config/loadConfig.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
+import { mockCheckForUpdates } from '../../../test/utils/mockCheckForUpdates';
 import {
   runInit,
   bootstrapProject,
@@ -18,6 +19,10 @@ import { loadConfig } from './loadConfig';
  */
 describe('loadConfig', () => {
   const paths = bootstrapProject(__filename);
+
+  beforeEach(() => {
+    mockCheckForUpdates();
+  });
 
   afterEach(() => {
     resetConfigAndMocks(paths.fuelsConfigPath);

--- a/packages/fuels/src/cli/utils/checkForAndDisplayUpdates.test.ts
+++ b/packages/fuels/src/cli/utils/checkForAndDisplayUpdates.test.ts
@@ -1,6 +1,7 @@
 import * as versionsMod from '@fuel-ts/versions';
 
 import * as checkForAndDisplayUpdatesMod from './checkForAndDisplayUpdates';
+import * as getLatestFuelsVersionMod from './getLatestFuelsVersion';
 import * as loggerMod from './logger';
 
 /**
@@ -17,7 +18,7 @@ describe('checkForAndDisplayUpdates', () => {
 
   const mockDeps = (params: { latestVersion: string; userVersion: string }) => {
     const { latestVersion, userVersion } = params;
-    vi.spyOn(Promise, 'race').mockReturnValue(Promise.resolve(latestVersion));
+    vi.spyOn(getLatestFuelsVersionMod, 'getLatestFuelsVersion').mockResolvedValue(latestVersion);
 
     vi.spyOn(versionsMod, 'versions', 'get').mockReturnValue({
       FUELS: userVersion,

--- a/packages/fuels/src/cli/utils/checkForAndDisplayUpdates.ts
+++ b/packages/fuels/src/cli/utils/checkForAndDisplayUpdates.ts
@@ -1,23 +1,13 @@
 import { versions, gt, eq } from '@fuel-ts/versions';
 
+import { getLatestFuelsVersion } from './getLatestFuelsVersion';
 import { warn, log } from './logger';
-
-export const getLatestFuelsVersion = async () => {
-  const response = await fetch('https://registry.npmjs.org/fuels/latest');
-  const data = await response.json();
-  return data.version as string;
-};
 
 export const checkForAndDisplayUpdates = async () => {
   try {
     const { FUELS: userFuelsVersion } = versions;
 
-    const latestFuelsVersion = await Promise.race<string | undefined>([
-      new Promise((resolve) => {
-        setTimeout(resolve, 3000);
-      }),
-      getLatestFuelsVersion(),
-    ]);
+    const latestFuelsVersion = await getLatestFuelsVersion();
 
     if (!latestFuelsVersion) {
       log(`\n Unable to fetch latest fuels version. Skipping...\n`);

--- a/packages/fuels/src/cli/utils/fuelsVersionCache.ts
+++ b/packages/fuels/src/cli/utils/fuelsVersionCache.ts
@@ -12,12 +12,19 @@ export const saveToCache = (cache: FuelsVersionCache) => {
 export const FUELS_VERSION_CACHE_TTL = 6 * 60 * 60 * 1000; // 6 hours in milliseconds
 
 export const checkAndLoadCache = (): FuelsVersionCache | null => {
-  if (fs.existsSync(FUELS_VERSION_CACHE_FILE)) {
+  const doesVersionCacheExist = fs.existsSync(FUELS_VERSION_CACHE_FILE);
+
+  if (doesVersionCacheExist) {
     const cachedVersion = fs.readFileSync(FUELS_VERSION_CACHE_FILE, 'utf-8');
-    const { mtimeMs: cacheTimestamp } = fs.statSync(FUELS_VERSION_CACHE_FILE);
-    if (cachedVersion && Date.now() - cacheTimestamp < FUELS_VERSION_CACHE_TTL) {
-      return cachedVersion;
+    if (!cachedVersion) {
+      return null;
     }
+
+    const { mtimeMs: cacheTimestamp } = fs.statSync(FUELS_VERSION_CACHE_FILE);
+    const hasCacheExpired = Date.now() - cacheTimestamp < FUELS_VERSION_CACHE_TTL;
+
+    return hasCacheExpired ? null : cachedVersion;
   }
+
   return null;
 };

--- a/packages/fuels/src/cli/utils/fuelsVersionCache.ts
+++ b/packages/fuels/src/cli/utils/fuelsVersionCache.ts
@@ -4,7 +4,7 @@ import path from 'path';
 export const FUELS_VERSION_CACHE_FILE = path.join(__dirname, '.fuels-cache.json');
 
 export type FuelsVersionCache = {
-  data: { version: string } | null;
+  version: string;
   timestamp: number;
 };
 

--- a/packages/fuels/src/cli/utils/fuelsVersionCache.ts
+++ b/packages/fuels/src/cli/utils/fuelsVersionCache.ts
@@ -1,28 +1,22 @@
 import fs from 'fs';
 import path from 'path';
 
-export const FUELS_VERSION_CACHE_FILE = path.join(__dirname, '.fuels-cache.json');
+export const FUELS_VERSION_CACHE_FILE = path.join(__dirname, 'FUELS_VERSION');
 
-export type FuelsVersionCache = {
-  version: string;
-  timestamp: number;
-};
+export type FuelsVersionCache = string;
 
 export const saveToCache = (cache: FuelsVersionCache) => {
-  fs.writeFileSync(FUELS_VERSION_CACHE_FILE, JSON.stringify(cache), 'utf-8');
+  fs.writeFileSync(FUELS_VERSION_CACHE_FILE, cache, 'utf-8');
 };
 
 export const FUELS_VERSION_CACHE_TTL = 6 * 60 * 60 * 1000; // 6 hours in milliseconds
 
 export const checkAndLoadCache = (): FuelsVersionCache | null => {
   if (fs.existsSync(FUELS_VERSION_CACHE_FILE)) {
-    const savedCache = JSON.parse(fs.readFileSync(FUELS_VERSION_CACHE_FILE, 'utf-8'));
-    if (
-      savedCache &&
-      savedCache.data &&
-      Date.now() - savedCache.timestamp < FUELS_VERSION_CACHE_TTL
-    ) {
-      return savedCache.data.version;
+    const cachedVersion = fs.readFileSync(FUELS_VERSION_CACHE_FILE, 'utf-8');
+    const { mtimeMs: cacheTimestamp } = fs.statSync(FUELS_VERSION_CACHE_FILE);
+    if (cachedVersion && Date.now() - cacheTimestamp < FUELS_VERSION_CACHE_TTL) {
+      return cachedVersion;
     }
   }
   return null;

--- a/packages/fuels/src/cli/utils/fuelsVersionCache.ts
+++ b/packages/fuels/src/cli/utils/fuelsVersionCache.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+
+export const FUELS_VERSION_CACHE_FILE = path.join(__dirname, '.fuels-cache.json');
+
+export type FuelsVersionCache = {
+  data: { version: string } | null;
+  timestamp: number;
+};
+
+export const saveToCache = (cache: FuelsVersionCache) => {
+  fs.writeFileSync(FUELS_VERSION_CACHE_FILE, JSON.stringify(cache), 'utf-8');
+};
+
+export const FUELS_VERSION_CACHE_TTL = 6 * 60 * 60 * 1000; // 6 hours in milliseconds
+
+export const checkAndLoadCache = (): FuelsVersionCache | null => {
+  if (fs.existsSync(FUELS_VERSION_CACHE_FILE)) {
+    const savedCache = JSON.parse(fs.readFileSync(FUELS_VERSION_CACHE_FILE, 'utf-8'));
+    if (
+      savedCache &&
+      savedCache.data &&
+      Date.now() - savedCache.timestamp < FUELS_VERSION_CACHE_TTL
+    ) {
+      return savedCache.data.version;
+    }
+  }
+  return null;
+};

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
@@ -34,7 +34,7 @@ describe('getLatestFuelsVersion', () => {
     expect(result).toEqual('1.0.0');
   });
 
-  it('should fetch if there is no cache, and save to cache', async () => {
+  it('should fetch if there is no cache or the cache is expired', async () => {
     const mockResponse = new Response(JSON.stringify({ version: '1.0.0' }));
     const fetchSpy = vi.spyOn(global, 'fetch').mockReturnValue(Promise.resolve(mockResponse));
     const saveCacheSpy = vi.spyOn(cacheMod, 'saveToCache').mockImplementation(() => {});
@@ -48,20 +48,5 @@ describe('getLatestFuelsVersion', () => {
       },
       timestamp: expect.any(Number),
     });
-  });
-
-  it('should refetch if the cache is expired', async () => {
-    const cache = {
-      data: {
-        version: '0.0.0',
-      },
-      timestamp: Date.now() - cacheMod.FUELS_VERSION_CACHE_TTL - 1000,
-    };
-    vi.spyOn(cacheMod, 'checkAndLoadCache').mockReturnValue(cache);
-    const mockResponse = new Response(JSON.stringify({ version: '1.0.0' }));
-    const fetchSpy = vi.spyOn(global, 'fetch').mockReturnValue(Promise.resolve(mockResponse));
-    const version = await getLatestFuelsVersion();
-    expect(fetchSpy).toHaveBeenCalled();
-    expect(version).toEqual('1.0.0');
   });
 });

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
@@ -24,9 +24,7 @@ describe('getLatestFuelsVersion', () => {
 
   it('should return cached version if it exists', async () => {
     const cache = {
-      data: {
-        version: '1.0.0',
-      },
+      version: '1.0.0',
       timestamp: Date.now(),
     };
     vi.spyOn(cacheMod, 'checkAndLoadCache').mockReturnValue(cache);
@@ -43,9 +41,7 @@ describe('getLatestFuelsVersion', () => {
     expect(fetchSpy).toHaveBeenCalled();
     expect(version).toEqual('1.0.0');
     expect(saveCacheSpy).toHaveBeenCalledWith({
-      data: {
-        version: '1.0.0',
-      },
+      version: '1.0.0',
       timestamp: expect.any(Number),
     });
   });

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
@@ -1,0 +1,64 @@
+import * as cacheMod from './fuelsVersionCache';
+import { getLatestFuelsVersion } from './getLatestFuelsVersion';
+
+describe('getLatestFuelsVersion', () => {
+  it('should fail if fetch fails', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.reject(new Error('Failed to fetch'))
+    );
+    await expect(getLatestFuelsVersion()).rejects.toThrowError('Failed to fetch');
+  });
+
+  it('should throw if fetch times out', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(resolve, 5000);
+        })
+    );
+    await expect(getLatestFuelsVersion()).rejects.toThrow();
+  });
+
+  it('should return cached version if it exists', async () => {
+    const cache = {
+      data: {
+        version: '1.0.0',
+      },
+      timestamp: Date.now(),
+    };
+    vi.spyOn(cacheMod, 'checkAndLoadCache').mockReturnValue(cache);
+    const result = await getLatestFuelsVersion();
+    expect(result).toEqual('1.0.0');
+  });
+
+  it('should fetch if there is no cache, and save to cache', async () => {
+    const mockResponse = new Response(JSON.stringify({ version: '1.0.0' }));
+    const fetchSpy = vi.spyOn(global, 'fetch').mockReturnValue(Promise.resolve(mockResponse));
+    const saveCacheSpy = vi.spyOn(cacheMod, 'saveToCache').mockImplementation(() => {});
+    vi.spyOn(cacheMod, 'checkAndLoadCache').mockReturnValue(null);
+    const version = await getLatestFuelsVersion();
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(version).toEqual('1.0.0');
+    expect(saveCacheSpy).toHaveBeenCalledWith({
+      data: {
+        version: '1.0.0',
+      },
+      timestamp: expect.any(Number),
+    });
+  });
+
+  it('should refetch if the cache is expired', async () => {
+    const cache = {
+      data: {
+        version: '0.0.0',
+      },
+      timestamp: Date.now() - cacheMod.FUELS_VERSION_CACHE_TTL - 1000,
+    };
+    vi.spyOn(cacheMod, 'checkAndLoadCache').mockReturnValue(cache);
+    const mockResponse = new Response(JSON.stringify({ version: '1.0.0' }));
+    const fetchSpy = vi.spyOn(global, 'fetch').mockReturnValue(Promise.resolve(mockResponse));
+    const version = await getLatestFuelsVersion();
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(version).toEqual('1.0.0');
+  });
+});

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
@@ -5,6 +5,14 @@ import { getLatestFuelsVersion } from './getLatestFuelsVersion';
  * @group node
  */
 describe('getLatestFuelsVersion', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should fail if fetch fails', async () => {
     vi.spyOn(global, 'fetch').mockImplementation(() =>
       Promise.reject(new Error('Failed to fetch'))

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
@@ -23,11 +23,8 @@ describe('getLatestFuelsVersion', () => {
   });
 
   it('should return cached version if it exists', async () => {
-    const cache = {
-      version: '1.0.0',
-      timestamp: Date.now(),
-    };
-    vi.spyOn(cacheMod, 'checkAndLoadCache').mockReturnValue(cache);
+    const cachedVersion = '1.0.0';
+    vi.spyOn(cacheMod, 'checkAndLoadCache').mockReturnValue(cachedVersion);
     const result = await getLatestFuelsVersion();
     expect(result).toEqual('1.0.0');
   });
@@ -40,9 +37,6 @@ describe('getLatestFuelsVersion', () => {
     const version = await getLatestFuelsVersion();
     expect(fetchSpy).toHaveBeenCalled();
     expect(version).toEqual('1.0.0');
-    expect(saveCacheSpy).toHaveBeenCalledWith({
-      version: '1.0.0',
-      timestamp: expect.any(Number),
-    });
+    expect(saveCacheSpy).toHaveBeenCalledWith('1.0.0');
   });
 });

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.test.ts
@@ -1,6 +1,9 @@
 import * as cacheMod from './fuelsVersionCache';
 import { getLatestFuelsVersion } from './getLatestFuelsVersion';
 
+/**
+ * @group node
+ */
 describe('getLatestFuelsVersion', () => {
   it('should fail if fetch fails', async () => {
     vi.spyOn(global, 'fetch').mockImplementation(() =>

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.ts
@@ -4,7 +4,7 @@ export const getLatestFuelsVersion = async (): Promise<string | undefined> => {
   const now = Date.now();
 
   const cache = checkAndLoadCache();
-  if (cache !== null && cache.data !== null && now - cache.timestamp < FUELS_VERSION_CACHE_TTL) {
+  if (cache !== null) {
     return cache.data.version;
   }
 

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.ts
@@ -1,0 +1,32 @@
+import { checkAndLoadCache, FUELS_VERSION_CACHE_TTL, saveToCache } from './fuelsVersionCache';
+
+export const getLatestFuelsVersion = async (): Promise<string | undefined> => {
+  const now = Date.now();
+
+  const cache = checkAndLoadCache();
+  if (cache !== null && cache.data !== null && now - cache.timestamp < FUELS_VERSION_CACHE_TTL) {
+    return cache.data.version;
+  }
+
+  const data: { version: string } | null = await Promise.race([
+    new Promise((resolve) => {
+      setTimeout(() => resolve(null), 3000);
+    }),
+    fetch('https://registry.npmjs.org/fuels/latest').then((response) => response.json()),
+  ]);
+
+  if (!data) {
+    throw new Error('Failed to fetch latest fuels version.');
+  }
+
+  const version = data.version as string;
+
+  saveToCache({
+    data: {
+      version,
+    },
+    timestamp: now,
+  });
+
+  return version;
+};

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.ts
@@ -4,8 +4,8 @@ export const getLatestFuelsVersion = async (): Promise<string | undefined> => {
   const now = Date.now();
 
   const cache = checkAndLoadCache();
-  if (cache && cache.data) {
-    return cache.data.version;
+  if (cache) {
+    return cache.version;
   }
 
   const data: { version: string } | null = await Promise.race([
@@ -22,9 +22,7 @@ export const getLatestFuelsVersion = async (): Promise<string | undefined> => {
   const version = data.version as string;
 
   saveToCache({
-    data: {
-      version,
-    },
+    version,
     timestamp: now,
   });
 

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.ts
@@ -1,10 +1,10 @@
-import { checkAndLoadCache, FUELS_VERSION_CACHE_TTL, saveToCache } from './fuelsVersionCache';
+import { checkAndLoadCache, saveToCache } from './fuelsVersionCache';
 
 export const getLatestFuelsVersion = async (): Promise<string | undefined> => {
   const now = Date.now();
 
   const cache = checkAndLoadCache();
-  if (cache !== null) {
+  if (cache && cache.data) {
     return cache.data.version;
   }
 

--- a/packages/fuels/src/cli/utils/getLatestFuelsVersion.ts
+++ b/packages/fuels/src/cli/utils/getLatestFuelsVersion.ts
@@ -1,11 +1,9 @@
 import { checkAndLoadCache, saveToCache } from './fuelsVersionCache';
 
 export const getLatestFuelsVersion = async (): Promise<string | undefined> => {
-  const now = Date.now();
-
-  const cache = checkAndLoadCache();
-  if (cache) {
-    return cache.version;
+  const cachedVersion = checkAndLoadCache();
+  if (cachedVersion) {
+    return cachedVersion;
   }
 
   const data: { version: string } | null = await Promise.race([
@@ -21,10 +19,7 @@ export const getLatestFuelsVersion = async (): Promise<string | undefined> => {
 
   const version = data.version as string;
 
-  saveToCache({
-    version,
-    timestamp: now,
-  });
+  saveToCache(version);
 
   return version;
 };

--- a/packages/fuels/src/run.ts
+++ b/packages/fuels/src/run.ts
@@ -3,6 +3,7 @@ import { checkForAndDisplayUpdates } from './cli/utils/checkForAndDisplayUpdates
 import { error } from './cli/utils/logger';
 
 export const run = async (argv: string[]) => {
+  await checkForAndDisplayUpdates().catch(error);
   const program = configureCli();
-  return Promise.all([await checkForAndDisplayUpdates().catch(error), program.parseAsync(argv)]);
+  return program.parseAsync(argv);
 };

--- a/packages/fuels/test/features/build.test.ts
+++ b/packages/fuels/test/features/build.test.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 
 import * as deployMod from '../../src/cli/commands/deploy/index';
 import { mockStartFuelCore } from '../utils/mockAutoStartFuelCore';
+import { mockCheckForUpdates } from '../utils/mockCheckForUpdates';
 import {
   bootstrapProject,
   resetConfigAndMocks,
@@ -16,6 +17,10 @@ import {
  */
 describe('build', { timeout: 180000 }, () => {
   const paths = bootstrapProject(__filename);
+
+  beforeEach(() => {
+    mockCheckForUpdates();
+  });
 
   afterEach(() => {
     resetConfigAndMocks(paths.fuelsConfigPath);

--- a/packages/fuels/test/features/deploy.test.ts
+++ b/packages/fuels/test/features/deploy.test.ts
@@ -23,9 +23,6 @@ describe('deploy', { timeout: 180000 }, () => {
 
   beforeEach(() => {
     mockCheckForUpdates();
-  });
-
-  afterAll(() => {
     resetConfigAndMocks(paths.fuelsConfigPath);
     resetDiskAndMocks(paths.root);
     paths = bootstrapProject(__filename);

--- a/packages/fuels/test/features/deploy.test.ts
+++ b/packages/fuels/test/features/deploy.test.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 import { launchTestNode } from '../../src/test-utils';
+import { mockCheckForUpdates } from '../utils/mockCheckForUpdates';
 import { resetDiskAndMocks } from '../utils/resetDiskAndMocks';
 import {
   bootstrapProject,
@@ -21,6 +22,10 @@ describe('deploy', { timeout: 180000 }, () => {
   let paths = bootstrapProject(__filename);
 
   beforeEach(() => {
+    mockCheckForUpdates();
+  });
+
+  afterAll(() => {
     resetConfigAndMocks(paths.fuelsConfigPath);
     resetDiskAndMocks(paths.root);
     paths = bootstrapProject(__filename);

--- a/packages/fuels/test/features/deploy.test.ts
+++ b/packages/fuels/test/features/deploy.test.ts
@@ -22,10 +22,10 @@ describe('deploy', { timeout: 180000 }, () => {
   let paths = bootstrapProject(__filename);
 
   beforeEach(() => {
-    mockCheckForUpdates();
     resetConfigAndMocks(paths.fuelsConfigPath);
     resetDiskAndMocks(paths.root);
     paths = bootstrapProject(__filename);
+    mockCheckForUpdates();
   });
 
   afterEach(() => {

--- a/packages/fuels/test/features/dev.test.ts
+++ b/packages/fuels/test/features/dev.test.ts
@@ -3,6 +3,7 @@ import * as chokidar from 'chokidar';
 import * as buildMod from '../../src/cli/commands/build/index';
 import * as deployMod from '../../src/cli/commands/deploy/index';
 import { mockStartFuelCore } from '../utils/mockAutoStartFuelCore';
+import { mockCheckForUpdates } from '../utils/mockCheckForUpdates';
 import { mockLogger } from '../utils/mockLogger';
 import { resetDiskAndMocks } from '../utils/resetDiskAndMocks';
 import { runInit, runDev, bootstrapProject, resetConfigAndMocks } from '../utils/runCommands';
@@ -20,6 +21,10 @@ vi.mock('chokidar', async () => {
  */
 describe('dev', () => {
   const paths = bootstrapProject(__filename);
+
+  beforeEach(() => {
+    mockCheckForUpdates();
+  });
 
   afterEach(() => {
     resetConfigAndMocks(paths.fuelsConfigPath);

--- a/packages/fuels/test/features/init.test.ts
+++ b/packages/fuels/test/features/init.test.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { existsSync, readFileSync } from 'fs';
 
 import { Commands } from '../../src';
+import { mockCheckForUpdates } from '../utils/mockCheckForUpdates';
 import { mockLogger } from '../utils/mockLogger';
 import {
   bootstrapProject,
@@ -19,6 +20,7 @@ describe('init', () => {
 
   beforeEach(() => {
     mockLogger();
+    mockCheckForUpdates();
   });
 
   afterEach(() => {

--- a/packages/fuels/test/utils/mockCheckForUpdates.ts
+++ b/packages/fuels/test/utils/mockCheckForUpdates.ts
@@ -1,0 +1,7 @@
+import * as checkForUpdatesMod from '../../src/cli/utils/checkForAndDisplayUpdates';
+
+export const mockCheckForUpdates = () => {
+  vi.spyOn(checkForUpdatesMod, 'checkForAndDisplayUpdates').mockImplementation(() =>
+    Promise.resolve()
+  );
+};


### PR DESCRIPTION
> Closes TS-654

- Closes #3177

# Summary

This PR adds a basic local cache for the latest `fuels` version fetched by the `fuels` CLI.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
