### PR TITLE
chore: silence recipes format logs

### DIFF
--- a/.changeset/afraid-ligers-work.md
+++ b/.changeset/afraid-ligers-work.md
@@ -1,5 +1,4 @@
 ---
-"@fuel-ts/recipes": patch
 ---
 
 chore: silence recipes format logs

--- a/.changeset/afraid-ligers-work.md
+++ b/.changeset/afraid-ligers-work.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/recipes": patch
+---
+
+chore: silence recipes format logs

--- a/packages/recipes/package.json
+++ b/packages/recipes/package.json
@@ -23,7 +23,7 @@
     "build": "run-s build:package build:recipes build:format",
     "build:package": "tsup",
     "build:recipes": "tsx ./scripts/build-recipes.ts",
-    "build:format": "prettier --config ../../.prettierrc --write .",
+    "build:format": "prettier --config ../../.prettierrc --log-level error --write .",
     "postbuild": "tsx ../../scripts/postbuild.ts"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
# Summary

Silences the prettier log output for the recipes package to reduce noise on build.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
