### PR TITLE
chore!: remove deprecated `submitAndAwait` operation

### DIFF
--- a/.changeset/shiny-meals-jog.md
+++ b/.changeset/shiny-meals-jog.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": minor
+---
+
+chore!: remove deprecated `submitAndAwait` operation

--- a/packages/account/src/providers/operations.graphql
+++ b/packages/account/src/providers/operations.graphql
@@ -822,12 +822,6 @@ query getConsensusParametersVersion {
   }
 }
 
-subscription submitAndAwait($encodedTransaction: HexString!) {
-  submitAndAwait(tx: $encodedTransaction) {
-    ...transactionStatusSubscriptionFragment
-  }
-}
-
 subscription submitAndAwaitStatus($encodedTransaction: HexString!) {
   submitAndAwaitStatus(tx: $encodedTransaction) {
     ...transactionStatusSubscriptionFragment

--- a/packages/account/src/providers/provider.test.ts
+++ b/packages/account/src/providers/provider.test.ts
@@ -1436,7 +1436,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
       const responseObject = {
         data: {
-          submitAndAwait: {
+          submitAndAwaitStatus: {
             type: 'SuccessStatus',
             time: 'data: 4611686020137152060',
           },
@@ -1457,11 +1457,11 @@ Supported fuel-core version: ${mock.supportedVersion}.`
       );
     });
 
-    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
+    for await (const { submitAndAwaitStatus } of await provider.operations.submitAndAwaitStatus({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
-      expect(submitAndAwait.type).toEqual('SuccessStatus');
-      expect((<SubmittedStatus>submitAndAwait).time).toEqual('data: 4611686020137152060');
+      expect(submitAndAwaitStatus.type).toEqual('SuccessStatus');
+      expect((<SubmittedStatus>submitAndAwaitStatus).time).toEqual('data: 4611686020137152060');
     }
   });
 
@@ -1476,11 +1476,11 @@ Supported fuel-core version: ${mock.supportedVersion}.`
         const encoder = new TextEncoder();
 
         controller.enqueue(
-          encoder.encode(`data:${JSON.stringify({ data: { submitAndAwait: { a: 0 } } })}\n\n`)
+          encoder.encode(`data:${JSON.stringify({ data: { submitAndAwaitStatus: { a: 0 } } })}\n\n`)
         );
         controller.enqueue(encoder.encode(':keep-alive-text\n\n'));
         controller.enqueue(
-          encoder.encode(`data:${JSON.stringify({ data: { submitAndAwait: { a: 1 } } })}\n\n`)
+          encoder.encode(`data:${JSON.stringify({ data: { submitAndAwaitStatus: { a: 1 } } })}\n\n`)
         );
         controller.close();
       },
@@ -1489,7 +1489,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
     let numberOfEvents = 0;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
+    for await (const { submitAndAwaitStatus } of await provider.operations.submitAndAwaitStatus({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
       numberOfEvents += 1;
@@ -1505,14 +1505,14 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
       const event1 = {
         data: {
-          submitAndAwait: {
+          submitAndAwaitStatus: {
             type: 'SubmittedStatus',
           },
         },
       };
       const event2 = {
         data: {
-          submitAndAwait: {
+          submitAndAwaitStatus: {
             type: 'SuccessStatus',
           },
         },
@@ -1536,16 +1536,16 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
     let numberOfEvents = 0;
 
-    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
+    for await (const { submitAndAwaitStatus } of await provider.operations.submitAndAwaitStatus({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
       numberOfEvents += 1;
 
       if (numberOfEvents === 1) {
-        expect(submitAndAwait.type).toEqual('SubmittedStatus');
+        expect(submitAndAwaitStatus.type).toEqual('SubmittedStatus');
       }
       if (numberOfEvents === 2) {
-        expect(submitAndAwait.type).toEqual('SuccessStatus');
+        expect(submitAndAwaitStatus.type).toEqual('SuccessStatus');
       }
     }
 
@@ -1558,7 +1558,7 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
       const responseObject = JSON.stringify({
         data: {
-          submitAndAwait: {
+          submitAndAwaitStatus: {
             type: 'SuccessStatus',
           },
         },
@@ -1584,10 +1584,10 @@ Supported fuel-core version: ${mock.supportedVersion}.`
       );
     });
 
-    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
+    for await (const { submitAndAwaitStatus } of await provider.operations.submitAndAwaitStatus({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
-      expect(submitAndAwait.type).toEqual('SuccessStatus');
+      expect(submitAndAwaitStatus.type).toEqual('SuccessStatus');
     }
   });
 
@@ -1598,14 +1598,14 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
       const event1 = {
         data: {
-          submitAndAwait: {
+          submitAndAwaitStatus: {
             type: 'SubmittedStatus',
           },
         },
       };
       const event2 = JSON.stringify({
         data: {
-          submitAndAwait: {
+          submitAndAwaitStatus: {
             type: 'SuccessStatus',
           },
         },
@@ -1632,16 +1632,16 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
     let numberOfEvents = 0;
 
-    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
+    for await (const { submitAndAwaitStatus } of await provider.operations.submitAndAwaitStatus({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
       numberOfEvents += 1;
 
       if (numberOfEvents === 1) {
-        expect(submitAndAwait.type).toEqual('SubmittedStatus');
+        expect(submitAndAwaitStatus.type).toEqual('SubmittedStatus');
       }
       if (numberOfEvents === 2) {
-        expect(submitAndAwait.type).toEqual('SuccessStatus');
+        expect(submitAndAwaitStatus.type).toEqual('SuccessStatus');
       }
     }
 
@@ -1655,14 +1655,14 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     vi.spyOn(global, 'fetch').mockImplementationOnce(() => {
       const event1 = JSON.stringify({
         data: {
-          submitAndAwait: {
+          submitAndAwaitStatus: {
             type: 'SubmittedStatus',
           },
         },
       });
       const event2 = JSON.stringify({
         data: {
-          submitAndAwait: {
+          submitAndAwaitStatus: {
             type: 'SuccessStatus',
           },
         },
@@ -1691,16 +1691,16 @@ Supported fuel-core version: ${mock.supportedVersion}.`
 
     let numberOfEvents = 0;
 
-    for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
+    for await (const { submitAndAwaitStatus } of await provider.operations.submitAndAwaitStatus({
       encodedTransaction: "it's mocked so doesn't matter",
     })) {
       numberOfEvents += 1;
 
       if (numberOfEvents === 1) {
-        expect(submitAndAwait.type).toEqual('SubmittedStatus');
+        expect(submitAndAwaitStatus.type).toEqual('SubmittedStatus');
       }
       if (numberOfEvents === 2) {
-        expect(submitAndAwait.type).toEqual('SuccessStatus');
+        expect(submitAndAwaitStatus.type).toEqual('SuccessStatus');
       }
     }
 
@@ -1729,9 +1729,11 @@ Supported fuel-core version: ${mock.supportedVersion}.`
     await expectToThrowFuelError(
       async () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for await (const { submitAndAwait } of await provider.operations.submitAndAwait({
-          encodedTransaction: "it's mocked so doesn't matter",
-        })) {
+        for await (const { submitAndAwaitStatus } of await provider.operations.submitAndAwaitStatus(
+          {
+            encodedTransaction: "it's mocked so doesn't matter",
+          }
+        )) {
           // shouldn't be reached!
           expect(true).toBeFalsy();
         }

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -377,20 +377,7 @@ type NodeInfoCache = Record<string, NodeInfo>;
 
 type Operations = ReturnType<typeof getOperationsSdk>;
 
-type SdkOperations = Omit<
-  Operations,
-  'submitAndAwait' | 'statusChange' | 'submitAndAwaitStatus'
-> & {
-  /**
-   * This method is DEPRECATED and will be REMOVED in v1.
-   *
-   * This method will hang until the transaction is fully processed, as described in https://github.com/FuelLabs/fuel-core/issues/2108.
-   *
-   * Please use the `submitAndAwaitStatus` method instead.
-   */
-  submitAndAwait: (
-    ...args: Parameters<Operations['submitAndAwait']>
-  ) => Promise<ReturnType<Operations['submitAndAwait']>>;
+type SdkOperations = Omit<Operations, 'statusChange' | 'submitAndAwaitStatus'> & {
   statusChange: (
     ...args: Parameters<Operations['statusChange']>
   ) => Promise<ReturnType<Operations['statusChange']>>;

--- a/packages/fuel-gauge/src/transaction-response.test.ts
+++ b/packages/fuel-gauge/src/transaction-response.test.ts
@@ -258,7 +258,7 @@ describe('TransactionResponse', () => {
   );
 
   it(
-    'should throw error for a SqueezedOut status update [submitAndAwait]',
+    'should throw error for a SqueezedOut status update [statusChange]',
     { retry: 10 },
     async () => {
       using launched = await launchTestNode({
@@ -294,11 +294,13 @@ describe('TransactionResponse', () => {
         genesisWallet.address,
         await genesisWallet.signTransaction(request)
       );
+      const submit = await provider.sendTransaction(request);
+
+      const txResponse = new TransactionResponse(submit.id, provider);
 
       await expectToThrowFuelError(
         async () => {
-          const submit = await provider.sendTransaction(request);
-          await submit.waitForResult();
+          await txResponse.waitForResult();
         },
         { code: ErrorCode.TRANSACTION_SQUEEZED_OUT }
       );

--- a/packages/fuel-gauge/src/transaction-response.test.ts
+++ b/packages/fuel-gauge/src/transaction-response.test.ts
@@ -296,7 +296,7 @@ describe('TransactionResponse', () => {
       );
       const submit = await provider.sendTransaction(request);
 
-      const txResponse = new TransactionResponse(submit.id, provider);
+      const txResponse = new TransactionResponse(submit.id, provider, await provider.getChainId());
 
       await expectToThrowFuelError(
         async () => {

--- a/packages/fuel-gauge/src/transaction-response.test.ts
+++ b/packages/fuel-gauge/src/transaction-response.test.ts
@@ -204,7 +204,7 @@ describe('TransactionResponse', () => {
   );
 
   it(
-    'should throw error for a SqueezedOut status update [waitForResult]',
+    'should throw error for a SqueezedOut status update [submitAndAwaitStatus]',
     { timeout: 10_000, retry: 10 },
     async () => {
       /**


### PR DESCRIPTION
<!-- LINEAR: closes TS-763 -->
<!-- LINEAR: relates to  -->
- Closes #3518 

# Summary

This PR removes the `submitAndAwait` operation which was previously deprecated.

# Breaking Changes

- `submitAndAwait` operation was removed

After being deprecated since #3101, we have removed this operation altogether. Please use the `submitAndAwaitStatus` method instead which gives the same results as `submitAndAwait`. If you are interested in the deprecation/removal reasons, please refer to https://github.com/FuelLabs/fuel-core/issues/2108.

```ts
// before
const response = await provider.operations.submitAndAwait(txRequest);
```

```ts
// after
const response = await provider.operations.submitAndAwaitStatus(txRequest);
```

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
