### PR TITLE
ci(release): `v0.99.0` @ `master`

### DIFF
--- a/.changeset/angry-crabs-float.md
+++ b/.changeset/angry-crabs-float.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": patch
----
-
-chore: prepend version mismatch to GraphQL errors

--- a/.changeset/big-dragons-count.md
+++ b/.changeset/big-dragons-count.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": minor
----
-
-chore!: remove `pageInfo` from `getBalances` GraphQl operations

--- a/.changeset/breezy-mugs-cheat.md
+++ b/.changeset/breezy-mugs-cheat.md
@@ -1,4 +1,0 @@
----
----
-
-test: fix predicate test in network test suite

--- a/.changeset/brown-chairs-tickle.md
+++ b/.changeset/brown-chairs-tickle.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": patch
----
-
-fix: bind `waitForResult` in `TransactionResponse`

--- a/.changeset/chilly-buses-add.md
+++ b/.changeset/chilly-buses-add.md
@@ -1,8 +1,0 @@
----
-"@internal/check-imports": patch
-"@fuel-ts/account": patch
-"@fuel-ts/address": patch
-"@fuel-ts/program": patch
----
-
-chore: `Address` constructor now accepts a range of inputs.

--- a/.changeset/clever-mirrors-jam.md
+++ b/.changeset/clever-mirrors-jam.md
@@ -1,6 +1,0 @@
----
-"@fuel-ts/account": patch
-"@fuel-ts/program": patch
----
-
-feat: allow passing `gasPrice` to `getTransactionCost`

--- a/.changeset/clever-wasps-nail.md
+++ b/.changeset/clever-wasps-nail.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": patch
----
-
-chore: un-deprecated network URLs

--- a/.changeset/fluffy-dingos-deliver.md
+++ b/.changeset/fluffy-dingos-deliver.md
@@ -1,4 +1,0 @@
----
----
-
-chore: fix generate fuel core graphql schema script

--- a/.changeset/gorgeous-plants-watch.md
+++ b/.changeset/gorgeous-plants-watch.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": patch
----
-
-feat: bytecode ID helpers

--- a/.changeset/grumpy-lamps-cough.md
+++ b/.changeset/grumpy-lamps-cough.md
@@ -1,4 +1,0 @@
----
----
-
-ci(deps): bump dawidd6/action-download-artifact from 7 to 8

--- a/.changeset/hungry-rivers-float.md
+++ b/.changeset/hungry-rivers-float.md
@@ -1,4 +1,0 @@
----
----
-
-chore: added validation for toolchain versions

--- a/.changeset/kind-ants-scream.md
+++ b/.changeset/kind-ants-scream.md
@@ -1,4 +1,0 @@
----
----
-
-docs: update documentation for running a local Fuel node

--- a/.changeset/lemon-avocados-walk.md
+++ b/.changeset/lemon-avocados-walk.md
@@ -1,7 +1,0 @@
----
-"@internal/forc": patch
-"create-fuels": patch
-"@fuel-ts/versions": patch
----
-
-chore: bump `forc` to `0.66.6`

--- a/.changeset/loud-deers-wait.md
+++ b/.changeset/loud-deers-wait.md
@@ -1,5 +1,0 @@
----
-"create-fuels": patch
----
-
-feat: add `forc` tests to create fuels

--- a/.changeset/nasty-carrots-report.md
+++ b/.changeset/nasty-carrots-report.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/abi-coder": patch
----
-
-fix: incorrect function coder offset usage

--- a/.changeset/new-seas-yawn.md
+++ b/.changeset/new-seas-yawn.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": patch
----
-
-feat: use configurable offset for blob ID

--- a/.changeset/pink-mails-dream.md
+++ b/.changeset/pink-mails-dream.md
@@ -1,6 +1,0 @@
----
-"@fuel-ts/account": patch
-"@fuel-ts/utils": patch
----
-
-chore: update `amountPerCoin` prop in `WalletConfig` to accept BN

--- a/.changeset/plenty-beds-bake.md
+++ b/.changeset/plenty-beds-bake.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": patch
----
-
-fix: s3 publishing

--- a/.changeset/quiet-shrimps-stare.md
+++ b/.changeset/quiet-shrimps-stare.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": patch
----
-
-chore: organized `assets` in account package

--- a/.changeset/red-fishes-move.md
+++ b/.changeset/red-fishes-move.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/contract": minor
----
-
-chore!: remove `ContractUtils` namespaced export

--- a/.changeset/red-ligers-invent.md
+++ b/.changeset/red-ligers-invent.md
@@ -1,4 +1,0 @@
----
----
-
-chore: fixed interplay with resource cache tests

--- a/.changeset/rich-items-argue.md
+++ b/.changeset/rich-items-argue.md
@@ -1,5 +1,0 @@
----
-"@fuel-ts/account": patch
----
-
-feat: support Explorer Asset API

--- a/.changeset/silly-pianos-fry.md
+++ b/.changeset/silly-pianos-fry.md
@@ -1,5 +1,0 @@
----
-"fuels": patch
----
-
-fix: `fuels dev` hangs after compilation errors

--- a/.changeset/six-moles-wonder.md
+++ b/.changeset/six-moles-wonder.md
@@ -1,6 +1,0 @@
----
-"@fuel-ts/abi-typegen": patch
-"@fuel-ts/recipes": patch
----
-
-chore: prevent naming collisions on typegen

--- a/.changeset/soft-poems-reflect.md
+++ b/.changeset/soft-poems-reflect.md
@@ -1,4 +1,0 @@
----
----
-
-docs: use `new Address` in favor of deprecated method

--- a/.changeset/stupid-owls-worry.md
+++ b/.changeset/stupid-owls-worry.md
@@ -1,7 +1,0 @@
----
-"@fuel-ts/transactions": patch
-"@fuel-ts/abi-coder": patch
-"@fuel-ts/contract": patch
----
-
-chore: fix version resolutions

--- a/.changeset/sweet-walls-wonder.md
+++ b/.changeset/sweet-walls-wonder.md
@@ -1,6 +1,0 @@
----
-"@fuel-ts/errors": patch
-"@fuel-ts/math": patch
----
-
-fix: improve BN unsafe numbers error handling

--- a/.changeset/ten-boats-deny.md
+++ b/.changeset/ten-boats-deny.md
@@ -1,7 +1,0 @@
----
-"@internal/fuel-core": patch
-"@fuel-ts/versions": patch
-"@fuel-ts/account": patch
----
-
-chore: upgrade `fuel-core` to `0.40.4`

--- a/.changeset/ten-cherries-perform.md
+++ b/.changeset/ten-cherries-perform.md
@@ -1,5 +1,0 @@
----
-"create-fuels": patch
----
-
-chore: changed Tailwind config from JS to TS

--- a/.changeset/three-taxis-do.md
+++ b/.changeset/three-taxis-do.md
@@ -1,5 +1,0 @@
----
-"fuels": patch
----
-
-feat: enable `fuels` callbacks to be asynchronous

--- a/.changeset/wet-goats-push.md
+++ b/.changeset/wet-goats-push.md
@@ -1,4 +1,0 @@
----
----
-
-chore: adjust commit conventions

--- a/.changeset/wet-radios-collect.md
+++ b/.changeset/wet-radios-collect.md
@@ -1,4 +1,0 @@
----
----
-
-docs: favour `B256` and `B512` type references

--- a/.changeset/young-queens-juggle.md
+++ b/.changeset/young-queens-juggle.md
@@ -1,4 +1,0 @@
----
----
-
-ci: configure timeout for docs and lint jobs

--- a/internal/check-imports/CHANGELOG.md
+++ b/internal/check-imports/CHANGELOG.md
@@ -1,5 +1,48 @@
 # @internal/check-imports
 
+## 0.0.19
+
+### Patch Changes
+
+- 86b8e94: chore: `Address` constructor now accepts a range of inputs.
+- Updated dependencies [edefe59]
+- Updated dependencies [4428556]
+- Updated dependencies [f3d5240]
+- Updated dependencies [86b8e94]
+- Updated dependencies [e5251e2]
+- Updated dependencies [f986891]
+- Updated dependencies [d35ccb7]
+- Updated dependencies [ab56ded]
+- Updated dependencies [69e1ba8]
+- Updated dependencies [ec84b8a]
+- Updated dependencies [d1825c9]
+- Updated dependencies [f7f0f0a]
+- Updated dependencies [d591df0]
+- Updated dependencies [baab80c]
+- Updated dependencies [8030180]
+- Updated dependencies [43dc5ee]
+- Updated dependencies [68e4b5a]
+- Updated dependencies [56adcc5]
+- Updated dependencies [b3bb765]
+- Updated dependencies [45cc32e]
+- Updated dependencies [c822522]
+  - @fuel-ts/account@0.99.0
+  - @fuel-ts/address@0.99.0
+  - @fuel-ts/program@0.99.0
+  - @fuel-ts/versions@0.99.0
+  - @fuel-ts/abi-coder@0.99.0
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/contract@0.99.0
+  - fuels@0.99.0
+  - @fuel-ts/abi-typegen@0.99.0
+  - @fuel-ts/transactions@0.99.0
+  - @fuel-ts/errors@0.99.0
+  - @fuel-ts/math@0.99.0
+  - @fuel-ts/script@0.99.0
+  - @fuel-ts/crypto@0.99.0
+  - @fuel-ts/hasher@0.99.0
+  - @fuel-ts/merkle@0.99.0
+
 ## 0.0.18
 
 ### Patch Changes

--- a/internal/check-imports/package.json
+++ b/internal/check-imports/package.json
@@ -26,5 +26,5 @@
     "@fuel-ts/account": "workspace:*",
     "fuels": "workspace:*"
   },
-  "version": "0.0.18"
+  "version": "0.0.19"
 }

--- a/internal/forc/CHANGELOG.md
+++ b/internal/forc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.89.6
+
+### Patch Changes
+
+- ab56ded: chore: bump `forc` to `0.66.6`
+
 ## 0.89.5
 
 ### Patch Changes

--- a/internal/forc/package.json
+++ b/internal/forc/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@internal/forc",
-  "version": "0.89.5",
+  "version": "0.89.6",
   "description": "NPM bin wrapper around Fuel `forc`",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/internal/fuel-core/CHANGELOG.md
+++ b/internal/fuel-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @internal/fuel-core
 
+## 0.89.8
+
+### Patch Changes
+
+- 45cc32e: chore: upgrade `fuel-core` to `0.40.4`
+
 ## 0.89.7
 
 ### Patch Changes

--- a/internal/fuel-core/package.json
+++ b/internal/fuel-core/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@internal/fuel-core",
-  "version": "0.89.7",
+  "version": "0.89.8",
   "description": "NPM bin wrapper around `fuel-core`",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/abi-coder/CHANGELOG.md
+++ b/packages/abi-coder/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- 69e1ba8: fix: incorrect function coder offset usage
+- 56adcc5: chore: fix version resolutions
+- Updated dependencies [d1825c9]
+- Updated dependencies [b3bb765]
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/errors@0.99.0
+  - @fuel-ts/math@0.99.0
+  - @fuel-ts/crypto@0.99.0
+  - @fuel-ts/hasher@0.99.0
+
 ## 0.98.0
 
 ### Patch Changes

--- a/packages/abi-coder/package.json
+++ b/packages/abi-coder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/abi-coder",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/abi-typegen/CHANGELOG.md
+++ b/packages/abi-typegen/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @fuel-ts/abi-typegen
 
+## 0.99.0
+
+### Patch Changes
+
+- 68e4b5a: chore: prevent naming collisions on typegen
+- Updated dependencies [ab56ded]
+- Updated dependencies [d1825c9]
+- Updated dependencies [b3bb765]
+- Updated dependencies [45cc32e]
+  - @fuel-ts/versions@0.99.0
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/errors@0.99.0
+
 ## 0.98.0
 
 ### Patch Changes

--- a/packages/abi-typegen/package.json
+++ b/packages/abi-typegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/abi-typegen",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Generates Typescript definitions from Sway ABI Json files",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/account/CHANGELOG.md
+++ b/packages/account/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Change Log
 
+## 0.99.0
+
+### Minor Changes
+
+- 4428556: chore!: remove `pageInfo` from `getBalances` GraphQl operations
+
+### Patch Changes
+
+- edefe59: chore: prepend version mismatch to GraphQL errors
+- f3d5240: fix: bind `waitForResult` in `TransactionResponse`
+- 86b8e94: chore: `Address` constructor now accepts a range of inputs.
+- e5251e2: feat: allow passing `gasPrice` to `getTransactionCost`
+- f986891: chore: un-deprecated network URLs
+- d35ccb7: feat: bytecode ID helpers
+- ec84b8a: feat: use configurable offset for blob ID
+- d1825c9: chore: update `amountPerCoin` prop in `WalletConfig` to accept BN
+- f7f0f0a: fix: s3 publishing
+- d591df0: chore: organized `assets` in account package
+- 8030180: feat: support Explorer Asset API
+- 45cc32e: chore: upgrade `fuel-core` to `0.40.4`
+- Updated dependencies [86b8e94]
+- Updated dependencies [ab56ded]
+- Updated dependencies [69e1ba8]
+- Updated dependencies [d1825c9]
+- Updated dependencies [56adcc5]
+- Updated dependencies [b3bb765]
+- Updated dependencies [45cc32e]
+  - @fuel-ts/address@0.99.0
+  - @fuel-ts/versions@0.99.0
+  - @fuel-ts/abi-coder@0.99.0
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/transactions@0.99.0
+  - @fuel-ts/errors@0.99.0
+  - @fuel-ts/math@0.99.0
+  - @fuel-ts/crypto@0.99.0
+  - @fuel-ts/hasher@0.99.0
+  - @fuel-ts/merkle@0.99.0
+
 ## 0.98.0
 
 ### Minor Changes

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/account",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/address/CHANGELOG.md
+++ b/packages/address/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- 86b8e94: chore: `Address` constructor now accepts a range of inputs.
+- Updated dependencies [d1825c9]
+- Updated dependencies [b3bb765]
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/errors@0.99.0
+  - @fuel-ts/crypto@0.99.0
+
 ## 0.98.0
 
 ### Minor Changes

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/address",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Utilities for encoding and decoding addresses",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/contract/CHANGELOG.md
+++ b/packages/contract/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Change Log
 
+## 0.99.0
+
+### Minor Changes
+
+- baab80c: chore!: remove `ContractUtils` namespaced export
+
+### Patch Changes
+
+- 56adcc5: chore: fix version resolutions
+- Updated dependencies [edefe59]
+- Updated dependencies [4428556]
+- Updated dependencies [f3d5240]
+- Updated dependencies [86b8e94]
+- Updated dependencies [e5251e2]
+- Updated dependencies [f986891]
+- Updated dependencies [d35ccb7]
+- Updated dependencies [69e1ba8]
+- Updated dependencies [ec84b8a]
+- Updated dependencies [d1825c9]
+- Updated dependencies [f7f0f0a]
+- Updated dependencies [d591df0]
+- Updated dependencies [8030180]
+- Updated dependencies [56adcc5]
+- Updated dependencies [b3bb765]
+- Updated dependencies [45cc32e]
+  - @fuel-ts/account@0.99.0
+  - @fuel-ts/program@0.99.0
+  - @fuel-ts/abi-coder@0.99.0
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/transactions@0.99.0
+  - @fuel-ts/errors@0.99.0
+  - @fuel-ts/math@0.99.0
+  - @fuel-ts/crypto@0.99.0
+  - @fuel-ts/hasher@0.99.0
+  - @fuel-ts/merkle@0.99.0
+
 ## 0.98.0
 
 ### Minor Changes

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/contract",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/create-fuels/CHANGELOG.md
+++ b/packages/create-fuels/CHANGELOG.md
@@ -1,5 +1,18 @@
 # create-fuels
 
+## 0.99.0
+
+### Patch Changes
+
+- ab56ded: chore: bump `forc` to `0.66.6`
+- 13064a7: feat: add `forc` tests to create fuels
+- 71691a2: chore: changed Tailwind config from JS to TS
+- Updated dependencies [ab56ded]
+- Updated dependencies [b3bb765]
+- Updated dependencies [45cc32e]
+  - @fuel-ts/versions@0.99.0
+  - @fuel-ts/errors@0.99.0
+
 ## 0.98.0
 
 ### Minor Changes

--- a/packages/create-fuels/package.json
+++ b/packages/create-fuels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-fuels",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/crypto/CHANGELOG.md
+++ b/packages/crypto/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- Updated dependencies [d1825c9]
+- Updated dependencies [b3bb765]
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/errors@0.99.0
+
 ## 0.98.0
 
 ### Patch Changes

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/crypto",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Utilities for encrypting and decrypting data",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/errors/CHANGELOG.md
+++ b/packages/errors/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @fuel-ts/errors
 
+## 0.99.0
+
+### Patch Changes
+
+- b3bb765: fix: improve BN unsafe numbers error handling
+- Updated dependencies [ab56ded]
+- Updated dependencies [45cc32e]
+  - @fuel-ts/versions@0.99.0
+
 ## 0.98.0
 
 ### Patch Changes

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/errors",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Error class and error codes that the fuels-ts library throws",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/fuels/CHANGELOG.md
+++ b/packages/fuels/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- 43dc5ee: fix: `fuels dev` hangs after compilation errors
+- c822522: feat: enable `fuels` callbacks to be asynchronous
+- Updated dependencies [edefe59]
+- Updated dependencies [4428556]
+- Updated dependencies [f3d5240]
+- Updated dependencies [86b8e94]
+- Updated dependencies [e5251e2]
+- Updated dependencies [f986891]
+- Updated dependencies [d35ccb7]
+- Updated dependencies [ab56ded]
+- Updated dependencies [69e1ba8]
+- Updated dependencies [ec84b8a]
+- Updated dependencies [d1825c9]
+- Updated dependencies [f7f0f0a]
+- Updated dependencies [d591df0]
+- Updated dependencies [baab80c]
+- Updated dependencies [8030180]
+- Updated dependencies [68e4b5a]
+- Updated dependencies [56adcc5]
+- Updated dependencies [b3bb765]
+- Updated dependencies [45cc32e]
+  - @fuel-ts/account@0.99.0
+  - @fuel-ts/address@0.99.0
+  - @fuel-ts/program@0.99.0
+  - @fuel-ts/versions@0.99.0
+  - @fuel-ts/abi-coder@0.99.0
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/contract@0.99.0
+  - @fuel-ts/abi-typegen@0.99.0
+  - @fuel-ts/recipes@0.99.0
+  - @fuel-ts/transactions@0.99.0
+  - @fuel-ts/errors@0.99.0
+  - @fuel-ts/math@0.99.0
+  - @fuel-ts/script@0.99.0
+  - @fuel-ts/crypto@0.99.0
+  - @fuel-ts/hasher@0.99.0
+
 ## 0.98.0
 
 ### Minor Changes

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuels",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Fuel TS SDK",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/hasher/CHANGELOG.md
+++ b/packages/hasher/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- Updated dependencies [d1825c9]
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/crypto@0.99.0
+
 ## 0.98.0
 
 ### Patch Changes

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/hasher",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Sha256 hash utility for Fuel",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @fuel-ts/logger
 
+## 0.99.0
+
+### Patch Changes
+
+- Updated dependencies [86b8e94]
+- Updated dependencies [b3bb765]
+  - @fuel-ts/address@0.99.0
+  - @fuel-ts/math@0.99.0
+
 ## 0.98.0
 
 ### Minor Changes

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/logger",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "description": "A logger for the Fuel-TS ecosystem",
   "main": "dist/index.js",

--- a/packages/math/CHANGELOG.md
+++ b/packages/math/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- b3bb765: fix: improve BN unsafe numbers error handling
+- Updated dependencies [b3bb765]
+  - @fuel-ts/errors@0.99.0
+
 ## 0.98.0
 
 ### Patch Changes

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/math",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/merkle/CHANGELOG.md
+++ b/packages/merkle/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- Updated dependencies [b3bb765]
+  - @fuel-ts/math@0.99.0
+  - @fuel-ts/hasher@0.99.0
+
 ## 0.98.0
 
 ### Patch Changes

--- a/packages/merkle/package.json
+++ b/packages/merkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/merkle",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/program/CHANGELOG.md
+++ b/packages/program/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- 86b8e94: chore: `Address` constructor now accepts a range of inputs.
+- e5251e2: feat: allow passing `gasPrice` to `getTransactionCost`
+- Updated dependencies [edefe59]
+- Updated dependencies [4428556]
+- Updated dependencies [f3d5240]
+- Updated dependencies [86b8e94]
+- Updated dependencies [e5251e2]
+- Updated dependencies [f986891]
+- Updated dependencies [d35ccb7]
+- Updated dependencies [69e1ba8]
+- Updated dependencies [ec84b8a]
+- Updated dependencies [d1825c9]
+- Updated dependencies [f7f0f0a]
+- Updated dependencies [d591df0]
+- Updated dependencies [8030180]
+- Updated dependencies [56adcc5]
+- Updated dependencies [b3bb765]
+- Updated dependencies [45cc32e]
+  - @fuel-ts/account@0.99.0
+  - @fuel-ts/address@0.99.0
+  - @fuel-ts/abi-coder@0.99.0
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/transactions@0.99.0
+  - @fuel-ts/errors@0.99.0
+  - @fuel-ts/math@0.99.0
+
 ## 0.98.0
 
 ### Minor Changes

--- a/packages/program/package.json
+++ b/packages/program/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/program",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/recipes/CHANGELOG.md
+++ b/packages/recipes/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- 68e4b5a: chore: prevent naming collisions on typegen
+- Updated dependencies [edefe59]
+- Updated dependencies [4428556]
+- Updated dependencies [f3d5240]
+- Updated dependencies [86b8e94]
+- Updated dependencies [e5251e2]
+- Updated dependencies [f986891]
+- Updated dependencies [d35ccb7]
+- Updated dependencies [69e1ba8]
+- Updated dependencies [ec84b8a]
+- Updated dependencies [d1825c9]
+- Updated dependencies [f7f0f0a]
+- Updated dependencies [d591df0]
+- Updated dependencies [baab80c]
+- Updated dependencies [8030180]
+- Updated dependencies [68e4b5a]
+- Updated dependencies [56adcc5]
+- Updated dependencies [45cc32e]
+  - @fuel-ts/account@0.99.0
+  - @fuel-ts/address@0.99.0
+  - @fuel-ts/program@0.99.0
+  - @fuel-ts/abi-coder@0.99.0
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/contract@0.99.0
+  - @fuel-ts/abi-typegen@0.99.0
+  - @fuel-ts/transactions@0.99.0
+
 ## 0.98.0
 
 ### Minor Changes

--- a/packages/recipes/package.json
+++ b/packages/recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/recipes",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Recipes for Sway Programs",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/script/CHANGELOG.md
+++ b/packages/script/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- Updated dependencies [edefe59]
+- Updated dependencies [4428556]
+- Updated dependencies [f3d5240]
+- Updated dependencies [86b8e94]
+- Updated dependencies [e5251e2]
+- Updated dependencies [f986891]
+- Updated dependencies [d35ccb7]
+- Updated dependencies [69e1ba8]
+- Updated dependencies [ec84b8a]
+- Updated dependencies [d1825c9]
+- Updated dependencies [f7f0f0a]
+- Updated dependencies [d591df0]
+- Updated dependencies [8030180]
+- Updated dependencies [56adcc5]
+- Updated dependencies [b3bb765]
+- Updated dependencies [45cc32e]
+  - @fuel-ts/account@0.99.0
+  - @fuel-ts/program@0.99.0
+  - @fuel-ts/abi-coder@0.99.0
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/transactions@0.99.0
+  - @fuel-ts/errors@0.99.0
+  - @fuel-ts/math@0.99.0
+
 ## 0.98.0
 
 ### Minor Changes

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/script",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/transactions/CHANGELOG.md
+++ b/packages/transactions/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## 0.99.0
+
+### Patch Changes
+
+- 56adcc5: chore: fix version resolutions
+- Updated dependencies [86b8e94]
+- Updated dependencies [69e1ba8]
+- Updated dependencies [d1825c9]
+- Updated dependencies [56adcc5]
+- Updated dependencies [b3bb765]
+  - @fuel-ts/address@0.99.0
+  - @fuel-ts/abi-coder@0.99.0
+  - @fuel-ts/utils@0.99.0
+  - @fuel-ts/errors@0.99.0
+  - @fuel-ts/math@0.99.0
+  - @fuel-ts/hasher@0.99.0
+
 ## 0.98.0
 
 ### Minor Changes

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/transactions",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @fuel-ts/utils
 
+## 0.99.0
+
+### Patch Changes
+
+- d1825c9: chore: update `amountPerCoin` prop in `WalletConfig` to accept BN
+- Updated dependencies [ab56ded]
+- Updated dependencies [b3bb765]
+- Updated dependencies [45cc32e]
+  - @fuel-ts/versions@0.99.0
+  - @fuel-ts/errors@0.99.0
+  - @fuel-ts/math@0.99.0
+
 ## 0.98.0
 
 ### Patch Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/utils",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Utilities (and test utilities) collection",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "main": "dist/index.js",

--- a/packages/versions/CHANGELOG.md
+++ b/packages/versions/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @fuel-ts/versions
 
+## 0.99.0
+
+### Patch Changes
+
+- ab56ded: chore: bump `forc` to `0.66.6`
+- 45cc32e: chore: upgrade `fuel-core` to `0.40.4`
+
 ## 0.98.0
 
 ### Patch Changes

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fuel-ts/versions",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Validates supported versions of the Fuel toolchain",
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "bin": {

--- a/packages/versions/src/lib/getBuiltinVersions.ts
+++ b/packages/versions/src/lib/getBuiltinVersions.ts
@@ -4,6 +4,6 @@ export function getBuiltinVersions(): Versions {
   return {
     FORC: '0.66.6',
     FUEL_CORE: '0.40.4',
-    FUELS: '0.98.0',
+    FUELS: '0.99.0',
   };
 }


### PR DESCRIPTION
# Summary

In this release, we:
- Allowed passing `gasPrice` to `getTransactionCost` functions to reduce possible network calls
- Introduced bytecode helpers to compute the Bytecode ID and Legacy Blob ID
- Added `forc` tests to the template
- Updated how we calculate Blob ID so that it mirrors Bytecode ID
- Added methods to allow querying the Explorer Asset API
- Enable `fuels` callbacks to be asynchronous
- Fixed a de-structuring issue when calling `waitForResult` on a submitted transaction
- Fixed incorrect offset usage for `Interface.decodeArguments()` function
- Migrated CDN host from `cdn.fuel.network` to `assets.fuel.network`
- Fixed a bug where `fuels dev` would hang after a Sway compilation error
- Embedding node incompatibility warnings in GQL errors
- Removed `pageInfo` from `provider.operations.getBalances` response
- The `Address` constructor now accepts a range of different inputs
- Upgraded `forc` to `0.66.6`
- Upgraded `fuel-core` to `0.40.4`

# Breaking

- Chores
    - [#3652](https://github.com/FuelLabs/fuels-ts/pull/3652) - Remove `pageInfo` from `getBalances` GraphQl operations, by [@Torres-ssf](https://github.com/Torres-ssf)
    - [#3570](https://github.com/FuelLabs/fuels-ts/pull/3570) - Remove `ContractUtils` namespaced export, by [@danielbate](https://github.com/danielbate)

---

# Features
- [#3608](https://github.com/FuelLabs/fuels-ts/pull/3608) - Allow passing `gasPrice` to `getTransactionCost`, by [@danielbate](https://github.com/danielbate)
- [#3641](https://github.com/FuelLabs/fuels-ts/pull/3641) - Bytecode ID helpers, by [@danielbate](https://github.com/danielbate)
- [#3585](https://github.com/FuelLabs/fuels-ts/pull/3585) - Add `forc` tests to create fuels, by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3631](https://github.com/FuelLabs/fuels-ts/pull/3631) - Use configurable offset for blob ID, by [@danielbate](https://github.com/danielbate)
- [#3648](https://github.com/FuelLabs/fuels-ts/pull/3648) - Support Explorer Asset API, by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3637](https://github.com/FuelLabs/fuels-ts/pull/3637) - Enable `fuels` callbacks to be asynchronous, by [@petertonysmith94](https://github.com/petertonysmith94)

# Fixes
- [#3660](https://github.com/FuelLabs/fuels-ts/pull/3660) - Bind `waitForResult` in `TransactionResponse`, by [@danielbate](https://github.com/danielbate)
- [#3589](https://github.com/FuelLabs/fuels-ts/pull/3589) - Incorrect function coder offset usage, by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3643](https://github.com/FuelLabs/fuels-ts/pull/3643) - S3 publishing, by [@mchristopher](https://github.com/mchristopher)
- [#3646](https://github.com/FuelLabs/fuels-ts/pull/3646) - `fuels dev` hangs after compilation errors, by [@nedsalk](https://github.com/nedsalk)
- [#3636](https://github.com/FuelLabs/fuels-ts/pull/3636) - Improve BN unsafe numbers error handling, by [@Torres-ssf](https://github.com/Torres-ssf)

# Chores
- [#3580](https://github.com/FuelLabs/fuels-ts/pull/3580) - Prepend version mismatch to GraphQL errors, by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3600](https://github.com/FuelLabs/fuels-ts/pull/3600) - `Address` constructor now accepts a range of inputs., by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3532](https://github.com/FuelLabs/fuels-ts/pull/3532) - Un-deprecated network URLs, by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3617](https://github.com/FuelLabs/fuels-ts/pull/3617) - Bump `forc` to `0.66.6`, by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3594](https://github.com/FuelLabs/fuels-ts/pull/3594) - Update `amountPerCoin` prop in `WalletConfig` to accept BN, by [@Torres-ssf](https://github.com/Torres-ssf)
- [#3619](https://github.com/FuelLabs/fuels-ts/pull/3619) - Organized `assets` in account package, by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3620](https://github.com/FuelLabs/fuels-ts/pull/3620) - Prevent naming collisions on typegen, by [@Torres-ssf](https://github.com/Torres-ssf)
- [#3633](https://github.com/FuelLabs/fuels-ts/pull/3633) - Fix version resolutions, by [@petertonysmith94](https://github.com/petertonysmith94)
- [#3626](https://github.com/FuelLabs/fuels-ts/pull/3626) - Upgrade `fuel-core` to `0.40.4`, by [@Torres-ssf](https://github.com/Torres-ssf)
- [#3579](https://github.com/FuelLabs/fuels-ts/pull/3579) - Changed Tailwind config from JS to TS, by [@petertonysmith94](https://github.com/petertonysmith94)

---

# Migration Notes

## Chores
### [#3652 - Remove `pageInfo` from `getBalances` GraphQl operations](https://github.com/FuelLabs/fuels-ts/pull/3652)

  The `pageInfo` field has been removed from the response of the `provider.operations.getBalances` query.

```ts
// before
const { balances, pageInfo } = await provider.operations.getBalances({
  first: 100,
  filter: { owner: wallet.address.toB256() },
});
```

```ts
// after
const { balances } = await provider.operations.getBalances({
  first: 100,
  filter: { owner: wallet.address.toB256() },
});
```

The `getBalances` method of the Provider class remains unchanged, as it never returned pageInfo:

```ts
// not affected
const { balances } = await provider.getBalances();
```
### [#3570 - Remove `ContractUtils` namespaced export](https://github.com/FuelLabs/fuels-ts/pull/3570)

  - `ContractUtils` was removed and the underlying functions (`getContractRoot()`, `getContractStorageRoot()`, `getContractId()`, `hexlifyWithPrefix()` are now exported directly from `fuels`.

```ts
// before
import { ContractUtils } from 'fuels';
```

```ts
// after
import { getContractRoot, getContractStorageRoot, getContractId, hexlifyWithPrefix } from 'fuels';
```