### PR TITLE
fix: ignored subscriptions not being read

### DIFF
--- a/.changeset/silent-points-punch.md
+++ b/.changeset/silent-points-punch.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+fix: ignored subscriptions not being read

--- a/packages/account/src/providers/provider.test.ts
+++ b/packages/account/src/providers/provider.test.ts
@@ -9,6 +9,7 @@ import { InputType, OutputType, ReceiptType } from '@fuel-ts/transactions';
 import { DateTime, arrayify, hexlify, sleep } from '@fuel-ts/utils';
 import { ASSET_A, ASSET_B } from '@fuel-ts/utils/test-utils';
 import { versions } from '@fuel-ts/versions';
+import type { MockInstance } from 'vitest';
 
 import { Wallet } from '..';
 import {
@@ -1751,6 +1752,53 @@ describe('Provider', () => {
     }
 
     expect(numberOfEvents).toEqual(2);
+  });
+
+  it('subscriptions: streams are consumed even if the async iterator is not', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const { provider } = launched;
+
+    const sseResponse = new TextEncoder().encode(`data:{"field":"not-relevant"}\n\n`);
+
+    let pullCallNum = 0;
+
+    const underlyingSource: UnderlyingDefaultSource = {
+      pull: (controller) => {
+        pullCallNum += 1;
+        controller.enqueue(sseResponse);
+        if (pullCallNum === 20) {
+          controller.close();
+        }
+      },
+    };
+
+    const pullSpy: MockInstance = vi.spyOn(underlyingSource, 'pull');
+
+    vi.spyOn(global, 'fetch').mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream(
+            underlyingSource,
+            /**
+             * Only pull when .read() is called.
+             * Don't do any behind-the-scenes buffering
+             * so that we can test that the sdk itself is pulling
+             * even if the user isn't reading.
+             */
+            { highWaterMark: 0 }
+          )
+        )
+      )
+    );
+
+    await provider.operations.submitAndAwaitStatus({
+      encodedTransaction: "it's mocked so doesn't matter",
+    });
+
+    // give time for the pulls to be called in the background
+    await sleep(500);
+
+    expect(pullSpy).toHaveBeenCalledTimes(20);
   });
 
   it('subscriptions: throws if the stream data string parsing fails for some reason', async () => {


### PR DESCRIPTION
- Closes #3684

# Summary

Fuel network logs showed some subscriptions weren't being closed and the current hypothesis is that the TS SDK is the culprit because it doesn't automatically read data as it comes from the node but rather waits for the user to start reading it. Even though the fuel-core nodes do close subscriptions once they stream all the data, they still have to wait for ACK messages from the clients and it might be the case that sometimes the clients' TCP receive buffer gets filled up to the point that they stop sending ACK messages to the server (because they don't read the stream), putting the server in a stalemate position until it kills the subscription via timeouts.

The next step would be to integrate the `submit` mutation ergonomically via
- #3683 

so that users can decide to not use the subscription if they don't need it.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
