### PR TITLE
chore(): added method to duplicate predicate

### DIFF
--- a/packages/account/src/predicate/predicate.ts
+++ b/packages/account/src/predicate/predicate.ts
@@ -96,6 +96,26 @@ export class Predicate<
   }
 
   /**
+   * Creates a new Predicate instance with updated parameters while maintaining the original bytecode and ABI
+   *
+   * @param params - Object containing optional new configurableConstants and data
+   * @returns A new Predicate instance with the updated parameters
+   */
+  toNewInstance(params: {
+    configurableConstants?: TConfigurables;
+    data?: TData;
+  }): Predicate<TData, TConfigurables> {
+    return new Predicate({
+      bytecode: this.bytes,
+      abi: this.interface?.jsonAbi,
+      provider: this.provider,
+      data: params.data ?? this.predicateData,
+      configurableConstants: params.configurableConstants,
+      loaderBytecode: this.loaderBytecode,
+    });
+  }
+
+  /**
    * Populates the transaction data with predicate data.
    *
    * @param transactionRequestLike - The transaction request-like object.

--- a/packages/account/test/fixtures/predicate-abi.ts
+++ b/packages/account/test/fixtures/predicate-abi.ts
@@ -30,5 +30,11 @@ export const predicateAbi: JsonAbi = {
   ],
   loggedTypes: [],
   messagesTypes: [],
-  configurables: [],
+  configurables: [
+    {
+      name: 'value',
+      concreteTypeId: 'b760f44fa5965c2474a3b471467a22c43185152129295af588b022ae50b50903',
+      offset: 0,
+    },
+  ],
 };

--- a/packages/account/test/predicate-functions.test.ts
+++ b/packages/account/test/predicate-functions.test.ts
@@ -64,5 +64,28 @@ describe('Predicate', () => {
         });
       }).toThrow('Cannot use ABI without "main" function');
     });
+
+    it('creates a new instance with updated parameters', async () => {
+      using launched = await setupTestProviderAndWallets();
+      const { provider } = launched;
+
+      const predicate = new Predicate({
+        bytecode: predicateBytecode,
+        abi: predicateAbi,
+        provider,
+        configurableConstants: { value: false },
+      });
+
+      const newPredicate = predicate.toNewInstance({
+        configurableConstants: { value: true },
+        data: ['NADA'],
+      });
+
+      expect(newPredicate.predicateData).toEqual(['NADA']);
+      expect(newPredicate.bytes.slice(1)).toEqual(predicate.bytes.slice(1));
+      expect(newPredicate.bytes[0]).not.toEqual(predicate.bytes[0]);
+      expect(newPredicate.interface?.jsonAbi).toEqual(predicate.interface?.jsonAbi);
+      expect(newPredicate.provider).toEqual(predicate.provider);
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuels-ts/issues/3392

# Summary
Added method `toNewInstance` which returns new instance of predicate with same abi, loaderBytecode, provider and different configurableConstants and data to be passed:
```typescript
toNewInstance(params: {
  configurableConstants?: TConfigurables;
  data?: TData;
}): Predicate<TData, TConfigurables> { }
```

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
