### PR TITLE
fix: incorrect function coder offset usage

### DIFF
--- a/.changeset/nasty-carrots-report.md
+++ b/.changeset/nasty-carrots-report.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-coder": patch
+---
+
+fix: incorrect function coder offset usage

--- a/packages/abi-coder/src/FunctionFragment.ts
+++ b/packages/abi-coder/src/FunctionFragment.ts
@@ -105,11 +105,11 @@ export class FunctionFragment {
     const result = this.jsonFnOld.inputs.reduce(
       (obj: { decoded: unknown[]; offset: number }, input) => {
         const coder = AbiCoder.getCoder(this.jsonAbiOld, input, { encoding: this.encoding });
-        const [decodedValue, decodedValueByteSize] = coder.decode(bytes, obj.offset);
+        const [decodedValue, decodedOffset] = coder.decode(bytes, obj.offset);
 
         return {
           decoded: [...obj.decoded, decodedValue],
-          offset: decodedValueByteSize,
+          offset: decodedOffset,
         };
       },
       { decoded: [], offset: 0 }

--- a/packages/abi-coder/src/FunctionFragment.ts
+++ b/packages/abi-coder/src/FunctionFragment.ts
@@ -109,7 +109,7 @@ export class FunctionFragment {
 
         return {
           decoded: [...obj.decoded, decodedValue],
-          offset: obj.offset + decodedValueByteSize,
+          offset: decodedValueByteSize,
         };
       },
       { decoded: [], offset: 0 }

--- a/packages/fuel-gauge/src/abi/abi-script.test.ts
+++ b/packages/fuel-gauge/src/abi/abi-script.test.ts
@@ -1,0 +1,83 @@
+import { getRandomB256 } from 'fuels';
+import { launchTestNode } from 'fuels/test-utils';
+
+import { ScriptMainReturnStruct } from '../../test/typegen/scripts/ScriptMainReturnStruct';
+import type { ScriptMainReturnStructInputs } from '../../test/typegen/scripts/ScriptMainReturnStruct';
+import {
+  ScriptWithComplexArgs,
+  type AssetIdInput,
+  type ScriptWithComplexArgsInputs,
+} from '../../test/typegen/scripts/ScriptWithComplexArgs';
+import type { Vec } from '../../test/typegen/scripts/common';
+
+describe('abi-script', () => {
+  describe('decodeArguments', () => {
+    it('should decode arguments with a simple script', async () => {
+      using launched = await launchTestNode();
+      const {
+        wallets: [funder],
+      } = launched;
+
+      const args: ScriptMainReturnStructInputs = [1, { x: 2 }];
+
+      // Run script
+      const script = new ScriptMainReturnStruct(funder);
+      const tx = await script.functions.main(...args).call();
+      const { value, transactionResult } = await tx.waitForResult();
+      expect(value).toEqual({ x: 3 });
+
+      // Assert script data
+      const scriptData = transactionResult.transaction.scriptData;
+      if (!scriptData) {
+        throw new Error('No script data');
+      }
+
+      // Assert the decoded script data matches the input arguments
+      const fn = script.interface.getFunction('main');
+      const decoded = fn.decodeArguments(scriptData);
+      expect(decoded).toEqual(args);
+    });
+
+    it('should decode arguments with a complex script', async () => {
+      using launched = await launchTestNode();
+
+      const {
+        wallets: [wallet],
+      } = launched;
+
+      const arg1 = 100;
+      const arg2 = { bits: getRandomB256() };
+      const arg3 = 100;
+      const arg4 = [[{ bits: getRandomB256() }, { bits: getRandomB256() }, true]] as Vec<
+        [AssetIdInput, AssetIdInput, boolean]
+      >;
+      const arg5 = { Address: { bits: getRandomB256() } };
+      const arg6 = 100;
+
+      // Run script
+      const script = new ScriptWithComplexArgs(wallet);
+      const args: ScriptWithComplexArgsInputs = [arg1, arg2, arg3, arg4, arg5, arg6];
+      const tx = await script.functions.main(...args).call();
+      const { value, transactionResult } = await tx.waitForResult();
+      expect(value).toEqual(true);
+
+      // Assert script data
+      const scriptData = transactionResult.transaction.scriptData;
+      if (!scriptData) {
+        throw new Error('No script data');
+      }
+
+      // Assert the decoded script data matches the input arguments
+      const fn = script.interface.getFunction('main');
+      const decoded = fn.decodeArguments(scriptData);
+      expect(decoded).toEqual([
+        expect.toEqualBn(arg1),
+        arg2,
+        expect.toEqualBn(arg3),
+        arg4,
+        arg5,
+        expect.toEqualBn(arg6),
+      ]);
+    });
+  });
+});

--- a/packages/fuel-gauge/src/abi/abi-script.test.ts
+++ b/packages/fuel-gauge/src/abi/abi-script.test.ts
@@ -10,6 +10,10 @@ import {
 } from '../../test/typegen/scripts/ScriptWithComplexArgs';
 import type { Vec } from '../../test/typegen/scripts/common';
 
+/**
+ * @group browser
+ * @group node
+ */
 describe('abi-script', () => {
   describe('decodeArguments', () => {
     it('should decode arguments with a simple script', async () => {

--- a/packages/fuel-gauge/src/abi/abi-script.test.ts
+++ b/packages/fuel-gauge/src/abi/abi-script.test.ts
@@ -57,13 +57,21 @@ describe('abi-script', () => {
       >;
       const arg5 = { Address: { bits: getRandomB256() } };
       const arg6 = 100;
+      const expected = [
+        expect.toEqualBn(arg1),
+        arg2,
+        expect.toEqualBn(arg3),
+        arg4,
+        arg5,
+        expect.toEqualBn(arg6),
+      ];
 
       // Run script
       const script = new ScriptWithComplexArgs(wallet);
       const args: ScriptWithComplexArgsInputs = [arg1, arg2, arg3, arg4, arg5, arg6];
       const tx = await script.functions.main(...args).call();
       const { value, transactionResult } = await tx.waitForResult();
-      expect(value).toEqual(true);
+      expect(value).toEqual(expected);
 
       // Assert script data
       const scriptData = transactionResult.transaction.scriptData;
@@ -74,14 +82,7 @@ describe('abi-script', () => {
       // Assert the decoded script data matches the input arguments
       const fn = script.interface.getFunction('main');
       const decoded = fn.decodeArguments(scriptData);
-      expect(decoded).toEqual([
-        expect.toEqualBn(arg1),
-        arg2,
-        expect.toEqualBn(arg3),
-        arg4,
-        arg5,
-        expect.toEqualBn(arg6),
-      ]);
+      expect(decoded).toEqual(expected);
     });
   });
 });

--- a/packages/fuel-gauge/test/fixtures/forc-projects/Forc.toml
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/Forc.toml
@@ -64,6 +64,7 @@ members = [
   "script-with-more-configurable",
   "script-with-vector",
   "script-with-options",
+  "script-with-complex-args",
   "script-with-vector-advanced",
   "script-with-vector-mixed",
   "small-bytes",

--- a/packages/fuel-gauge/test/fixtures/forc-projects/script-with-complex-args/Forc.toml
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/script-with-complex-args/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "script-with-complex-args"
+
+[dependencies]

--- a/packages/fuel-gauge/test/fixtures/forc-projects/script-with-complex-args/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/script-with-complex-args/src/main.sw
@@ -1,0 +1,16 @@
+script;
+
+use std::bytes::Bytes;
+
+pub type PoolId = (AssetId, AssetId, bool);
+
+fn main(
+    amount_in: u64,
+    asset_in: AssetId,
+    amount_out_min: u64,
+    pools: Vec<PoolId>,
+    recipient: Identity,
+    deadline: u32,
+) -> bool {
+    return true;
+}

--- a/packages/fuel-gauge/test/fixtures/forc-projects/script-with-complex-args/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/script-with-complex-args/src/main.sw
@@ -2,7 +2,9 @@ script;
 
 use std::bytes::Bytes;
 
-pub type PoolId = (AssetId, AssetId, bool);
+type PoolId = (AssetId, AssetId, bool);
+
+type ScriptResult = (u64, AssetId, u64, Vec<PoolId>, Identity, u32);
 
 fn main(
     amount_in: u64,
@@ -11,6 +13,6 @@ fn main(
     pools: Vec<PoolId>,
     recipient: Identity,
     deadline: u32,
-) -> bool {
-    return true;
+) -> ScriptResult {
+    return (amount_in, asset_in, amount_out_min, pools, recipient, deadline);
 }


### PR DESCRIPTION
<!-- LINEAR: closes TS-787 -->
<!-- LINEAR: relates to  -->
- Closes #3587 

# Release notes

In this release, we:

- Fixed incorrect offset usage for `Interface.decodeArguments` function.

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
