### PR TITLE
docs: add max outputs documentation to combining UTXO docs

### DIFF
--- a/.changeset/rotten-chefs-shake.md
+++ b/.changeset/rotten-chefs-shake.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: add max outputs documentation to combining UTXO docs

--- a/apps/docs/src/guide/cookbook/combining-utxos.md
+++ b/apps/docs/src/guide/cookbook/combining-utxos.md
@@ -9,3 +9,7 @@ One way to avoid these errors is to combine your UTXOs. This can be done by perf
 > **Note:** You will not be able to have a single UTXO for the base asset after combining, as one output will be for the transfer, and you will have another for the fees.
 
 <<< @./snippets/combining-utxos.ts#combining-utxos{ts:line-numbers}
+
+## Max Outputs
+
+It's also important to note that depending on the chain configuration, you may be limited on the number of outputs you can have in a transaction. This amount can be queried via the [TxParameters](https://docs.fuel.network/docs/graphql/reference/objects/#txparameters) GQL query.


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

- Closes https://github.com/FuelLabs/fuels-ts/issues/3429



# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

Merely added a section about `maxOutputs` to the [Combining UTXOs docs](https://docs.fuel.network/docs/fuels-ts/cookbook/combining-utxos/)

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
