### PR TITLE
Typo fix test-node-options.md

### DIFF
--- a/apps/docs/src/guide/testing/test-node-options.md
+++ b/apps/docs/src/guide/testing/test-node-options.md
@@ -30,7 +30,7 @@ The `TestAssetId` utility integrates with [`walletsConfig`](./test-node-options.
 
 ### `walletsConfig.messages`
 
-The `TestMessage` helper class is used to create messages for testing purposes. When passed via `walletsConfig.messages`, the `recipient` field of the message is overriden to be the wallet's address.
+The `TestMessage` helper class is used to create messages for testing purposes. When passed via `walletsConfig.messages`, the `recipient` field of the message is overridden to be the wallet's address.
 
 <<< @./snippets/launching-a-test-node.ts#test-messages{ts:line-numbers}
 


### PR DESCRIPTION
# Typo Fix in `test-node-options.md`

## Description
This pull request addresses a minor typo in the `test-node-options.md` file. The word "overriden" was corrected to "overridden" to ensure proper spelling.

## Changes
- Corrected the typo in the documentation:
  - "overriden" -> "overridden" in the description of the `walletsConfig.messages` field.
