### PR TITLE
chore: update Twitter URL to X.com

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     ],
     socialLinks: [
       { icon: 'github', link: 'https://github.com/FuelLabs/fuels-ts' },
-      { icon: 'twitter', link: 'https://twitter.com/fuel_network' },
+      { icon: 'twitter', link: 'https://x.com/fuel_network' },
       { icon: 'discord', link: 'https://discord.com/invite/xfpK4Pe' },
     ],
     editLink: {


### PR DESCRIPTION
Update social media link from twitter.com to x.com to reflect the platform's rebranding while maintaining the same @fuel_network handle..

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
