### PR TITLE
fix: bind `waitForResult` in `TransactionResponse`

### DIFF
--- a/.changeset/brown-chairs-tickle.md
+++ b/.changeset/brown-chairs-tickle.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+fix: bind `waitForResult` in `TransactionResponse`

--- a/packages/account/src/providers/transaction-response/transaction-response.ts
+++ b/packages/account/src/providers/transaction-response/transaction-response.ts
@@ -155,6 +155,8 @@ export class TransactionResponse {
     this.provider = provider;
     this.abis = abis;
     this.request = typeof tx === 'string' ? undefined : tx;
+
+    this.waitForResult = this.waitForResult.bind(this);
   }
 
   /**

--- a/packages/fuel-gauge/src/advanced-logging.test.ts
+++ b/packages/fuel-gauge/src/advanced-logging.test.ts
@@ -235,9 +235,11 @@ describe('Advanced Logging', () => {
 
       await request.estimateAndFund(wallet);
 
-      const tx = await wallet.sendTransaction(request, { estimateTxDependencies: false });
+      const { waitForResult } = await wallet.sendTransaction(request, {
+        estimateTxDependencies: false,
+      });
 
-      const { logs } = await tx.waitForResult();
+      const { logs } = await waitForResult();
 
       expect(logs).toBeDefined();
 
@@ -309,9 +311,9 @@ describe('Advanced Logging', () => {
 
       await request.estimateAndFund(wallet);
 
-      const tx = await wallet.sendTransaction(request);
+      const { waitForResult } = await wallet.sendTransaction(request);
 
-      const { logs } = await tx.waitForResult();
+      const { logs } = await waitForResult();
 
       expect(logs).toBeDefined();
 

--- a/packages/fuel-gauge/src/await-execution.test.ts
+++ b/packages/fuel-gauge/src/await-execution.test.ts
@@ -34,8 +34,8 @@ describe('await-execution', () => {
       await genesisWallet.signTransaction(transfer)
     );
 
-    const response = await provider.sendTransaction(transfer);
-    const { isStatusSuccess } = await response.waitForResult();
+    const { waitForResult } = await provider.sendTransaction(transfer);
+    const { isStatusSuccess } = await waitForResult();
 
     expect(isStatusSuccess).toBe(true);
   });

--- a/packages/fuel-gauge/src/doc-examples.test.ts
+++ b/packages/fuel-gauge/src/doc-examples.test.ts
@@ -273,7 +273,7 @@ describe('Doc Examples', () => {
 
     const assetId = await provider.getBaseAssetId();
 
-    const submitted = await fundingWallet.batchTransfer([
+    const { waitForResult } = await fundingWallet.batchTransfer([
       {
         amount: 1_000_000,
         destination: wallet1.address,
@@ -291,7 +291,7 @@ describe('Doc Examples', () => {
       },
     ]);
 
-    await submitted.waitForResult();
+    await waitForResult();
 
     const receiver = Wallet.generate({ provider });
 

--- a/packages/fuel-gauge/src/min-gas.test.ts
+++ b/packages/fuel-gauge/src/min-gas.test.ts
@@ -63,8 +63,8 @@ describe('Minimum gas tests', () => {
     /**
      * Send transaction
      */
-    const result = await wallet.sendTransaction(request);
-    const { status } = await result.waitForResult();
+    const { waitForResult } = await wallet.sendTransaction(request);
+    const { status } = await waitForResult();
 
     expect(status).toBe(TransactionStatus.success);
   });
@@ -149,8 +149,8 @@ describe('Minimum gas tests', () => {
     /**
      * Send transaction predicate
      */
-    const result = await predicate.sendTransaction(request);
-    const { status, receipts } = await result.waitForResult();
+    const { waitForResult } = await predicate.sendTransaction(request);
+    const { status, receipts } = await waitForResult();
     const gasUsedFromReceipts = getGasUsedFromReceipts(receipts);
 
     expect(status).toBe(TransactionStatus.success);

--- a/packages/fuel-gauge/src/predicate/predicate-populate-witness.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-populate-witness.test.ts
@@ -73,9 +73,9 @@ describe('Predicate', () => {
       transactionRequest.gasLimit = bn(100_000);
       transactionRequest.maxFee = bn(120_000);
 
-      const tx = await provider.sendTransaction(transactionRequest);
+      const { waitForResult } = await provider.sendTransaction(transactionRequest);
 
-      const { isStatusSuccess } = await tx.waitForResult();
+      const { isStatusSuccess } = await waitForResult();
 
       expect(isStatusSuccess).toBeTruthy();
     });
@@ -129,9 +129,9 @@ describe('Predicate', () => {
 
       transactionRequest = await wallet1.populateTransactionWitnessesSignature(transactionRequest);
 
-      const tx = await provider.sendTransaction(transactionRequest);
+      const { waitForResult } = await provider.sendTransaction(transactionRequest);
 
-      const { isStatusSuccess } = await tx.waitForResult();
+      const { isStatusSuccess } = await waitForResult();
 
       expect(isStatusSuccess).toBeTruthy();
     });
@@ -201,9 +201,9 @@ describe('Predicate', () => {
       transactionRequest = await wallet1.populateTransactionWitnessesSignature(transactionRequest);
       transactionRequest = await wallet2.populateTransactionWitnessesSignature(transactionRequest);
 
-      const tx = await provider.sendTransaction(transactionRequest);
+      const { waitForResult } = await provider.sendTransaction(transactionRequest);
 
-      const { isStatusSuccess } = await tx.waitForResult();
+      const { isStatusSuccess } = await waitForResult();
 
       expect(isStatusSuccess).toBeTruthy();
     });
@@ -296,9 +296,9 @@ describe('Predicate', () => {
       transactionRequest = await wallet2.populateTransactionWitnessesSignature(transactionRequest);
       transactionRequest = await wallet3.populateTransactionWitnessesSignature(transactionRequest);
 
-      const tx = await provider.sendTransaction(transactionRequest);
+      const { waitForResult } = await provider.sendTransaction(transactionRequest);
 
-      const { isStatusSuccess } = await tx.waitForResult();
+      const { isStatusSuccess } = await waitForResult();
 
       expect(isStatusSuccess).toBeTruthy();
     });
@@ -378,9 +378,9 @@ describe('Predicate', () => {
       transactionRequest = await wallet1.populateTransactionWitnessesSignature(transactionRequest);
       transactionRequest = await wallet2.populateTransactionWitnessesSignature(transactionRequest);
 
-      const tx = await provider.sendTransaction(transactionRequest);
+      const { waitForResult } = await provider.sendTransaction(transactionRequest);
 
-      const { isStatusSuccess } = await tx.waitForResult();
+      const { isStatusSuccess } = await waitForResult();
 
       expect(isStatusSuccess).toBeTruthy();
     });
@@ -472,9 +472,9 @@ describe('Predicate', () => {
       transactionRequest = await wallet2.populateTransactionWitnessesSignature(transactionRequest);
       transactionRequest = await wallet3.populateTransactionWitnessesSignature(transactionRequest);
 
-      const tx = await provider.sendTransaction(transactionRequest);
+      const { waitForResult } = await provider.sendTransaction(transactionRequest);
 
-      const { isStatusSuccess } = await tx.waitForResult();
+      const { isStatusSuccess } = await waitForResult();
 
       expect(isStatusSuccess).toBeTruthy();
     });

--- a/packages/fuel-gauge/src/str-slice.test.ts
+++ b/packages/fuel-gauge/src/str-slice.test.ts
@@ -47,13 +47,21 @@ describe('str slice', () => {
     const amountToPredicate = 250_000;
     const amountToReceiver = 50_000;
 
-    const setupTx = await sender.transfer(predicate.address, amountToPredicate, baseAssetId);
-    await setupTx.waitForResult();
+    const { waitForResult: setupTx } = await sender.transfer(
+      predicate.address,
+      amountToPredicate,
+      baseAssetId
+    );
+    await setupTx();
 
     const initialReceiverBalance = await receiver.getBalance();
 
-    const tx = await predicate.transfer(receiver.address, amountToReceiver, baseAssetId);
-    const { isStatusSuccess } = await tx.waitForResult();
+    const { waitForResult } = await predicate.transfer(
+      receiver.address,
+      amountToReceiver,
+      baseAssetId
+    );
+    const { isStatusSuccess } = await waitForResult();
     const finalReceiverBalance = await receiver.getBalance();
     expect(bn(initialReceiverBalance).add(amountToReceiver).toHex()).toEqual(
       finalReceiverBalance.toHex()

--- a/packages/fuel-gauge/src/transaction-response.test.ts
+++ b/packages/fuel-gauge/src/transaction-response.test.ts
@@ -1,9 +1,9 @@
 import { ErrorCode } from '@fuel-ts/errors';
-import { TransactionResponse, Wallet, ScriptTransactionRequest, buildFunctionResult } from 'fuels';
+import { TransactionResponse, Wallet, ScriptTransactionRequest } from 'fuels';
 import { expectToThrowFuelError, launchTestNode } from 'fuels/test-utils';
 import type { MockInstance } from 'vitest';
 
-import { CallTestContract, CallTestContractFactory } from '../test/typegen';
+import { CallTestContractFactory } from '../test/typegen';
 
 async function verifyKeepAliveMessageWasSent(subscriptionStream: ReadableStream<Uint8Array>) {
   const decoder = new TextDecoder();

--- a/packages/fuel-gauge/src/transaction.test.ts
+++ b/packages/fuel-gauge/src/transaction.test.ts
@@ -76,9 +76,9 @@ describe('Transaction', () => {
 
     await request.estimateAndFund(fundedWallet);
 
-    const tx = await fundedWallet.sendTransaction(request);
+    const { waitForResult } = await fundedWallet.sendTransaction(request);
 
-    const { isStatusSuccess } = await tx.waitForResult();
+    const { isStatusSuccess } = await waitForResult();
 
     // Wait for message status to update
     await sleep(1000);
@@ -127,9 +127,9 @@ describe('Transaction', () => {
 
     await request.estimateAndFund(fundedWallet);
 
-    const tx = await fundedWallet.sendTransaction(request);
+    const { waitForResult } = await fundedWallet.sendTransaction(request);
 
-    const { isStatusSuccess } = await tx.waitForResult();
+    const { isStatusSuccess } = await waitForResult();
 
     // Wait for message status to update
     await sleep(1000);
@@ -166,10 +166,10 @@ describe('Transaction', () => {
 
     await request.estimateAndFund(sender);
 
-    const tx = await sender.sendTransaction(request, {
+    const { waitForResult } = await sender.sendTransaction(request, {
       enableAssetBurn: true,
     });
-    const { isStatusSuccess } = await tx.waitForResult();
+    const { isStatusSuccess } = await waitForResult();
     expect(isStatusSuccess).toEqual(true);
     expect(request.outputs).to.not.contain(
       expect.objectContaining({
@@ -254,10 +254,10 @@ describe('Transaction', () => {
 
     await request.estimateAndFund(owner);
 
-    const tx = await owner.sendTransaction(request, {
+    const { waitForResult } = await owner.sendTransaction(request, {
       enableAssetBurn: true,
     });
-    const { isStatusSuccess } = await tx.waitForResult();
+    const { isStatusSuccess } = await waitForResult();
     expect(isStatusSuccess).toEqual(true);
     expect(request.outputs).to.not.contain(
       expect.objectContaining({


### PR DESCRIPTION
- Closes #3659

# Release notes

In this release, we:

- Fixed a de-structuring issue when calling `waitForResult` on a submitted transaction

# Summary

- Binds `waitForResult` to the `TransactionResponse` to defend against de-structuring problems
- Added result de-structuring to a few different tests

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
