### PR TITLE
chore: adjust commit conventions

### DIFF
--- a/.changeset/wet-goats-push.md
+++ b/.changeset/wet-goats-push.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore: adjust commit conventions

--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -39,10 +39,10 @@ jobs:
             feat
             fix
             chore
+            test
             build
             docs
             ci
-            rc
 
       - name: Check PR title length
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,7 +228,6 @@ pnpm bench:node
 pnpm bench:node packages/my-desired-package
 ```
 
-
 ### CI Test
 
 During the CI process an automated end-to-end (e2e) test is executed. This test is crucial as it simulates real-world scenarios on the current test-net, ensuring that the changeset maintains the expected functionality and stability.
@@ -268,11 +267,10 @@ When you create a commit we kindly ask you to follow the convention
 `category(scope or module): message` in your commit message while using one of
 the following categories:
 
-- `feat / feature`: all changes that introduce completely new code or new
+- `feat`: all changes that introduce completely new code or new
   features
 - `fix`: changes that fix a bug (ideally you will additionally reference an
   issue if present)
-- `refactor`: any code related change that is not a fix nor a feature
 - `docs`: changing existing or creating new documentation (i.e. README, docs for
   usage of a lib or cli usage)
 - `build`: all changes regarding the build of the software, changes to


### PR DESCRIPTION
# Summary

Updated commit conventions to align with the `CONTRIBUTING.md` guidelines. Removed the `rc` convention.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
