### PR TITLE
Typo fix in CHANGELOG.md

### DIFF
--- a/internal/forc/CHANGELOG.md
+++ b/internal/forc/CHANGELOG.md
@@ -118,7 +118,7 @@
 
 ### Minor Changes
 
-- Updated `forc` to verson `0.51.1`, by [@nedsalk](https://github.com/nedsalk) (See [#1804](https://github.com/FuelLabs/fuels-ts/pull/1804))
+- Updated `forc` to version `0.51.1`, by [@nedsalk](https://github.com/nedsalk) (See [#1804](https://github.com/FuelLabs/fuels-ts/pull/1804))
 
 ## 0.75.0
 


### PR DESCRIPTION
# Typo Fix in `CHANGELOG.md`

## Description

This pull request fixes a small typo in the `CHANGELOG.md` file. Specifically, the word **"verson"** was corrected to **"version"** in the entry describing the update of `forc` to version `0.51.1`.

### Changes Made:
1. **Fixed Typo**:
   - **"verson"** → **"version"**

