### PR TITLE
fix: s3 publishing

### DIFF
--- a/.changeset/plenty-beds-bake.md
+++ b/.changeset/plenty-beds-bake.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+Migrating CDN hostname from `cdn.fuel.network` to `assets.fuel.network`.

--- a/.changeset/plenty-beds-bake.md
+++ b/.changeset/plenty-beds-bake.md
@@ -2,4 +2,4 @@
 "@fuel-ts/account": patch
 ---
 
-Migrating CDN hostname from `cdn.fuel.network` to `assets.fuel.network`.
+fix: s3 publishing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,19 +166,17 @@ jobs:
           rootdir: ""
           workdir: ""
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         if: github.ref_name == 'master' && steps.changesets.outputs.published != 'true'
         with:
-          aws-access-key-id: ${{ secrets.S3_CDN_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.S3_CDN_SECRET_KEY }}
-          aws-region: us-east-1
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_S3_REGION }}
 
       - name: Upload assets to s3
         if: github.ref_name == 'master' && steps.changesets.outputs.published != 'true'
         run: |
-          aws s3 cp ./packages/account/src/providers/assets/images/ s3://${S3_CDN_BUCKET}/assets/ --recursive
-        env:
-          S3_CDN_BUCKET: ${{ secrets.S3_CDN_BUCKET }}
+          aws s3 cp ./packages/account/src/providers/assets/images/ s3://${{ env.AWS_S3_BUCKET }}/providers/ --recursive
 
       # # Commenting out as we require permissions to trigger across repos
       # - name: Notify migrations and disclosures of the new release (breaking changes)

--- a/apps/docs/src/guide/wallets/snippets/connectors.ts
+++ b/apps/docs/src/guide/wallets/snippets/connectors.ts
@@ -99,7 +99,7 @@ class WalletConnector extends FuelConnector {
       {
         name: 'Ethereum',
         symbol: 'ETH',
-        icon: 'https://cdn.fuel.network/assets/eth.svg',
+        icon: 'https://assets.fuel.network/providers/eth.svg',
         networks: [
           {
             type: 'ethereum',

--- a/packages/account/src/providers/assets/assets.test.ts
+++ b/packages/account/src/providers/assets/assets.test.ts
@@ -10,6 +10,6 @@ describe('assets', async () => {
   });
 
   it.each(assets)('$symbol should have icon resolved to URL', async ({ icon }) => {
-    expect(icon).toContain('https://cdn.fuel.network/assets');
+    expect(icon).toContain('https://assets.fuel.network/providers');
   });
 });

--- a/packages/account/src/providers/assets/utils/fuelAssetsBaseUrl.ts
+++ b/packages/account/src/providers/assets/utils/fuelAssetsBaseUrl.ts
@@ -1,1 +1,1 @@
-export const fuelAssetsBaseUrl = 'https://cdn.fuel.network/assets/'
+export const fuelAssetsBaseUrl = 'https://assets.fuel.network/providers/'

--- a/packages/account/src/providers/assets/utils/network.test.ts
+++ b/packages/account/src/providers/assets/utils/network.test.ts
@@ -19,7 +19,7 @@ describe('Network Utils', () => {
       type: 'ethereum',
       chainId: CHAIN_IDS.eth.sepolia,
       decimals: 18,
-      icon: 'https://cdn.fuel.network/assets/eth.svg',
+      icon: 'https://assets.fuel.network/providers/eth.svg',
       name: 'Ethereum',
       symbol: 'ETH'
     })
@@ -33,7 +33,7 @@ describe('Network Utils', () => {
       chainId: CHAIN_IDS.fuel.testnet,
       decimals: 9,
       assetId: '0xf8f8b6283d7fa5b672b530cbb84fcccb4ff8dc40f8176ef4544ddb1f1952ad07',
-      icon: 'https://cdn.fuel.network/assets/eth.svg',
+      icon: 'https://assets.fuel.network/providers/eth.svg',
       name: 'Ethereum',
       symbol: 'ETH'
     })
@@ -52,7 +52,7 @@ describe('Network Utils', () => {
       type: 'ethereum',
       chainId: CHAIN_IDS.eth.sepolia,
       decimals: 18,
-      icon: 'https://cdn.fuel.network/assets/eth.svg',
+      icon: 'https://assets.fuel.network/providers/eth.svg',
       name: 'Ethereum',
       symbol: 'ETH',
     })
@@ -67,7 +67,7 @@ describe('Network Utils', () => {
       chainId: CHAIN_IDS.fuel.testnet,
       decimals: 9,
       assetId: '0xf8f8b6283d7fa5b672b530cbb84fcccb4ff8dc40f8176ef4544ddb1f1952ad07',
-      icon: 'https://cdn.fuel.network/assets/eth.svg',
+      icon: 'https://assets.fuel.network/providers/eth.svg',
       name: 'Ethereum',
       symbol: 'ETH',
     })

--- a/packages/fuel-gauge/src/e2e-script.test.ts
+++ b/packages/fuel-gauge/src/e2e-script.test.ts
@@ -219,7 +219,7 @@ describe.each(selectedNetworks)('Live Script Test', (selectedNetwork) => {
     const expectedBaseAsset = [
       {
         ...expectedRawBaseAsset[0],
-        icon: 'https://cdn.fuel.network/assets/eth.svg',
+        icon: 'https://assets.fuel.network/providers/eth.svg',
       },
     ];
 


### PR DESCRIPTION
# Release notes

In this release, we:

- Migrated CDN host from `cdn.fuel.network` to `assets.fuel.network`

# Summary

This PR updates the GitHub release workflow to publish to our assets CDN endpoint. It also migrates the flow to using OIDC-based AWS authentication instead of static access keys.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
