### PR TITLE
fix: use `latest` toolchain channel for `create fuels`

### DIFF
--- a/.changeset/warm-horses-matter.md
+++ b/.changeset/warm-horses-matter.md
@@ -1,0 +1,5 @@
+---
+"create-fuels": patch
+---
+
+fix: use `latest` toolchain channel for `create fuels`

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    if: false
+    # if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/apps/create-fuels-counter-guide/fuel-toolchain.toml
+++ b/apps/create-fuels-counter-guide/fuel-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "testnet"
+channel = "latest"

--- a/templates/nextjs/fuel-toolchain.toml
+++ b/templates/nextjs/fuel-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "testnet"
+channel = "latest"

--- a/templates/vite/fuel-toolchain.toml
+++ b/templates/vite/fuel-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "testnet"
+channel = "latest"


### PR DESCRIPTION
- Closes #3472

# Summary

This PR fixes the 'deploying to testnet' guide not working as expected for new users by changing the toolchain specified for `create fuels` template projects from `testnet` to `latest`.

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
