### PR TITLE
chore: use playwright in browser tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,10 @@ jobs:
       - name: Pretest
         run: pnpm pretest
 
+      - name: Install playwright dependencies
+        if: matrix.env.name == 'browser'
+        run: pnpm exec playwright install --with-deps --only-shell chromium
+
       - name: Run Tests - ${{ matrix.env.name }}
         run: pnpm test:${{ matrix.env.name }}
 

--- a/apps/create-fuels-counter-guide/package.json
+++ b/apps/create-fuels-counter-guide/package.json
@@ -30,7 +30,7 @@
     "@vitejs/plugin-react": "^4.3.3",
     "@eslint/js": "^9.10.0",
     "@types/node": "^22.5.5",
-    "@playwright/test": "^1.47.2",
+    "@playwright/test": "^1.49.1",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3",
     "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@internal/fuel-core": "workspace:*",
     "@internal/tsup": "workspace:*",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
-    "@playwright/test": "^1.47.2",
+    "@playwright/test": "^1.49.1",
     "@types/node": "^22.5.5",
     "@types/node-fetch": "^2.6.11",
     "@types/web": "^0.0.174",
@@ -124,8 +124,7 @@
     "vite-plugin-json5": "^1.1.2",
     "vite-plugin-node-polyfills": "^0.22.0",
     "vite-plugin-plain-text": "^1.4.2",
-    "vitest": "~2.0.5",
-    "webdriverio": "^9.0.9"
+    "vitest": "~2.0.5"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(nyc@17.1.0)
       '@playwright/test':
-        specifier: ^1.47.2
-        version: 1.47.2
+        specifier: ^1.49.1
+        version: 1.49.1
       '@types/node':
         specifier: ^22.5.5
         version: 22.5.5
@@ -64,10 +64,10 @@ importers:
         version: 6.21.0(eslint@8.57.0)(typescript@5.6.3)
       '@vitest/browser':
         specifier: ~2.0.5
-        version: 2.0.5(bufferutil@4.0.8)(playwright@1.47.2)(typescript@5.6.3)(utf-8-validate@6.0.4)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@6.0.4))
+        version: 2.0.5(bufferutil@4.0.8)(playwright@1.49.1)(typescript@5.6.3)(utf-8-validate@6.0.4)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@6.0.4))
       '@vitest/coverage-istanbul':
         specifier: ~2.0.5
-        version: 2.0.5(vitest@2.0.5)
+        version: 2.0.5(vitest@2.0.5(@types/node@22.5.5)(@vitest/browser@2.0.5)(jsdom@16.7.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(terser@5.36.0))
       autocannon:
         specifier: ^7.15.0
         version: 7.15.0
@@ -179,9 +179,6 @@ importers:
       vitest:
         specifier: ~2.0.5
         version: 2.0.5(@types/node@22.5.5)(@vitest/browser@2.0.5)(jsdom@16.7.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(terser@5.36.0)
-      webdriverio:
-        specifier: ^9.0.9
-        version: 9.0.9(bufferutil@4.0.8)(utf-8-validate@6.0.4)
 
   apps/create-fuels-counter-guide:
     dependencies:
@@ -223,8 +220,8 @@ importers:
         specifier: ^9.10.0
         version: 9.10.0
       '@playwright/test':
-        specifier: ^1.47.2
-        version: 1.47.2
+        specifier: ^1.49.1
+        version: 1.49.1
       '@types/node':
         specifier: ^22.5.5
         version: 22.5.5
@@ -318,7 +315,7 @@ importers:
         version: link:../../packages/fuels
       next:
         specifier: 14.2.15
-        version: 14.2.15(@babel/core@7.25.8)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.15(@babel/core@7.25.8)(@playwright/test@1.49.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -456,7 +453,7 @@ importers:
         version: link:../../packages/fuels
       next:
         specifier: 14.2.15
-        version: 14.2.15(@babel/core@7.25.8)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.15(@babel/core@7.25.8)(@playwright/test@1.49.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1269,7 +1266,7 @@ importers:
         version: link:../../packages/fuels
       next:
         specifier: 14.2.15
-        version: 14.2.15(@babel/core@7.25.8)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.15(@babel/core@7.25.8)(@playwright/test@1.49.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1284,8 +1281,8 @@ importers:
         version: 17.5.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@playwright/test':
-        specifier: ^1.47.2
-        version: 1.47.2
+        specifier: ^1.49.1
+        version: 1.49.1
       '@types/node':
         specifier: ^22.5.5
         version: 22.5.5
@@ -1357,8 +1354,8 @@ importers:
         specifier: ^9.10.0
         version: 9.10.0
       '@playwright/test':
-        specifier: ^1.47.2
-        version: 1.47.2
+        specifier: ^1.49.1
+        version: 1.49.1
       '@tanstack/router-plugin':
         specifier: ^1.58.12
         version: 1.58.12(vite@5.4.9(@types/node@22.7.7)(terser@5.36.0))(webpack-sources@3.2.3)
@@ -4549,8 +4546,8 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.47.2':
-    resolution: {integrity: sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==}
+  '@playwright/test@1.49.1':
+    resolution: {integrity: sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9178,10 +9175,6 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
-  fast-xml-parser@4.4.1:
-    resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
-    hasBin: true
-
   fast-xml-parser@4.5.0:
     resolution: {integrity: sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==}
     hasBin: true
@@ -12291,13 +12284,13 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
-  playwright-core@1.47.2:
-    resolution: {integrity: sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==}
+  playwright-core@1.49.1:
+    resolution: {integrity: sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.47.2:
-    resolution: {integrity: sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==}
+  playwright@1.49.1:
+    resolution: {integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -20820,9 +20813,9 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@playwright/test@1.47.2':
+  '@playwright/test@1.49.1':
     dependencies:
-      playwright: 1.47.2
+      playwright: 1.49.1
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.10(react-refresh@0.11.0)(type-fest@3.1.0)(webpack-dev-server@4.15.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)(webpack@5.88.0(@swc/core@1.7.14(@swc/helpers@0.5.12))(esbuild@0.17.19)))(webpack@5.88.0(@swc/core@1.7.14(@swc/helpers@0.5.12))(esbuild@0.17.19))':
     dependencies:
@@ -20846,6 +20839,7 @@ snapshots:
   '@promptbook/utils@0.63.0':
     dependencies:
       spacetrim: 0.11.39
+    optional: true
 
   '@puppeteer/browsers@2.4.0':
     dependencies:
@@ -20859,6 +20853,7 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@radix-ui/primitive@1.0.1':
     dependencies:
@@ -22264,6 +22259,7 @@ snapshots:
   '@types/node@20.14.15':
     dependencies:
       undici-types: 5.26.5
+    optional: true
 
   '@types/node@22.5.5':
     dependencies:
@@ -22358,7 +22354,8 @@ snapshots:
       '@types/mime': 3.0.1
       '@types/node': 22.7.7
 
-  '@types/sinonjs__fake-timers@8.1.5': {}
+  '@types/sinonjs__fake-timers@8.1.5':
+    optional: true
 
   '@types/sockjs@0.3.33':
     dependencies:
@@ -22386,7 +22383,8 @@ snapshots:
 
   '@types/webgl-ext@0.0.30': {}
 
-  '@types/which@2.0.2': {}
+  '@types/which@2.0.2':
+    optional: true
 
   '@types/wrap-ansi@3.0.0': {}
 
@@ -22778,7 +22776,7 @@ snapshots:
       vite: 5.4.9(@types/node@22.7.7)(terser@5.36.0)
       vue: 3.5.12(typescript@5.6.3)
 
-  '@vitest/browser@2.0.5(bufferutil@4.0.8)(playwright@1.47.2)(typescript@5.6.3)(utf-8-validate@5.0.10)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
+  '@vitest/browser@2.0.5(bufferutil@4.0.8)(playwright@1.49.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@5.0.10))':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
@@ -22789,7 +22787,7 @@ snapshots:
       vitest: 2.0.5(@types/node@22.5.5)(@vitest/browser@2.0.5)(jsdom@16.7.0(bufferutil@4.0.8)(utf-8-validate@5.0.10))(terser@5.36.0)
       ws: 8.18.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     optionalDependencies:
-      playwright: 1.47.2
+      playwright: 1.49.1
       webdriverio: 9.0.9(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
@@ -22797,7 +22795,7 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@vitest/browser@2.0.5(bufferutil@4.0.8)(playwright@1.47.2)(typescript@5.6.3)(utf-8-validate@6.0.4)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@6.0.4))':
+  '@vitest/browser@2.0.5(bufferutil@4.0.8)(playwright@1.49.1)(typescript@5.6.3)(utf-8-validate@6.0.4)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@6.0.4))':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
@@ -22808,14 +22806,14 @@ snapshots:
       vitest: 2.0.5(@types/node@22.5.5)(@vitest/browser@2.0.5)(jsdom@16.7.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(terser@5.36.0)
       ws: 8.18.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
     optionalDependencies:
-      playwright: 1.47.2
+      playwright: 1.49.1
       webdriverio: 9.0.9(bufferutil@4.0.8)(utf-8-validate@6.0.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
 
-  '@vitest/coverage-istanbul@2.0.5(vitest@2.0.5)':
+  '@vitest/coverage-istanbul@2.0.5(vitest@2.0.5(@types/node@22.5.5)(@vitest/browser@2.0.5)(jsdom@16.7.0(bufferutil@4.0.8)(utf-8-validate@6.0.4))(terser@5.36.0))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.3.7(supports-color@5.5.0)
@@ -23868,6 +23866,7 @@ snapshots:
       import-meta-resolve: 4.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@wdio/logger@8.38.0':
     dependencies:
@@ -23875,6 +23874,7 @@ snapshots:
       loglevel: 1.9.1
       loglevel-plugin-prefix: 0.8.4
       strip-ansi: 7.1.0
+    optional: true
 
   '@wdio/logger@9.0.8':
     dependencies:
@@ -23882,16 +23882,20 @@ snapshots:
       loglevel: 1.9.1
       loglevel-plugin-prefix: 0.8.4
       strip-ansi: 7.1.0
+    optional: true
 
-  '@wdio/protocols@9.0.8': {}
+  '@wdio/protocols@9.0.8':
+    optional: true
 
   '@wdio/repl@9.0.8':
     dependencies:
       '@types/node': 20.14.15
+    optional: true
 
   '@wdio/types@9.0.8':
     dependencies:
       '@types/node': 20.14.15
+    optional: true
 
   '@wdio/utils@9.0.8':
     dependencies:
@@ -23910,6 +23914,7 @@ snapshots:
       wait-port: 1.1.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@web3modal/common@5.0.0':
     dependencies:
@@ -24256,7 +24261,8 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
-  '@zip.js/zip.js@2.7.48': {}
+  '@zip.js/zip.js@2.7.48':
+    optional: true
 
   JSONStream@1.3.5:
     dependencies:
@@ -24461,6 +24467,7 @@ snapshots:
       lodash: 4.17.21
       normalize-path: 3.0.0
       readable-stream: 4.5.2
+    optional: true
 
   archiver@7.0.1:
     dependencies:
@@ -24471,6 +24478,7 @@ snapshots:
       readdir-glob: 1.1.3
       tar-stream: 3.1.7
       zip-stream: 6.0.1
+    optional: true
 
   archy@1.0.0: {}
 
@@ -25309,9 +25317,11 @@ snapshots:
       buffer-alloc-unsafe: 1.1.0
       buffer-fill: 1.0.0
 
-  buffer-crc32@0.2.13: {}
+  buffer-crc32@0.2.13:
+    optional: true
 
-  buffer-crc32@1.0.0: {}
+  buffer-crc32@1.0.0:
+    optional: true
 
   buffer-equal@0.0.1: {}
 
@@ -25816,6 +25826,7 @@ snapshots:
       is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.5.2
+    optional: true
 
   compressible@2.0.18:
     dependencies:
@@ -25996,6 +26007,7 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.5.2
+    optional: true
 
   create-ecdh@4.0.4:
     dependencies:
@@ -26144,7 +26156,8 @@ snapshots:
       domutils: 3.1.0
       nth-check: 2.1.1
 
-  css-shorthand-properties@1.1.1: {}
+  css-shorthand-properties@1.1.1:
+    optional: true
 
   css-tree@1.0.0-alpha.37:
     dependencies:
@@ -26156,7 +26169,8 @@ snapshots:
       mdn-data: 2.0.14
       source-map: 0.6.1
 
-  css-value@0.0.1: {}
+  css-value@0.0.1:
+    optional: true
 
   css-what@3.4.2: {}
 
@@ -26401,7 +26415,8 @@ snapshots:
 
   decamelize@1.2.0: {}
 
-  decamelize@6.0.0: {}
+  decamelize@6.0.0:
+    optional: true
 
   decimal.js@10.4.3: {}
 
@@ -26440,7 +26455,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
-  deepmerge-ts@7.1.0: {}
+  deepmerge-ts@7.1.0:
+    optional: true
 
   deepmerge@4.3.1: {}
 
@@ -26717,6 +26733,7 @@ snapshots:
     dependencies:
       '@types/which': 2.0.2
       which: 2.0.2
+    optional: true
 
   edgedriver@5.6.1:
     dependencies:
@@ -26724,9 +26741,10 @@ snapshots:
       '@zip.js/zip.js': 2.7.48
       decamelize: 6.0.0
       edge-paths: 3.0.5
-      fast-xml-parser: 4.4.1
+      fast-xml-parser: 4.5.0
       node-fetch: 3.3.2
       which: 4.0.0
+    optional: true
 
   ee-first@1.1.1: {}
 
@@ -27903,6 +27921,7 @@ snapshots:
       '@types/yauzl': 2.10.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   extsprintf@1.3.0: {}
 
@@ -27914,13 +27933,15 @@ snapshots:
 
   fast-decode-uri-component@1.0.1: {}
 
-  fast-deep-equal@2.0.1: {}
+  fast-deep-equal@2.0.1:
+    optional: true
 
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
 
-  fast-fifo@1.3.2: {}
+  fast-fifo@1.3.2:
+    optional: true
 
   fast-glob@3.3.1:
     dependencies:
@@ -27953,10 +27974,6 @@ snapshots:
   fast-shallow-equal@1.0.0: {}
 
   fast-stable-stringify@1.0.0: {}
-
-  fast-xml-parser@4.4.1:
-    dependencies:
-      strnum: 1.0.5
 
   fast-xml-parser@4.5.0:
     dependencies:
@@ -27993,6 +28010,7 @@ snapshots:
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
+    optional: true
 
   fetch-blob@3.2.0:
     dependencies:
@@ -28273,6 +28291,7 @@ snapshots:
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   generate-function@2.3.1:
     dependencies:
@@ -28317,7 +28336,8 @@ snapshots:
 
   get-port-please@3.1.2: {}
 
-  get-port@7.1.0: {}
+  get-port@7.1.0:
+    optional: true
 
   get-stream@4.1.0:
     dependencies:
@@ -28718,7 +28738,8 @@ snapshots:
 
   htmlescape@1.1.1: {}
 
-  htmlfy@0.2.1: {}
+  htmlfy@0.2.1:
+    optional: true
 
   htmlparser2@6.1.0:
     dependencies:
@@ -28882,7 +28903,8 @@ snapshots:
     dependencies:
       queue: 6.0.2
 
-  immediate@3.0.6: {}
+  immediate@3.0.6:
+    optional: true
 
   immer@9.0.21: {}
 
@@ -28907,7 +28929,8 @@ snapshots:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
 
-  import-meta-resolve@4.1.0: {}
+  import-meta-resolve@4.1.0:
+    optional: true
 
   imurmurhash@0.1.4: {}
 
@@ -29170,7 +29193,8 @@ snapshots:
 
   is-plain-obj@3.0.0: {}
 
-  is-plain-obj@4.1.0: {}
+  is-plain-obj@4.1.0:
+    optional: true
 
   is-plain-object@2.0.4:
     dependencies:
@@ -29276,7 +29300,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isexe@3.1.1: {}
+  isexe@3.1.1:
+    optional: true
 
   isobject@3.0.1: {}
 
@@ -30140,6 +30165,7 @@ snapshots:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+    optional: true
 
   keccak@3.0.4:
     dependencies:
@@ -30207,6 +30233,7 @@ snapshots:
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
+    optional: true
 
   leven@2.1.0: {}
 
@@ -30225,6 +30252,7 @@ snapshots:
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
+    optional: true
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -30349,6 +30377,7 @@ snapshots:
       '@promptbook/utils': 0.63.0
       type-fest: 2.13.0
       userhome: 1.0.0
+    optional: true
 
   locate-path@3.0.0:
     dependencies:
@@ -30391,7 +30420,8 @@ snapshots:
 
   lodash.uniq@4.5.0: {}
 
-  lodash.zip@4.2.0: {}
+  lodash.zip@4.2.0:
+    optional: true
 
   lodash@4.17.21: {}
 
@@ -30418,9 +30448,11 @@ snapshots:
       dayjs: 1.11.13
       yargs: 15.4.1
 
-  loglevel-plugin-prefix@0.8.4: {}
+  loglevel-plugin-prefix@0.8.4:
+    optional: true
 
-  loglevel@1.9.1: {}
+  loglevel@1.9.1:
+    optional: true
 
   long@4.0.0: {}
 
@@ -31118,7 +31150,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@14.2.15(@babel/core@7.25.8)(@playwright/test@1.47.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.15(@babel/core@7.25.8)(@playwright/test@1.49.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.15
       '@swc/helpers': 0.5.5
@@ -31139,7 +31171,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.15
       '@next/swc-win32-ia32-msvc': 14.2.15
       '@next/swc-win32-x64-msvc': 14.2.15
-      '@playwright/test': 1.47.2
+      '@playwright/test': 1.49.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -31768,7 +31800,8 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  pend@1.2.0: {}
+  pend@1.2.0:
+    optional: true
 
   perfect-debounce@1.0.0: {}
 
@@ -31841,11 +31874,11 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  playwright-core@1.47.2: {}
+  playwright-core@1.49.1: {}
 
-  playwright@1.47.2:
+  playwright@1.49.1:
     dependencies:
-      playwright-core: 1.47.2
+      playwright-core: 1.49.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -32536,7 +32569,8 @@ snapshots:
 
   qs@6.5.3: {}
 
-  query-selector-shadow-dom@1.0.1: {}
+  query-selector-shadow-dom@1.0.1:
+    optional: true
 
   query-string@7.1.3:
     dependencies:
@@ -32990,6 +33024,7 @@ snapshots:
   readdir-glob@1.1.3:
     dependencies:
       minimatch: 5.1.6
+    optional: true
 
   readdirp@3.6.0:
     dependencies:
@@ -33201,6 +33236,7 @@ snapshots:
   resq@1.11.0:
     dependencies:
       fast-deep-equal: 2.0.1
+    optional: true
 
   restore-cursor@2.0.0:
     dependencies:
@@ -33225,7 +33261,8 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rgb2hex@0.2.5: {}
+  rgb2hex@0.2.5:
+    optional: true
 
   rimraf@2.6.3:
     dependencies:
@@ -33333,7 +33370,8 @@ snapshots:
     dependencies:
       tslib: 2.8.0
 
-  safaridriver@0.1.2: {}
+  safaridriver@0.1.2:
+    optional: true
 
   safe-array-concat@1.1.2:
     dependencies:
@@ -33509,6 +33547,7 @@ snapshots:
   serialize-error@11.0.3:
     dependencies:
       type-fest: 2.19.0
+    optional: true
 
   serialize-error@2.1.0: {}
 
@@ -33773,7 +33812,8 @@ snapshots:
 
   sourcemap-codec@1.4.8: {}
 
-  spacetrim@0.11.39: {}
+  spacetrim@0.11.39:
+    optional: true
 
   spawn-wrap@2.0.0:
     dependencies:
@@ -33961,6 +34001,7 @@ snapshots:
       text-decoder: 1.1.1
     optionalDependencies:
       bare-events: 2.4.2
+    optional: true
 
   strict-event-emitter@0.5.1: {}
 
@@ -34337,12 +34378,14 @@ snapshots:
     optionalDependencies:
       bare-fs: 2.3.1
       bare-path: 2.1.3
+    optional: true
 
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.6.6
       fast-fifo: 1.3.2
       streamx: 2.18.0
+    optional: true
 
   temp-dir@2.0.0: {}
 
@@ -34419,6 +34462,7 @@ snapshots:
   text-decoder@1.1.1:
     dependencies:
       b4a: 1.6.6
+    optional: true
 
   text-encoding-utf-8@1.0.2: {}
 
@@ -34756,7 +34800,8 @@ snapshots:
 
   type-fest@0.8.1: {}
 
-  type-fest@2.13.0: {}
+  type-fest@2.13.0:
+    optional: true
 
   type-fest@2.19.0: {}
 
@@ -34877,6 +34922,7 @@ snapshots:
     dependencies:
       buffer: 5.7.1
       through: 2.3.8
+    optional: true
 
   unc-path-regex@0.1.2: {}
 
@@ -35069,7 +35115,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  userhome@1.0.0: {}
+  userhome@1.0.0:
+    optional: true
 
   utf-8-validate@5.0.10:
     dependencies:
@@ -35330,7 +35377,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.5.5
-      '@vitest/browser': 2.0.5(bufferutil@4.0.8)(playwright@1.47.2)(typescript@5.6.3)(utf-8-validate@5.0.10)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@vitest/browser': 2.0.5(bufferutil@4.0.8)(playwright@1.49.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       jsdom: 16.7.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - less
@@ -35365,7 +35412,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.5.5
-      '@vitest/browser': 2.0.5(bufferutil@4.0.8)(playwright@1.47.2)(typescript@5.6.3)(utf-8-validate@6.0.4)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@6.0.4))
+      '@vitest/browser': 2.0.5(bufferutil@4.0.8)(playwright@1.49.1)(typescript@5.6.3)(utf-8-validate@6.0.4)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@6.0.4))
       jsdom: 16.7.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
     transitivePeerDependencies:
       - less
@@ -35400,7 +35447,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.7.7
-      '@vitest/browser': 2.0.5(bufferutil@4.0.8)(playwright@1.47.2)(typescript@5.6.3)(utf-8-validate@5.0.10)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@5.0.10))
+      '@vitest/browser': 2.0.5(bufferutil@4.0.8)(playwright@1.49.1)(typescript@5.6.3)(utf-8-validate@5.0.10)(vitest@2.0.5)(webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       jsdom: 16.7.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - less
@@ -35445,6 +35492,7 @@ snapshots:
       debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   walker@1.0.8:
     dependencies:
@@ -35504,6 +35552,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   webdriverio@9.0.9(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     dependencies:
@@ -35573,6 +35622,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   webextension-polyfill@0.10.0: {}
 
@@ -35778,6 +35828,7 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.1
+    optional: true
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -36108,6 +36159,7 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+    optional: true
 
   yn@3.1.1:
     optional: true
@@ -36128,6 +36180,7 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.5.2
+    optional: true
 
   zod-validation-error@3.4.0(zod@3.23.8):
     dependencies:

--- a/templates/nextjs/package.json
+++ b/templates/nextjs/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.5.5",
-    "@playwright/test": "^1.47.2",
+    "@playwright/test": "^1.49.1",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3",
     "autoprefixer": "^10.4.20",

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -29,7 +29,7 @@
     "@vitejs/plugin-react": "^4.3.3",
     "@eslint/js": "^9.10.0",
     "@tanstack/router-plugin": "^1.58.12",
-    "@playwright/test": "^1.47.2",
+    "@playwright/test": "^1.49.1",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3",
     "autoprefixer": "^10.4.20",

--- a/vitest.browser.config.mts
+++ b/vitest.browser.config.mts
@@ -30,7 +30,12 @@ const config: UserConfig = {
     }),
   ],
   optimizeDeps: {
-    exclude: ["fsevents", "path-scurry", "@vitest/coverage-istanbul"],
+    exclude: [
+      "fsevents",
+      "path-scurry",
+      "@vitest/coverage-istanbul",
+      "chromium-bidi",
+    ],
     include: ["events", "timers/promises"],
     entries: ["**/*.test.ts"],
   },
@@ -43,10 +48,11 @@ const config: UserConfig = {
       reportsDirectory: "coverage/environments/browser",
     },
     browser: {
-      provider: "webdriverio",
+      provider: "playwright",
+      isolate: false,
       headless: true,
       enabled: true,
-      name: "chrome",
+      name: "chromium",
     },
   },
 };

--- a/vitest.browser.config.mts
+++ b/vitest.browser.config.mts
@@ -49,7 +49,6 @@ const config: UserConfig = {
     },
     browser: {
       provider: "playwright",
-      isolate: false,
       headless: true,
       enabled: true,
       name: "chromium",


### PR DESCRIPTION
# Summary

Vitest now [recommends](https://vitest.dev/guide/browser/#manual-installation) running browser tests with playwright because of parallel execution capabilities:

> If you don't already use one of these tools, we recommend starting with Playwright because it supports parallel execution, which makes your tests run faster. Additionally, the Chrome DevTools Protocol that Playwright uses is generally faster than WebDriver.

We get a 2-3 minute speed-up in browser tests with this change ([before](https://github.com/FuelLabs/fuels-ts/actions/runs/12319828961/job/34387779085), [now](https://github.com/FuelLabs/fuels-ts/actions/runs/12571326373/job/35042116724?pr=3515)). I expected a larger speed-up given that it parallelizes the tests, though. There might be some configuration missing but I didn't find anything that'd make a difference. What's interesting is that vitest [reported](https://github.com/FuelLabs/fuels-ts/actions/runs/12571381073/job/35042243634?pr=3249#step:7:1384) the duration of the run (485.22s) to be larger than what it reports in the brackets:
```sh
   Duration  485.22s 
   (transform 54ms, setup 9.82s, collect 67.44s, tests 239.45s, environment 0ms, prepare 14.17s)
```


# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
