### PR TITLE
chore: removing obsolete `Provider.create` method

### DIFF
--- a/.changeset/strange-experts-roll.md
+++ b/.changeset/strange-experts-roll.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+chore: removing obsolete `Provider.create` method

--- a/apps/docs/src/guide/getting-started/snippets/connecting-to-the-network.ts
+++ b/apps/docs/src/guide/getting-started/snippets/connecting-to-the-network.ts
@@ -3,7 +3,7 @@ import { Provider } from 'fuels';
 
 const NETWORK_URL = 'https://mainnet.fuel.network/v1/graphql';
 
-const provider = await Provider.create(NETWORK_URL);
+const provider = new Provider(NETWORK_URL);
 
 const baseAssetId = provider.getBaseAssetId();
 const chainId = provider.getChainId();

--- a/apps/docs/src/guide/transactions/snippets/transaction-request/auto-cost.ts
+++ b/apps/docs/src/guide/transactions/snippets/transaction-request/auto-cost.ts
@@ -3,7 +3,7 @@ import { Provider, ScriptTransactionRequest, Wallet } from 'fuels';
 import { LOCAL_NETWORK_URL, WALLET_PVT_KEY } from '../../../../env';
 import { ScriptSum } from '../../../../typegend';
 
-const provider = await Provider.create(LOCAL_NETWORK_URL);
+const provider = new Provider(LOCAL_NETWORK_URL);
 const wallet = Wallet.fromPrivateKey(WALLET_PVT_KEY, provider);
 
 // #region auto-cost

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -508,18 +508,6 @@ export default class Provider {
   }
 
   /**
-   * Creates a new instance of the Provider class. This is the recommended way to initialize a Provider.
-   * @deprecated Use `new Provider(...)` instead.
-   *
-   * @param url - GraphQL endpoint of the Fuel node
-   * @param options - Additional options for the provider
-   * @returns A promise that resolves to a Provider instance.
-   */
-  static async create(url: string, options: ProviderOptions = {}): Promise<Provider> {
-    return new Provider(url, options).init();
-  }
-
-  /**
    * Initialize Provider async stuff
    */
   async init(): Promise<Provider> {


### PR DESCRIPTION
# Summary

Quick follow-up after:
 - https://github.com/FuelLabs/fuels-ts/pull/3514

Ultimately, the breaking changes were inevitable, so there's no point in keeping a deprecated method.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
