### PR TITLE
feat: prevent illicit burn

### DIFF
--- a/.changeset/wild-avocados-carry.md
+++ b/.changeset/wild-avocados-carry.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/account": patch
+"@fuel-ts/errors": patch
+---
+
+feat: prevent implicit asset burn

--- a/apps/docs/src/guide/errors/index.md
+++ b/apps/docs/src/guide/errors/index.md
@@ -24,6 +24,12 @@ When an [`Account`](https://fuels-ts-docs-api.vercel.app/classes/_fuel_ts_accoun
 
 It could be caused during the deployments of contracts when an account is required to sign the transaction. This can be resolved by following the deployment guide [here](../contracts/deploying-contracts.md).
 
+### `ASSET_BURN_DETECTED`
+
+When you are trying to send a transaction that will result in an asset burn.
+
+Add relevant coin change outputs to the transaction, or [enable asset burn](#TODO) in the transaction request.
+
 ### `CONFIG_FILE_NOT_FOUND`
 
 When a configuration file is not found. This could either be a `fuels.config.[ts,js,mjs,cjs]` file or a TOML file.

--- a/apps/docs/src/guide/errors/index.md
+++ b/apps/docs/src/guide/errors/index.md
@@ -28,7 +28,7 @@ It could be caused during the deployments of contracts when an account is requir
 
 When you are trying to send a transaction that will result in an asset burn.
 
-Add relevant coin change outputs to the transaction, or [enable asset burn](#TODO) in the transaction request.
+Add relevant coin change outputs to the transaction, or enable asset burn in the transaction request.
 
 ### `CONFIG_FILE_NOT_FOUND`
 

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -866,6 +866,13 @@ Supported fuel-core version: ${supportedVersion}.`
         `The transaction exceeds the maximum allowed number of outputs. Tx outputs: ${tx.outputs.length}, max outputs: ${maxOutputs}`
       );
     }
+
+    if (tx.hasBurnableAssets()) {
+      throw new FuelError(
+        ErrorCode.ASSET_BURN_DETECTED,
+        'Asset burn detected.\nAdd relevant coin change outputs to the transaction, or enable asset burn in the transaction request (`request.enableBurn()`).'
+      );
+    }
   }
 
   /**

--- a/packages/account/src/providers/transaction-request/transaction-request.test.ts
+++ b/packages/account/src/providers/transaction-request/transaction-request.test.ts
@@ -6,6 +6,10 @@ import { TransactionType, UpgradePurposeTypeEnum } from '@fuel-ts/transactions';
 import { concat, hexlify } from '@fuel-ts/utils';
 import { ASSET_A, ASSET_B } from '@fuel-ts/utils/test-utils';
 
+import {
+  SCRIPT_TX_COIN_REQUEST_INPUT,
+  SCRIPT_TX_COIN_REQUEST_OUTPUT_CHANGE,
+} from '../../../test/fixtures/transaction-request';
 import { WalletUnlocked } from '../../wallet';
 import type { Coin } from '../coin';
 import type { CoinQuantity } from '../coin-quantity';
@@ -290,5 +294,34 @@ describe('transactionRequestify', () => {
     expect(txRequest.subsection).toEqual(txRequestLike.subsection);
     expect(txRequest.witnessIndex).toEqual(txRequestLike.witnessIndex);
     expect(txRequest.type).toEqual(txRequestLike.type);
+  });
+
+  it('should have burnable assets [single input, no change]', () => {
+    const txRequest = new ScriptTransactionRequest();
+    const hasBurnableAssets = true;
+
+    txRequest.inputs.push(SCRIPT_TX_COIN_REQUEST_INPUT);
+
+    expect(txRequest.hasBurnableAssets()).toEqual(hasBurnableAssets);
+  });
+
+  it('should not have burnable assets [single input, single change]', () => {
+    const txRequest = new ScriptTransactionRequest();
+    const hasBurnableAssets = false;
+
+    txRequest.inputs.push(SCRIPT_TX_COIN_REQUEST_INPUT);
+    txRequest.outputs.push(SCRIPT_TX_COIN_REQUEST_OUTPUT_CHANGE);
+
+    expect(txRequest.hasBurnableAssets()).toEqual(hasBurnableAssets);
+  });
+
+  it('should not have burnable assets [single input, burn asset enabled]', () => {
+    const txRequest = new ScriptTransactionRequest();
+    const hasBurnableAssets = false;
+
+    txRequest.enableBurn(true);
+    txRequest.inputs.push(SCRIPT_TX_COIN_REQUEST_INPUT);
+
+    expect(txRequest.hasBurnableAssets()).toEqual(hasBurnableAssets);
   });
 });

--- a/packages/account/test/fixtures/transaction-request.ts
+++ b/packages/account/test/fixtures/transaction-request.ts
@@ -1,4 +1,35 @@
+import type {
+  ChangeTransactionRequestOutput,
+  CoinTransactionRequestInput,
+  CoinTransactionRequestOutput,
+} from '../../src';
 import { ScriptTransactionRequest } from '../../src/providers/transaction-request/script-transaction-request';
+
+export const SCRIPT_TX_COIN_REQUEST_INPUT: CoinTransactionRequestInput = {
+  type: 0,
+  id: '0x000000000000000000000000000000000000000000000000000000000000000000',
+  assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  amount: '0x989680',
+  owner: '0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e',
+  txPointer: '0x00000000000000000000000000000000',
+  witnessIndex: 0,
+  predicate: '0x',
+  predicateData: '0x',
+  predicateGasUsed: '0x20',
+};
+
+export const SCRIPT_TX_COIN_REQUEST_OUTPUT_COIN: CoinTransactionRequestOutput = {
+  type: 0,
+  to: '0xc7862855b418ba8f58878db434b21053a61a2025209889cc115989e8040ff077',
+  assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  amount: 1,
+};
+
+export const SCRIPT_TX_COIN_REQUEST_OUTPUT_CHANGE: ChangeTransactionRequestOutput = {
+  type: 2,
+  to: '0xc7862855b418ba8f58878db434b21053a61a2025209889cc115989e8040ff077',
+  assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+};
 
 export const SCRIPT_TX_REQUEST = new ScriptTransactionRequest({
   gasLimit: 10_000,
@@ -8,27 +39,7 @@ export const SCRIPT_TX_REQUEST = new ScriptTransactionRequest({
   maxFee: 90000,
   maturity: 0,
   witnessLimit: 3000,
-  inputs: [
-    {
-      type: 0,
-      id: '0x000000000000000000000000000000000000000000000000000000000000000000',
-      assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      amount: '0x989680',
-      owner: '0xf1e92c42b90934aa6372e30bc568a326f6e66a1a0288595e6e3fbd392a4f3e6e',
-      txPointer: '0x00000000000000000000000000000000',
-      witnessIndex: 0,
-      predicate: '0x',
-      predicateData: '0x',
-      predicateGasUsed: '0x20',
-    },
-  ],
-  outputs: [
-    {
-      type: 0,
-      to: '0xc7862855b418ba8f58878db434b21053a61a2025209889cc115989e8040ff077',
-      assetId: '0x0000000000000000000000000000000000000000000000000000000000000000',
-      amount: 1,
-    },
-  ],
+  inputs: [SCRIPT_TX_COIN_REQUEST_INPUT],
+  outputs: [SCRIPT_TX_COIN_REQUEST_OUTPUT_COIN],
   witnesses: ['0x'],
 });

--- a/packages/errors/src/error-codes.ts
+++ b/packages/errors/src/error-codes.ts
@@ -85,6 +85,8 @@ export enum ErrorCode {
   FUNDS_TOO_LOW = 'funds-too-low',
   MAX_OUTPUTS_EXCEEDED = 'max-outputs-exceeded',
   MAX_COINS_REACHED = 'max-coins-reached',
+  ASSET_BURN_DETECTED = 'asset-burn-detected',
+
   // receipt
   INVALID_RECEIPT_TYPE = 'invalid-receipt-type',
 


### PR DESCRIPTION
- Closes #3489 

# Release notes

In this release, we:

- Added a guard to transaction to ensure that we prevent implicit asset burns. 

# Summary

- When building a transaction, if inputs are added to a request without respective change outputs, then we will throw an error on sending a transaction.
- Unless you set the `enableBurn` flag on the transaction.  

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
