### PR TITLE
Typo fix CHANGELOG.md

### DIFF
--- a/packages/account/src/providers/CHANGELOG.md
+++ b/packages/account/src/providers/CHANGELOG.md
@@ -1136,7 +1136,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### 🚀 Features
 
 - add support to void return ([#181](https://github.com/FuelLabs/fuels-ts/issues/181))
-- call contract method with mutiple params ([#170](https://github.com/FuelLabs/fuels-ts/issues/170))
+- call contract method with multiple params ([#170](https://github.com/FuelLabs/fuels-ts/issues/170))
 - update abi code to support new syntax ([#169](https://github.com/FuelLabs/fuels-ts/issues/169))
 
 <a name="v0.3.0"></a>


### PR DESCRIPTION
# Pull Request: Typo Fix in `CHANGELOG.md`

## Description

This pull request addresses a typo in the `CHANGELOG.md` file. The word **"mutiple"** has been corrected to **"multiple"** in the description of a feature update.
