### PR TITLE
chore: `@fuel-ts/recipes` now correctly bumped on release

### DIFF
--- a/.changeset/empty-pigs-talk.md
+++ b/.changeset/empty-pigs-talk.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: `@fuel-ts/recipes` now correctly bumped on release

--- a/scripts/changeset/changeset-version-with-docs.ts
+++ b/scripts/changeset/changeset-version-with-docs.ts
@@ -24,21 +24,21 @@ import { error } from 'console';
     execSync(`pnpm -C packages/versions build`);
 
     // Invoke fuels' build:proxy script (will rewrite header versions in generated files)
-    execSync(`pnpm -C packages/fuels build:proxy`);
+    execSync(`pnpm -C packages/recipes build`);
 
     // Checks if the commands above generated git changes
     const versionsFilePath = `packages/versions/src/lib/getBuiltinVersions.ts`;
-    const proxyDirPath = `packages/fuels/src/cli/commands/deploy/proxy`;
+    const recipeDirPath = `packages/recipes/src`;
 
     const versionsChanged = !!execSync(`git status --porcelain ${versionsFilePath}`)
       .toString()
       .trim();
 
-    const proxyChanged = !!execSync(`git status --porcelain ${proxyDirPath}`).toString().trim();
+    const proxyChanged = !!execSync(`git status --porcelain ${recipeDirPath}`).toString().trim();
 
     // If they did, add and commit the changes
     if (versionsChanged || proxyChanged) {
-      execSync(`git add ${versionsFilePath} ${proxyDirPath}`);
+      execSync(`git add ${versionsFilePath} ${recipeDirPath}`);
       execSync(`git commit -m"ci(scripts): update versions"`);
     }
   } catch (err) {


### PR DESCRIPTION
- Closes #3682

# Summary

- `@fuel-ts/recipes` now correctly bumped on release

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
