### PR TITLE
fix: use GitHub vars instead of env vars

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,13 +170,13 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         if: github.ref_name == 'master' && steps.changesets.outputs.published != 'true'
         with:
-          role-to-assume: ${{ env.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_S3_REGION }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_S3_REGION }}
 
       - name: Upload assets to s3
         if: github.ref_name == 'master' && steps.changesets.outputs.published != 'true'
         run: |
-          aws s3 cp ./packages/account/src/assets/images/ s3://${{ env.AWS_S3_BUCKET }}/providers/ --recursive
+          aws s3 cp ./packages/account/src/assets/images/ s3://${{ vars.AWS_S3_BUCKET }}/providers/ --recursive
 
       # # Commenting out as we require permissions to trigger across repos
       # - name: Notify migrations and disclosures of the new release (breaking changes)


### PR DESCRIPTION
# Summary

This PR updates the values in the GitHub release workflow to source values from GitHub variables and not environment variables.

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
