### PR TITLE
chore: bumped punycode

### DIFF
--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -8,7 +8,7 @@ jobs:
     name: "Release PR to npm"
     runs-on: ubuntu-latest
     # comment out if:false to enable release PR to npm
-    if: false
+    # if: false
     permissions: write-all
     steps:
       - name: Checkout

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -62,7 +62,7 @@
     "@noble/curves": "1.6.0",
     "events": "3.3.0",
     "graphql": "16.9.0",
-    "graphql-request": "6.1.0",
+    "graphql-request": "6.2.0-next.4",
     "graphql-tag": "2.12.6",
     "ramda": "0.30.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,8 +679,8 @@ importers:
         specifier: 16.9.0
         version: 16.9.0
       graphql-request:
-        specifier: 6.1.0
-        version: 6.1.0(graphql@16.9.0)
+        specifier: 6.2.0-next.4
+        version: 6.2.0-next.4(graphql@16.9.0)
       graphql-tag:
         specifier: 2.12.6
         version: 2.12.6(graphql@16.9.0)
@@ -8726,6 +8726,11 @@ packages:
 
   graphql-request@6.1.0:
     resolution: {integrity: sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==}
+    peerDependencies:
+      graphql: 14 - 16
+
+  graphql-request@6.2.0-next.4:
+    resolution: {integrity: sha512-jkr/lHxvHF6PYG6Hpf5vFyRJ48hKw0asASQHAtmik96M8Xsf4IiF3NjolkbMGS9FER+RnezSCuVOD+Y8LS6FpQ==}
     peerDependencies:
       graphql: 14 - 16
 
@@ -24533,6 +24538,14 @@ snapshots:
       - utf-8-validate
 
   graphql-request@6.1.0(graphql@16.9.0):
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
+      cross-fetch: 4.0.0
+      graphql: 16.9.0
+    transitivePeerDependencies:
+      - encoding
+
+  graphql-request@6.2.0-next.4(graphql@16.9.0):
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
       cross-fetch: 4.0.0


### PR DESCRIPTION
- Related to #2907
- Related to #3546 

# Summary

- Found a version of `graphql-request` that is still `CJS` compatibility but with updated dependencies.
- It is an unofficial `6.2.0-next.4` tag, so will [create an issue](https://github.com/graffle-js/graffle/issues) to obtain a proper release, if we can resolve the `punycode` warning.

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
