### PR TITLE
chore!: remove `pageInfo` from `getBalances` GraphQl operations

### DIFF
--- a/.changeset/big-dragons-count.md
+++ b/.changeset/big-dragons-count.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": minor
+---
+
+chore!: remove `pageInfo` from `getBalances` GraphQl operations

--- a/packages/account/src/providers/operations.graphql
+++ b/packages/account/src/providers/operations.graphql
@@ -693,9 +693,6 @@ query getBalances(
     first: $first
     last: $last
   ) {
-    pageInfo {
-      ...pageInfoFragment
-    }
     edges {
       node {
         assetId

--- a/packages/account/src/providers/provider.test.ts
+++ b/packages/account/src/providers/provider.test.ts
@@ -2487,4 +2487,23 @@ describe('Provider', () => {
 
     vi.restoreAllMocks();
   });
+
+  it('should ensures getBalances query does not returns pageInfo', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const {
+      provider,
+      wallets: [wallet],
+    } = launched;
+
+    const { balances } = await provider.operations.getBalances({
+      first: 10000,
+      filter: { owner: wallet.address.toB256() },
+    });
+
+    const keys = Object.keys(balances);
+
+    expect(keys.includes('edges')).toBeTruthy();
+
+    expect(keys.includes('pageInfo')).toBeFalsy();
+  });
 });

--- a/packages/account/src/providers/provider.test.ts
+++ b/packages/account/src/providers/provider.test.ts
@@ -2496,7 +2496,7 @@ describe('Provider', () => {
     } = launched;
 
     const { balances } = await provider.operations.getBalances({
-      first: 10000,
+      first: 100,
       filter: { owner: wallet.address.toB256() },
     });
 


### PR DESCRIPTION
- Closes #3651

# Release notes

In this release, we:

- Removed `pageInfo` from `provider.operations.getBalances` response

# Summary

<!--
Please write a summary of your changes and why you made them.
Not all PRs will be complex or substantial enough to require this
section, so you can remove it if you think it's unnecessary.
-->

# Breaking Changes

The `pageInfo` field has been removed from the response of the `provider.operations.getBalances` query.

```ts
// before
const { balances, pageInfo } = await provider.operations.getBalances({
  first: 100,
  filter: { owner: wallet.address.toB256() },
});
```

```ts
// after
const { balances } = await provider.operations.getBalances({
  first: 100,
  filter: { owner: wallet.address.toB256() },
});
```

The `getBalances` method of the Provider class remains unchanged, as it never returned pageInfo:

```ts
// not affected
const { balances } = await provider.getBalances();
```

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
