### PR TITLE
docs: use `new Address` in favor of deprecated method

### DIFF
--- a/.changeset/soft-poems-reflect.md
+++ b/.changeset/soft-poems-reflect.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: use `new Address` in favor of deprecated method

--- a/apps/create-fuels-counter-guide/src/components/LocalFaucet.tsx
+++ b/apps/create-fuels-counter-guide/src/components/LocalFaucet.tsx
@@ -25,7 +25,7 @@ export default function LocalFaucet({ refetch, addressToFund }: Props) {
         wallet.provider,
       );
       const tx = await genesis.transfer(
-        Address.fromB256(addressToFund || wallet.address.toB256()),
+        new Address(addressToFund || wallet.address.toB256()),
         bn(5_000_000_000),
       );
       transactionSubmitNotification(tx.id);

--- a/apps/docs/src/guide/types/b256.md
+++ b/apps/docs/src/guide/types/b256.md
@@ -16,6 +16,6 @@ To convert between a `B256` hexlified string and a `Uint8Array`, you can use the
 
 ## Support from `Address` Class
 
-A `B256` value is also supported as part of the [`Address`](https://fuels-ts-docs-api.vercel.app/classes/_fuel_ts_address.Address.html) class, providing seamless integration with other components of your application. To create an [`Address`](https://fuels-ts-docs-api.vercel.app/classes/_fuel_ts_address.Address.html) instance from a b256 value, use the `Address.fromB256()` method:
+A `B256` value is also supported as part of the [`Address`](https://fuels-ts-docs-api.vercel.app/classes/_fuel_ts_address.Address.html) class, providing seamless integration with other components of your application. To create an [`Address`](https://fuels-ts-docs-api.vercel.app/classes/_fuel_ts_address.Address.html) instance from a b256 value, use the `new Address()` method:
 
 <<< @./snippets/b256/support-from-address-class.ts#full{ts:line-numbers}

--- a/apps/docs/src/guide/wallets/wallet-transferring.md
+++ b/apps/docs/src/guide/wallets/wallet-transferring.md
@@ -42,7 +42,7 @@ When transferring assets to a deployed contract, we use the `transferToContract`
 
 However, instead of supplying the target wallet's address, as done in `destination.address` for the transfer method, we need to provide an instance of [Address](../types/address.md) created from the deployed contract id.
 
-If you have the [Contract](../contracts/) instance of the deployed contract, you can simply use its `id` property. However, if the contract was deployed with `forc deploy` or not by you, you will likely only have its ID in a hex string format. In such cases, you can create an [Address](../types/address.md) instance from the contract ID using `Address.fromAddressOrString('0x123...')`.
+If you have the [Contract](../contracts/) instance of the deployed contract, you can simply use its `id` property. However, if the contract was deployed with `forc deploy` or not by you, you will likely only have its ID in a hex string format. In such cases, you can create an [Address](../types/address.md) instance from the contract ID using `new Address('0x123...')`.
 
 Here's an example demonstrating how to use `transferToContract`:
 


### PR DESCRIPTION
# Summary

Using `new Address` on docs instead of deprecated methods

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
