### PR TITLE
chore: support BN input in block fetch methods

### DIFF
--- a/.changeset/shaggy-ravens-switch.md
+++ b/.changeset/shaggy-ravens-switch.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+chore: support BN input in block fetch methods

--- a/packages/account/src/providers/provider.test.ts
+++ b/packages/account/src/providers/provider.test.ts
@@ -26,7 +26,7 @@ import { setupTestProviderAndWallets, launchNode, TestMessage } from '../test-ut
 import type { Coin } from './coin';
 import { coinQuantityfy } from './coin-quantity';
 import type { Message } from './message';
-import type { ChainInfo, CursorPaginationArgs, NodeInfo } from './provider';
+import type { Block, ChainInfo, CursorPaginationArgs, NodeInfo } from './provider';
 import Provider, {
   BLOCKS_PAGE_SIZE_LIMIT,
   DEFAULT_RESOURCE_CACHE_TTL,
@@ -1043,6 +1043,66 @@ describe('Provider', () => {
       transactionIds: expect.any(Array<string>),
       transactions,
     });
+  });
+
+  it('should ensure getBlockWithTransactions supports different parameters types', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const {
+      provider,
+      wallets: [sender],
+    } = launched;
+
+    const baseAssetId = await provider.getBaseAssetId();
+
+    const tx = await sender.transfer(sender.address, 1, baseAssetId);
+    const { blockId } = await tx.waitForResult();
+
+    expect(blockId).toBeDefined();
+
+    const block = (await provider.getBlockWithTransactions('latest')) as Block;
+    expect(block).toBeDefined();
+
+    let sameBlock = await provider.getBlockWithTransactions(blockId as string);
+    expect(block).toStrictEqual(sameBlock);
+
+    sameBlock = await provider.getBlockWithTransactions(block.height.toString());
+    expect(block).toStrictEqual(sameBlock);
+
+    sameBlock = await provider.getBlockWithTransactions(block.height.toNumber());
+    expect(block).toStrictEqual(sameBlock);
+
+    sameBlock = await provider.getBlockWithTransactions(block.height);
+    expect(block).toStrictEqual(sameBlock);
+  });
+
+  it('should ensure getBlock supports different parameters types', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const {
+      provider,
+      wallets: [sender],
+    } = launched;
+
+    const baseAssetId = await provider.getBaseAssetId();
+
+    const tx = await sender.transfer(sender.address, 1, baseAssetId);
+    const { blockId } = await tx.waitForResult();
+
+    expect(blockId).toBeDefined();
+
+    const block = (await provider.getBlock('latest')) as Block;
+    expect(block).toBeDefined();
+
+    let sameBlock = await provider.getBlock(blockId as string);
+    expect(block).toStrictEqual(sameBlock);
+
+    sameBlock = await provider.getBlock(block.height.toNumber());
+    expect(block).toStrictEqual(sameBlock);
+
+    sameBlock = await provider.getBlock(block.height.toString());
+    expect(block).toStrictEqual(sameBlock);
+
+    sameBlock = await provider.getBlock(block.height);
+    expect(block).toStrictEqual(sameBlock);
   });
 
   it('can getMessageProof with all data', async () => {

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -1,5 +1,5 @@
 import type { AddressInput } from '@fuel-ts/address';
-import { Address } from '@fuel-ts/address';
+import { Address, isB256 } from '@fuel-ts/address';
 import { ErrorCode, FuelError } from '@fuel-ts/errors';
 import type { BigNumberish, BN } from '@fuel-ts/math';
 import { bn } from '@fuel-ts/math';
@@ -1601,7 +1601,7 @@ export default class Provider {
       } = await this.operations.getLatestBlock();
       block = latestBlock;
     } else {
-      const isblockId = typeof idOrHeight === 'string' && idOrHeight.length === 66;
+      const isblockId = typeof idOrHeight === 'string' && isB256(idOrHeight);
       const variables = isblockId
         ? { blockId: idOrHeight }
         : { height: bn(idOrHeight).toString(10) };
@@ -1684,7 +1684,7 @@ export default class Provider {
       variables = { blockHeight: bn(idOrHeight).toString(10) };
     } else if (idOrHeight === 'latest') {
       variables = { blockHeight: (await this.getBlockNumber()).toString() };
-    } else if (typeof idOrHeight === 'string' && idOrHeight.length === 66) {
+    } else if (typeof idOrHeight === 'string' && isB256(idOrHeight)) {
       variables = { blockId: idOrHeight };
     } else {
       variables = { blockHeight: bn(idOrHeight).toString() };

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -1,7 +1,7 @@
 import type { AddressInput } from '@fuel-ts/address';
 import { Address } from '@fuel-ts/address';
 import { ErrorCode, FuelError } from '@fuel-ts/errors';
-import type { BN } from '@fuel-ts/math';
+import type { BigNumberish, BN } from '@fuel-ts/math';
 import { bn } from '@fuel-ts/math';
 import type { Transaction } from '@fuel-ts/transactions';
 import { InputType, InputMessageCoder, TransactionCoder } from '@fuel-ts/transactions';
@@ -1592,7 +1592,7 @@ export default class Provider {
    * @param idOrHeight - ID or height of the block.
    * @returns A promise that resolves to the block or null.
    */
-  async getBlock(idOrHeight: string | number | 'latest'): Promise<Block | null> {
+  async getBlock(idOrHeight: BigNumberish | 'latest'): Promise<Block | null> {
     let block: GqlBlockFragment | undefined | null;
 
     if (idOrHeight === 'latest') {
@@ -1677,15 +1677,17 @@ export default class Provider {
    */
   async getBlockWithTransactions(
     /** ID or height of the block */
-    idOrHeight: string | number | 'latest'
+    idOrHeight: BigNumberish | 'latest'
   ): Promise<(Block & { transactions: Transaction[] }) | null> {
     let variables;
     if (typeof idOrHeight === 'number') {
       variables = { blockHeight: bn(idOrHeight).toString(10) };
     } else if (idOrHeight === 'latest') {
       variables = { blockHeight: (await this.getBlockNumber()).toString() };
-    } else {
+    } else if (typeof idOrHeight === 'string' && idOrHeight.length === 66) {
       variables = { blockId: idOrHeight };
+    } else {
+      variables = { blockHeight: bn(idOrHeight).toString() };
     }
 
     const { block } = await this.operations.getBlockWithTransactions(variables);


### PR DESCRIPTION
- Closes #3692

In this release, we:

- Made `getBlockWithTransactions` and `getBlock` supports BN paramter 

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
