### PR TITLE
chore: added `useBaseAssetId` hook to templates

### DIFF
--- a/.changeset/small-spoons-drive.md
+++ b/.changeset/small-spoons-drive.md
@@ -1,0 +1,5 @@
+---
+"create-fuels": patch
+---
+
+chore: added `useBaseAssetId` hook to templates

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    # if: false
+    if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    if: false
+    # if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/apps/create-fuels-counter-guide/src/components/Faucet.tsx
+++ b/apps/create-fuels-counter-guide/src/components/Faucet.tsx
@@ -4,16 +4,17 @@ import { useEffect, useState } from "react";
 import LocalFaucet from "./LocalFaucet";
 import Button from "./Button";
 import { isLocal, renderFormattedBalance, testnetFaucetUrl } from "../lib.tsx";
+import { useBaseAssetId } from "../hooks/useBaseAssetId.tsx";
 
 export default function Faucet() {
   const { wallet } = useWallet();
+  const { baseAssetId } = useBaseAssetId();
   const connectedWalletAddress = wallet?.address.toB256() || "";
 
   const [addressToFund, setAddressToFund] = useState("");
-
-  const { balance, refetch } = useBalance({ address: addressToFund });
-
   const [initialAddressLoaded, setInitialAddressLoaded] = useState(false);
+
+  const { balance, refetch } = useBalance({ address: addressToFund, assetId: baseAssetId });
 
   useEffect(() => {
     if (connectedWalletAddress && !initialAddressLoaded && !addressToFund) {

--- a/apps/create-fuels-counter-guide/src/components/Predicate.tsx
+++ b/apps/create-fuels-counter-guide/src/components/Predicate.tsx
@@ -7,6 +7,7 @@ import Button from "./Button";
 import LocalFaucet from "./LocalFaucet";
 import { isLocal, renderFormattedBalance } from "../lib.tsx";
 import { useNotification } from "../hooks/useNotification.tsx";
+import { useBaseAssetId } from "../hooks/useBaseAssetId.tsx";
 
 export default function Predicate() {
   const { errorNotification, transactionSubmitNotification, transactionSuccessNotification, successNotification } = useNotification();
@@ -14,15 +15,18 @@ export default function Predicate() {
   const [predicate, setPredicate] = useState<FuelPredicate<InputValue[]>>();
   const [predicatePin, setPredicatePin] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
+  const { baseAssetId } = useBaseAssetId();
 
   const { wallet } = useWallet();
   const address = wallet?.address.toB256() || "";
   const { balance: walletBalance, refetch: refetchWallet } = useBalance({
     address,
+    assetId: baseAssetId,
   });
   const predicateAddress = predicate?.address?.toB256();
   const { balance: predicateBalance, refetch: refetchPredicate } = useBalance({
     address: predicateAddress,
+    assetId: baseAssetId,
   });
 
   useEffect(() => {

--- a/apps/create-fuels-counter-guide/src/components/Wallet.tsx
+++ b/apps/create-fuels-counter-guide/src/components/Wallet.tsx
@@ -4,12 +4,16 @@ import { useEffect } from "react";
 import Button from "./Button";
 import LocalFaucet from "./LocalFaucet";
 import { isLocal, renderFormattedBalance } from "../lib.tsx";
+import { useBaseAssetId } from "../hooks/useBaseAssetId.tsx";
 
 export default function Wallet() {
   const { disconnect } = useDisconnect();
   const { wallet } = useWallet();
+  const { baseAssetId } = useBaseAssetId();
+
   const address = wallet?.address.toB256() || "";
-  const { balance, refetch } = useBalance({ address });
+
+  const { balance, refetch } = useBalance({ address, assetId: baseAssetId });
 
   useEffect(() => {
     refetch();

--- a/apps/create-fuels-counter-guide/src/hooks/useBaseAssetId.tsx
+++ b/apps/create-fuels-counter-guide/src/hooks/useBaseAssetId.tsx
@@ -1,0 +1,17 @@
+import { useNamedQuery, useProvider } from "@fuels/react";
+
+export const useBaseAssetId = () => {
+  const { provider } = useProvider();
+
+  return useNamedQuery("baseAssetId", {
+    queryKey: ["baseAssetId"],
+    queryFn: async () => {
+      if (!provider) {
+        throw new Error("Provider not found");
+      }
+
+      return await provider.getBaseAssetId();
+    },
+    placeholderData: undefined,
+  });
+};

--- a/templates/nextjs/src/components/Faucet.tsx
+++ b/templates/nextjs/src/components/Faucet.tsx
@@ -4,16 +4,20 @@ import { useEffect, useState } from "react";
 import LocalFaucet from "./LocalFaucet";
 import Button from "./Button";
 import { isLocal, renderFormattedBalance, testnetFaucetUrl } from "../lib";
+import { useBaseAssetId } from "@/hooks/useBaseAssetId";
 
 export default function Faucet() {
   const { wallet } = useWallet();
+  const { baseAssetId } = useBaseAssetId();
   const connectedWalletAddress = wallet?.address.toB256() || "";
 
   const [addressToFund, setAddressToFund] = useState("");
-
-  const { balance, refetch } = useBalance({ address: addressToFund });
-
   const [initialAddressLoaded, setInitialAddressLoaded] = useState(false);
+
+  const { balance, refetch } = useBalance({
+    address: addressToFund,
+    assetId: baseAssetId,
+  });
 
   useEffect(() => {
     if (connectedWalletAddress && !initialAddressLoaded && !addressToFund) {
@@ -21,6 +25,7 @@ export default function Faucet() {
       setInitialAddressLoaded(true);
     }
   }, [connectedWalletAddress, addressToFund, initialAddressLoaded]);
+
   useEffect(() => {
     refetch();
   }, [refetch]);

--- a/templates/nextjs/src/components/Predicate.tsx
+++ b/templates/nextjs/src/components/Predicate.tsx
@@ -7,6 +7,7 @@ import Button from "./Button";
 import LocalFaucet from "./LocalFaucet";
 import { isLocal, renderFormattedBalance } from "../lib";
 import { useNotification } from "../hooks/useNotification";
+import { useBaseAssetId } from "@/hooks/useBaseAssetId";
 
 export default function Predicate() {
   const {
@@ -19,15 +20,18 @@ export default function Predicate() {
   const [predicate, setPredicate] = useState<TestPredicate>();
   const [predicatePin, setPredicatePin] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
+  const { baseAssetId } = useBaseAssetId();
 
   const { wallet } = useWallet();
   const address = wallet?.address.toB256() || "";
   const { balance: walletBalance, refetch: refetchWallet } = useBalance({
     address,
+    assetId: baseAssetId,
   });
   const predicateAddress = predicate?.address?.toB256();
   const { balance: predicateBalance, refetch: refetchPredicate } = useBalance({
     address: predicateAddress,
+    assetId: baseAssetId,
   });
 
   useEffect(() => {

--- a/templates/nextjs/src/components/Wallet.tsx
+++ b/templates/nextjs/src/components/Wallet.tsx
@@ -4,12 +4,15 @@ import { useEffect } from "react";
 import Button from "./Button";
 import LocalFaucet from "./LocalFaucet";
 import { isLocal, renderFormattedBalance } from "../lib";
+import { useBaseAssetId } from "@/hooks/useBaseAssetId";
 
 export default function Wallet() {
   const { disconnect } = useDisconnect();
   const { wallet } = useWallet();
+  const { baseAssetId } = useBaseAssetId();
+
   const address = wallet?.address.toB256() || "";
-  const { balance, refetch } = useBalance({ address });
+  const { balance, refetch } = useBalance({ address, assetId: baseAssetId });
 
   useEffect(() => {
     refetch();

--- a/templates/nextjs/src/hooks/useBaseAssetId.tsx
+++ b/templates/nextjs/src/hooks/useBaseAssetId.tsx
@@ -1,0 +1,17 @@
+import { useNamedQuery, useProvider } from "@fuels/react";
+
+export const useBaseAssetId = () => {
+  const { provider } = useProvider();
+
+  return useNamedQuery("baseAssetId", {
+    queryKey: ["baseAssetId"],
+    queryFn: async () => {
+      if (!provider) {
+        throw new Error("Provider not found");
+      }
+
+      return await provider.getBaseAssetId();
+    },
+    placeholderData: undefined,
+  });
+};

--- a/templates/vite/src/components/Faucet.tsx
+++ b/templates/vite/src/components/Faucet.tsx
@@ -4,16 +4,20 @@ import { useEffect, useState } from "react";
 import LocalFaucet from "./LocalFaucet";
 import Button from "./Button";
 import { isLocal, renderFormattedBalance, testnetFaucetUrl } from "../lib.tsx";
+import { useBaseAssetId } from "../hooks/useBaseAssetId.tsx";
 
 export default function Faucet() {
   const { wallet } = useWallet();
+  const { baseAssetId } = useBaseAssetId();
   const connectedWalletAddress = wallet?.address.toB256() || "";
 
   const [addressToFund, setAddressToFund] = useState("");
-
-  const { balance, refetch } = useBalance({ address: addressToFund });
-
   const [initialAddressLoaded, setInitialAddressLoaded] = useState(false);
+
+  const { balance, refetch } = useBalance({
+    address: addressToFund,
+    assetId: baseAssetId,
+  });
 
   useEffect(() => {
     if (connectedWalletAddress && !initialAddressLoaded && !addressToFund) {

--- a/templates/vite/src/components/Predicate.tsx
+++ b/templates/vite/src/components/Predicate.tsx
@@ -1,12 +1,13 @@
 import { useBalance, useWallet } from "@fuels/react";
 import { useEffect, useState } from "react";
-import { bn, Predicate as FuelPredicate, InputValue } from "fuels";
+import { bn } from "fuels";
 
 import { TestPredicate } from "../sway-api/predicates";
 import Button from "./Button";
 import LocalFaucet from "./LocalFaucet";
 import { isLocal, renderFormattedBalance } from "../lib.tsx";
 import { useNotification } from "../hooks/useNotification.tsx";
+import { useBaseAssetId } from "../hooks/useBaseAssetId.tsx";
 
 export default function Predicate() {
   const {
@@ -18,15 +19,18 @@ export default function Predicate() {
   const [predicate, setPredicate] = useState<TestPredicate>();
   const [predicatePin, setPredicatePin] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
+  const { baseAssetId } = useBaseAssetId();
 
   const { wallet } = useWallet();
   const address = wallet?.address.toB256() || "";
   const { balance: walletBalance, refetch: refetchWallet } = useBalance({
     address,
+    assetId: baseAssetId,
   });
   const predicateAddress = predicate?.address?.toB256();
   const { balance: predicateBalance, refetch: refetchPredicate } = useBalance({
     address: predicateAddress,
+    assetId: baseAssetId,
   });
 
   useEffect(() => {

--- a/templates/vite/src/components/Wallet.tsx
+++ b/templates/vite/src/components/Wallet.tsx
@@ -4,12 +4,16 @@ import { useEffect } from "react";
 import Button from "./Button";
 import LocalFaucet from "./LocalFaucet";
 import { isLocal, renderFormattedBalance } from "../lib.tsx";
+import { useBaseAssetId } from "../hooks/useBaseAssetId.tsx";
 
 export default function Wallet() {
   const { disconnect } = useDisconnect();
   const { wallet } = useWallet();
+  const { baseAssetId } = useBaseAssetId();
+
   const address = wallet?.address.toB256() || "";
-  const { balance, refetch } = useBalance({ address });
+
+  const { balance, refetch } = useBalance({ address, assetId: baseAssetId });
 
   useEffect(() => {
     refetch();

--- a/templates/vite/src/hooks/useBaseAssetId.tsx
+++ b/templates/vite/src/hooks/useBaseAssetId.tsx
@@ -1,0 +1,17 @@
+import { useNamedQuery, useProvider } from "@fuels/react";
+
+export const useBaseAssetId = () => {
+  const { provider } = useProvider();
+
+  return useNamedQuery("baseAssetId", {
+    queryKey: ["baseAssetId"],
+    queryFn: async () => {
+      if (!provider) {
+        throw new Error("Provider not found");
+      }
+
+      return await provider.getBaseAssetId();
+    },
+    placeholderData: undefined,
+  });
+};


### PR DESCRIPTION
# Summary

- Fix [failing](https://github.com/FuelLabs/fuels-ts/actions/runs/12635048842/job/35204125857) integration tests
- Due to the breaking changes in #3509, the [`useBalance`](https://github.com/FuelLabs/fuel-connectors/blob/d9c06243c092313a331228a081a0c5f722905234/packages/react/src/hooks/useBalance.ts#L62) hook was not obtaining the `baseAssetId` correctly.

```bash
$ PUBLISHED_NPM_TAG=pr-3550 sh ./scripts/tests-ui-integration.sh

Running 2 tests using 2 workers
  2 passed (10.7s)
```

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
