### PR TITLE
ci: configure timeout for docs and lint jobs

### DIFF
--- a/.changeset/young-queens-juggle.md
+++ b/.changeset/young-queens-juggle.md
@@ -1,0 +1,4 @@
+---
+---
+
+ci: configure timeout for docs and lint jobs

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -13,10 +13,10 @@ concurrency:
 jobs:
   docs:
     uses: FuelLabs/github-actions/.github/workflows/vp-docs.yml@master
+    timeout-minutes: 15
     with:
       doc-folder-path: "apps/docs/src"
       spellcheck-config-path: "apps/docs/.spellcheck.yml"
-      timeout-minutes: 15
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -16,10 +16,12 @@ jobs:
     with:
       doc-folder-path: "apps/docs/src"
       spellcheck-config-path: "apps/docs/.spellcheck.yml"
+      timeout-minutes: 15
 
   lint:
     runs-on: ubuntu-latest
     name: Lint
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   docs:
     uses: FuelLabs/github-actions/.github/workflows/vp-docs.yml@master
-    timeout-minutes: 15
     with:
       doc-folder-path: "apps/docs/src"
       spellcheck-config-path: "apps/docs/.spellcheck.yml"


### PR DESCRIPTION
- Closes #3596 

# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

- Set the `timeout-minutes` for CI jobs:  **30** minutes for `lint`, enhancing build efficiency and preventing excessive runtime

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
