### PR TITLE
feat: allow passing `gasPrice` to `getTransactionCost`

### DIFF
--- a/.changeset/clever-mirrors-jam.md
+++ b/.changeset/clever-mirrors-jam.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/account": patch
+"@fuel-ts/program": patch
+---
+
+feat: allow passing `gasPrice` to `getTransactionCost`

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -552,7 +552,7 @@ export class Account extends AbstractAccount implements WithAddress {
    */
   async getTransactionCost(
     transactionRequestLike: TransactionRequestLike,
-    { signatureCallback, quantities = [] }: TransactionCostParams = {}
+    { signatureCallback, quantities = [], gasPrice }: TransactionCostParams = {}
   ): Promise<TransactionCost> {
     const txRequestClone = clone(transactionRequestify(transactionRequestLike));
     const baseAssetId = await this.provider.getBaseAssetId();
@@ -603,6 +603,7 @@ export class Account extends AbstractAccount implements WithAddress {
 
     const txCost = await this.provider.getTransactionCost(txRequestClone, {
       signatureCallback,
+      gasPrice,
     });
 
     return {

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -354,6 +354,30 @@ export type TransactionCostParams = EstimateTransactionParams & {
    * @returns A promise that resolves to the signed transaction request.
    */
   signatureCallback?: (request: ScriptTransactionRequest) => Promise<ScriptTransactionRequest>;
+
+  /**
+   * The gas price to use for the transaction.
+   */
+  gasPrice?: BN;
+};
+
+export type EstimateTxDependenciesParams = {
+  /**
+   * The gas price to use for the transaction.
+   */
+  gasPrice?: BN;
+};
+
+export type EstimateTxGasAndFeeParams = {
+  /**
+   * The transaction request to estimate the gas and fee for.
+   */
+  transactionRequest: TransactionRequest;
+
+  /**
+   * The gas price to use for the transaction.
+   */
+  gasPrice?: BN;
 };
 
 /**
@@ -971,10 +995,12 @@ export default class Provider {
    * `addVariableOutputs` is called on the transaction.
    *
    * @param transactionRequest - The transaction request object.
+   * @param gasPrice - The gas price to use for the transaction, if not provided it will be fetched.
    * @returns A promise that resolves to the estimate transaction dependencies.
    */
   async estimateTxDependencies(
-    transactionRequest: TransactionRequest
+    transactionRequest: TransactionRequest,
+    { gasPrice: gasPriceParam }: EstimateTxDependenciesParams = {}
   ): Promise<EstimateTxDependenciesReturns> {
     if (isTransactionTypeCreate(transactionRequest)) {
       return {
@@ -991,13 +1017,15 @@ export default class Provider {
 
     await this.validateTransaction(transactionRequest);
 
+    const gasPrice = gasPriceParam ?? (await this.estimateGasPrice(10));
+
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       const {
         dryRun: [{ receipts: rawReceipts, status }],
       } = await this.operations.dryRun({
         encodedTransactions: [hexlify(transactionRequest.toTransactionBytes())],
         utxoValidation: false,
-        gasPrice: '0',
+        gasPrice: gasPrice.toString(),
       });
 
       receipts = rawReceipts.map(processGqlReceipt);
@@ -1019,7 +1047,7 @@ export default class Provider {
 
         const { maxFee } = await this.estimateTxGasAndFee({
           transactionRequest,
-          gasPrice: bn(0),
+          gasPrice,
         });
 
         // eslint-disable-next-line no-param-reassign
@@ -1186,12 +1214,12 @@ export default class Provider {
 
   /**
    * Estimates the transaction gas and fee based on the provided transaction request.
-   * @param transactionRequest - The transaction request object.
+   * @param params - The parameters for estimating the transaction gas and fee.
    * @returns An object containing the estimated minimum gas, minimum fee, maximum gas, and maximum fee.
    */
-  async estimateTxGasAndFee(params: { transactionRequest: TransactionRequest; gasPrice?: BN }) {
-    const { transactionRequest } = params;
-    let { gasPrice } = params;
+  async estimateTxGasAndFee(params: EstimateTxGasAndFeeParams) {
+    const { transactionRequest, gasPrice: gasPriceParam } = params;
+    let gasPrice = gasPriceParam;
 
     await this.autoRefetchConfigs();
 
@@ -1307,7 +1335,7 @@ export default class Provider {
    */
   async getTransactionCost(
     transactionRequestLike: TransactionRequestLike,
-    { signatureCallback }: TransactionCostParams = {}
+    { signatureCallback, gasPrice: gasPriceParam }: TransactionCostParams = {}
   ): Promise<Omit<TransactionCost, 'requiredQuantities'>> {
     const txRequestClone = clone(transactionRequestify(transactionRequestLike));
     const updateMaxFee = txRequestClone.maxFee.eq(0);
@@ -1329,12 +1357,16 @@ export default class Provider {
     await this.estimatePredicates(signedRequest);
     txRequestClone.updatePredicateGasUsed(signedRequest.inputs);
 
+    const gasPrice = gasPriceParam ?? (await this.estimateGasPrice(10));
+
     /**
      * Calculate minGas and maxGas based on the real transaction
      */
     // eslint-disable-next-line prefer-const
-    let { maxFee, maxGas, minFee, minGas, gasPrice, gasLimit } = await this.estimateTxGasAndFee({
+    let { maxFee, maxGas, minFee, minGas, gasLimit } = await this.estimateTxGasAndFee({
+      // Fetches and returns a gas price
       transactionRequest: signedRequest,
+      gasPrice,
     });
 
     let receipts: TransactionResultReceipt[] = [];
@@ -1351,7 +1383,7 @@ export default class Provider {
       }
 
       ({ receipts, missingContractIds, outputVariables, dryRunStatus } =
-        await this.estimateTxDependencies(txRequestClone));
+        await this.estimateTxDependencies(txRequestClone, { gasPrice }));
 
       if (dryRunStatus && 'reason' in dryRunStatus) {
         throw this.extractDryRunError(txRequestClone, receipts, dryRunStatus);
@@ -1363,7 +1395,7 @@ export default class Provider {
       gasUsed = bn(pristineGasUsed.muln(GAS_USED_MODIFIER)).max(maxGasPerTx.sub(minGas));
       txRequestClone.gasLimit = gasUsed;
 
-      ({ maxFee, maxGas, minFee, minGas, gasPrice } = await this.estimateTxGasAndFee({
+      ({ maxFee, maxGas, minFee, minGas } = await this.estimateTxGasAndFee({
         transactionRequest: txRequestClone,
         gasPrice,
       }));

--- a/packages/program/src/functions/base-invocation-scope.ts
+++ b/packages/program/src/functions/base-invocation-scope.ts
@@ -224,7 +224,6 @@ export class BaseInvocationScope<TReturn = any> {
   /**
    * Gets the transaction cost for dry running the transaction.
    *
-   * @param options - Optional transaction cost options.
    * @returns The transaction cost details.
    */
   async getTransactionCost(): Promise<TransactionCost> {


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #3607 
- Relates to #3577 
-->

# Release notes

In this release, we:

- Allowed passing `gasPrice` to `getTransactionCost` functions to reduce possible network calls

# Summary

In the Fuel Wallet, a user can set a custom gas limit or tip for a transaction. It then checks if that changes the fee. If it has, it will re-estimate and fund the transaction. 

This leads to two gas price fetches. One in the initial fee calculation, and one in the re-estimation. 

By allowing the `getTransactionCost` to take a `gasPrice` parameter, we can reduce the number of network calls for this flow.

The expected flow could then look like so:

```ts
// Some user input that could change the fee
const tip = userInput.tip;
transactionRequest.tip = tip;

// Calculate the new fee, also fetches and returns the gas price
const { maxFee, gasPrice } = await provider.estimateTxGasAndFee({
    transactionRequest,
});

// Check if the fee has increased and if so, re-estimate and re-fund
if (maxFee.gt(transactionRequest.maxFee)) {
    const cost = await wallet.getTransactionCost(proposedTxRequest, {
        estimateTxDependencies: true,
        gasPrice, // passing this means we will not fetch gas price again
    });
    await wallet.fund(proposedTxRequest, { cost });
}
```

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
