### PR TITLE
ci(release): `v0.97.2` @ `master`

### DIFF
--- a/.changeset/lucky-flies-search.md
+++ b/.changeset/lucky-flies-search.md
@@ -1,4 +1,0 @@
----
----
-
-chore: release deprecation script

--- a/.changeset/popular-wasps-tie.md
+++ b/.changeset/popular-wasps-tie.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/utils": patch
----
-
-fix: Vitest matcher integration

--- a/.changeset/proud-spoons-allow.md
+++ b/.changeset/proud-spoons-allow.md
@@ -1,6 +1,0 @@
----
-"@fuel-ts/versions": patch
-"@internal/forc": patch
----
-
-chore: updated forc version to `0.66.5`

--- a/.changeset/rare-hornets-rush.md
+++ b/.changeset/rare-hornets-rush.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/utils": patch
----
-
-chore: integrate vitest matchers globally

--- a/.changeset/rotten-chefs-shake.md
+++ b/.changeset/rotten-chefs-shake.md
@@ -1,4 +1,0 @@
----
----
-
-docs: add docs for splitting UTXOs, `maxOutputs` and `maxInputs`

--- a/.changeset/warm-horses-matter.md
+++ b/.changeset/warm-horses-matter.md
@@ -1,5 +1,0 @@
----
-"create-fuels": patch
----
-
-fix: specify versions in `create fuels` toolchain file

--- a/.changeset/wild-stingrays-cheat.md
+++ b/.changeset/wild-stingrays-cheat.md
@@ -1,8 +1,0 @@
----
-"@fuel-ts/contract": patch
-"@fuel-ts/account": patch
-"fuels": patch
-"@fuel-ts/utils": patch
----
-
-chore: update internally used chain config

--- a/internal/benchmarks/CHANGELOG.md
+++ b/internal/benchmarks/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @internal/benchmarks
 
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [ebe5ecd]
+  - fuels@0.97.2
+
 ## 1.0.9
 
 ### Patch Changes

--- a/internal/benchmarks/package.json
+++ b/internal/benchmarks/package.json
@@ -14,5 +14,5 @@
     "fuels": "workspace:*",
     "@internal/utils": "workspace:*"
   },
-  "version": "1.0.9"
+  "version": "1.0.10"
 }

--- a/internal/check-imports/CHANGELOG.md
+++ b/internal/check-imports/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @internal/check-imports
 
+## 0.0.17
+
+### Patch Changes
+
+- Updated dependencies [0970bc4]
+- Updated dependencies [5ec254d]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/versions@0.97.2
+  - @fuel-ts/contract@0.97.2
+  - @fuel-ts/account@0.97.2
+  - fuels@0.97.2
+  - @fuel-ts/abi-coder@0.97.2
+  - @fuel-ts/abi-typegen@0.97.2
+  - @fuel-ts/address@0.97.2
+  - @fuel-ts/crypto@0.97.2
+  - @fuel-ts/hasher@0.97.2
+  - @fuel-ts/program@0.97.2
+  - @fuel-ts/script@0.97.2
+  - @fuel-ts/transactions@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/merkle@0.97.2
+  - @fuel-ts/math@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.0.16
 
 ### Patch Changes

--- a/internal/check-imports/package.json
+++ b/internal/check-imports/package.json
@@ -27,5 +27,5 @@
     "@fuel-ts/account": "workspace:*",
     "fuels": "workspace:*"
   },
-  "version": "0.0.16"
+  "version": "0.0.17"
 }

--- a/internal/forc/CHANGELOG.md
+++ b/internal/forc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.89.5
+
+### Patch Changes
+
+- 5ec254d: chore: updated forc version to `0.66.5`
+
 ## 0.89.4
 
 ### Patch Changes

--- a/internal/forc/package.json
+++ b/internal/forc/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@internal/forc",
-  "version": "0.89.4",
+  "version": "0.89.5",
   "description": "NPM bin wrapper around Fuel `forc`",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/abi-coder/CHANGELOG.md
+++ b/packages/abi-coder/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- Updated dependencies [0970bc4]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/crypto@0.97.2
+  - @fuel-ts/hasher@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/math@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/abi-coder/package.json
+++ b/packages/abi-coder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/abi-coder",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/abi-typegen/CHANGELOG.md
+++ b/packages/abi-typegen/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @fuel-ts/abi-typegen
 
+## 0.97.2
+
+### Patch Changes
+
+- Updated dependencies [0970bc4]
+- Updated dependencies [5ec254d]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/versions@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/abi-typegen/package.json
+++ b/packages/abi-typegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/abi-typegen",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "Generates Typescript definitions from Sway ABI Json files",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/account/CHANGELOG.md
+++ b/packages/account/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- ebe5ecd: chore: update internally used chain config
+- Updated dependencies [0970bc4]
+- Updated dependencies [5ec254d]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/versions@0.97.2
+  - @fuel-ts/abi-coder@0.97.2
+  - @fuel-ts/address@0.97.2
+  - @fuel-ts/crypto@0.97.2
+  - @fuel-ts/hasher@0.97.2
+  - @fuel-ts/transactions@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/merkle@0.97.2
+  - @fuel-ts/math@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/account",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/address/CHANGELOG.md
+++ b/packages/address/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- Updated dependencies [0970bc4]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/crypto@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/address",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "Utilities for encoding and decoding addresses",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/contract/CHANGELOG.md
+++ b/packages/contract/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- ebe5ecd: chore: update internally used chain config
+- Updated dependencies [0970bc4]
+- Updated dependencies [5ec254d]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/versions@0.97.2
+  - @fuel-ts/account@0.97.2
+  - @fuel-ts/abi-coder@0.97.2
+  - @fuel-ts/crypto@0.97.2
+  - @fuel-ts/hasher@0.97.2
+  - @fuel-ts/program@0.97.2
+  - @fuel-ts/transactions@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/merkle@0.97.2
+  - @fuel-ts/math@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/contract",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/create-fuels/CHANGELOG.md
+++ b/packages/create-fuels/CHANGELOG.md
@@ -1,5 +1,14 @@
 # create-fuels
 
+## 0.97.2
+
+### Patch Changes
+
+- efdf9a1: fix: specify versions in `create fuels` toolchain file
+- Updated dependencies [5ec254d]
+  - @fuel-ts/versions@0.97.2
+  - @fuel-ts/errors@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/create-fuels/package.json
+++ b/packages/create-fuels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-fuels",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/crypto/CHANGELOG.md
+++ b/packages/crypto/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- Updated dependencies [0970bc4]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/math@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/crypto",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "Utilities for encrypting and decrypting data",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @fuel-ts/errors
 
+## 0.97.2
+
+### Patch Changes
+
+- Updated dependencies [5ec254d]
+  - @fuel-ts/versions@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/errors",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "Error class and error codes that the fuels-ts library throws",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/fuels/CHANGELOG.md
+++ b/packages/fuels/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- ebe5ecd: chore: update internally used chain config
+- Updated dependencies [0970bc4]
+- Updated dependencies [5ec254d]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/versions@0.97.2
+  - @fuel-ts/contract@0.97.2
+  - @fuel-ts/account@0.97.2
+  - @fuel-ts/abi-coder@0.97.2
+  - @fuel-ts/abi-typegen@0.97.2
+  - @fuel-ts/address@0.97.2
+  - @fuel-ts/crypto@0.97.2
+  - @fuel-ts/hasher@0.97.2
+  - @fuel-ts/program@0.97.2
+  - @fuel-ts/recipes@0.97.2
+  - @fuel-ts/script@0.97.2
+  - @fuel-ts/transactions@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/merkle@0.97.2
+  - @fuel-ts/math@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuels",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "Fuel TS SDK",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/hasher/CHANGELOG.md
+++ b/packages/hasher/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- Updated dependencies [0970bc4]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/crypto@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/hasher",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "Sha256 hash utility for Fuel",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/interfaces/CHANGELOG.md
+++ b/packages/interfaces/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## 0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/interfaces",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @fuel-ts/logger
 
+## 0.97.2
+
+### Patch Changes
+
+- @fuel-ts/address@0.97.2
+- @fuel-ts/math@0.97.2
+- @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/logger",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "description": "A logger for the Fuel-TS ecosystem",
   "main": "dist/index.js",

--- a/packages/math/CHANGELOG.md
+++ b/packages/math/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- @fuel-ts/errors@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/math",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/merkle/CHANGELOG.md
+++ b/packages/merkle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- @fuel-ts/hasher@0.97.2
+- @fuel-ts/math@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/merkle/package.json
+++ b/packages/merkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/merkle",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/program/CHANGELOG.md
+++ b/packages/program/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- Updated dependencies [0970bc4]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/account@0.97.2
+  - @fuel-ts/abi-coder@0.97.2
+  - @fuel-ts/address@0.97.2
+  - @fuel-ts/transactions@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/math@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/program/package.json
+++ b/packages/program/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/program",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/recipes/CHANGELOG.md
+++ b/packages/recipes/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- Updated dependencies [0970bc4]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/contract@0.97.2
+  - @fuel-ts/account@0.97.2
+  - @fuel-ts/abi-coder@0.97.2
+  - @fuel-ts/abi-typegen@0.97.2
+  - @fuel-ts/program@0.97.2
+  - @fuel-ts/transactions@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/recipes/package.json
+++ b/packages/recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/recipes",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "Recipes for Sway Programs",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/script/CHANGELOG.md
+++ b/packages/script/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- Updated dependencies [0970bc4]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/account@0.97.2
+  - @fuel-ts/abi-coder@0.97.2
+  - @fuel-ts/address@0.97.2
+  - @fuel-ts/program@0.97.2
+  - @fuel-ts/transactions@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/math@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/script",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/transactions/CHANGELOG.md
+++ b/packages/transactions/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## 0.97.2
+
+### Patch Changes
+
+- Updated dependencies [0970bc4]
+- Updated dependencies [896bf5b]
+- Updated dependencies [ebe5ecd]
+  - @fuel-ts/utils@0.97.2
+  - @fuel-ts/abi-coder@0.97.2
+  - @fuel-ts/address@0.97.2
+  - @fuel-ts/hasher@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/math@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/transactions",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @fuel-ts/utils
 
+## 0.97.2
+
+### Patch Changes
+
+- 0970bc4: fix: Vitest matcher integration
+- 896bf5b: chore: integrate vitest matchers globally
+- ebe5ecd: chore: update internally used chain config
+- Updated dependencies [5ec254d]
+  - @fuel-ts/versions@0.97.2
+  - @fuel-ts/errors@0.97.2
+  - @fuel-ts/math@0.97.2
+  - @fuel-ts/interfaces@0.97.2
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/utils",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "Utilities (and test utilities) collection",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/versions/CHANGELOG.md
+++ b/packages/versions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @fuel-ts/versions
 
+## 0.97.2
+
+### Patch Changes
+
+- 5ec254d: chore: updated forc version to `0.66.5`
+
 ## 0.97.1
 
 ### Patch Changes

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/versions",
-  "version": "0.97.1",
+  "version": "0.97.2",
   "description": "Validates supported versions of the Fuel toolchain",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/versions/src/lib/getBuiltinVersions.ts
+++ b/packages/versions/src/lib/getBuiltinVersions.ts
@@ -4,6 +4,6 @@ export function getBuiltinVersions(): Versions {
   return {
     FORC: '0.66.5',
     FUEL_CORE: '0.40.1',
-    FUELS: '0.97.1',
+    FUELS: '0.97.2',
   };
 }


### PR DESCRIPTION
# Summary

In this release, we:
- Updated forc version to `0.66.5`

# Fixes
- [#3477](https://github.com/FuelLabs/fuels-ts/pull/3477) - Vitest matcher integration, by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3475](https://github.com/FuelLabs/fuels-ts/pull/3475) - Specify versions in `create fuels` toolchain file, by [@Dhaiwat10](https://github.com/Dhaiwat10)

# Chores
- [#3468](https://github.com/FuelLabs/fuels-ts/pull/3468) - Updated forc version to `0.66.5`, by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3425](https://github.com/FuelLabs/fuels-ts/pull/3425) - Integrate vitest matchers globally, by [@starc007](https://github.com/starc007)
- [#3420](https://github.com/FuelLabs/fuels-ts/pull/3420) - Update internally used chain config, by [@Dhaiwat10](https://github.com/Dhaiwat10)