### PR TITLE
fix: multi-call contract operations in tx summary

### DIFF
--- a/.changeset/odd-news-smile.md
+++ b/.changeset/odd-news-smile.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+fix: multi-call contract operations in tx summary

--- a/packages/account/src/providers/transaction-summary/operations.test.ts
+++ b/packages/account/src/providers/transaction-summary/operations.test.ts
@@ -1,7 +1,8 @@
 import { getRandomB256 } from '@fuel-ts/address';
 import { ZeroBytes32 } from '@fuel-ts/address/configs';
 import { bn } from '@fuel-ts/math';
-import { ReceiptCall, ReceiptType, TransactionType } from '@fuel-ts/transactions';
+import type { ReceiptCall} from '@fuel-ts/transactions';
+import { ReceiptType, TransactionType } from '@fuel-ts/transactions';
 import { ASSET_A, ASSET_B } from '@fuel-ts/utils/test-utils';
 import * as asm from '@fuels/vm-asm';
 
@@ -1087,11 +1088,7 @@ describe('operations', () => {
     // RET instruction size
     const retSize = asm.Instruction.size();
 
-    const calculateScriptVariableSizeAsm = (calls: any[]) => {
-      return calls.reduce((acc) => {
-        return acc + callDataOffset.byteLength + amountOffset.byteLength + assetIdOffset.byteLength + loadBytes.byteLength + gasOffset.byteLength;
-      }, retSize);
-    }
+    const calculateScriptVariableSizeAsm = (calls: any[]) => calls.reduce((acc) => acc + callDataOffset.byteLength + amountOffset.byteLength + assetIdOffset.byteLength + loadBytes.byteLength + gasOffset.byteLength, retSize)
 
     const scriptVariableSize = calculateScriptVariableSize(calls);
     expect(scriptVariableSize).toEqual(24);

--- a/packages/account/src/providers/transaction-summary/operations.test.ts
+++ b/packages/account/src/providers/transaction-summary/operations.test.ts
@@ -1,7 +1,7 @@
 import { getRandomB256 } from '@fuel-ts/address';
 import { ZeroBytes32 } from '@fuel-ts/address/configs';
 import { bn } from '@fuel-ts/math';
-import type { ReceiptCall} from '@fuel-ts/transactions';
+import type { ReceiptCall } from '@fuel-ts/transactions';
 import { ReceiptType, TransactionType } from '@fuel-ts/transactions';
 import { ASSET_A, ASSET_B } from '@fuel-ts/utils/test-utils';
 import * as asm from '@fuels/vm-asm';
@@ -1088,7 +1088,17 @@ describe('operations', () => {
     // RET instruction size
     const retSize = asm.Instruction.size();
 
-    const calculateScriptVariableSizeAsm = (calls: any[]) => calls.reduce((acc) => acc + callDataOffset.byteLength + amountOffset.byteLength + assetIdOffset.byteLength + loadBytes.byteLength + gasOffset.byteLength, retSize)
+    const calculateScriptVariableSizeAsm = (recs: ReceiptCall[]) =>
+      recs.reduce(
+        (acc) =>
+          acc +
+          callDataOffset.byteLength +
+          amountOffset.byteLength +
+          assetIdOffset.byteLength +
+          loadBytes.byteLength +
+          gasOffset.byteLength,
+        retSize
+      );
 
     const scriptVariableSize = calculateScriptVariableSize(calls);
     expect(scriptVariableSize).toEqual(24);

--- a/packages/account/src/providers/transaction-summary/operations.ts
+++ b/packages/account/src/providers/transaction-summary/operations.ts
@@ -374,19 +374,19 @@ export const calculateScriptVariableSize = (calls: ReceiptCall[]): number => {
     (total) => {
       let callOffset = total;
       // Call Data Offset - asm.movi(0x10, 0)
-      const callDataOffset = new Uint8Array([ 114, 64, 0, 0 ]);
+      const callDataOffset = new Uint8Array([114, 64, 0, 0]);
       callOffset += callDataOffset.byteLength;
       // Amount Offset - asm.movi(0x11, 0)
-      const amountOffset = new Uint8Array([ 114, 68, 0, 0 ])
+      const amountOffset = new Uint8Array([114, 68, 0, 0]);
       callOffset += amountOffset.byteLength;
       // Load Asset ID- asm.lw(0x11, 0x11, 0)
-      const assetIdOffset = new Uint8Array([ 93, 69, 16, 0 ])
+      const assetIdOffset = new Uint8Array([93, 69, 16, 0]);
       callOffset += assetIdOffset.byteLength;
       // Asset ID - asm.movi(0x12, 0)
-      const loadBytes = new Uint8Array([ 114, 72, 0, 0 ]);
+      const loadBytes = new Uint8Array([114, 72, 0, 0]);
       callOffset += loadBytes.byteLength;
       // Gas Offset - asm.call(0x10, 0x11, 0x12, asm.RegId.cgas().to_u8())
-      const gasOffset = new Uint8Array([ 45, 65, 20, 138 ]);
+      const gasOffset = new Uint8Array([45, 65, 20, 138]);
       callOffset += gasOffset.byteLength;
 
       return callOffset;

--- a/packages/account/src/providers/transaction-summary/operations.ts
+++ b/packages/account/src/providers/transaction-summary/operations.ts
@@ -11,7 +11,6 @@ import type {
   Input,
   ReceiptCall,
 } from '@fuel-ts/transactions';
-import * as asm from '@fuels/vm-asm';
 
 import type {
   TransactionResultReceipt,

--- a/packages/fuel-gauge/src/transaction-summary.test.ts
+++ b/packages/fuel-gauge/src/transaction-summary.test.ts
@@ -631,8 +631,6 @@ describe('TransactionSummary', () => {
     // expect(summary).toStrictEqual(responseSummary);
   });
 
-  // Tx summary with multicall does not set contract operations correctly
-  // https://github.com/FuelLabs/fuels-ts/issues/3706
   it('should ensure getTransactionsSummaries executes just fine [w/ ABI & call/transfer multicall]', async () => {
     using launched = await launchTestNode({
       contractsConfigs: [

--- a/packages/fuel-gauge/src/transaction-summary.test.ts
+++ b/packages/fuel-gauge/src/transaction-summary.test.ts
@@ -610,17 +610,19 @@ describe('TransactionSummary', () => {
 
     const contractId = contract.id.toB256();
 
-    const call = await contract.multiCall([
-      contract.functions.mint_coins(bn(100_000)),
-      contract.functions.mint_coins(bn(200_000)),
-      contract.functions.mint_coins(bn(300_000)),
-      contract.functions.mint_coins(bn(400_000)),
-      contract.functions.mint_coins(bn(500_000)),
-      contract.functions.mint_coins(bn(600_000)),
-      contract.functions.mint_coins(bn(700_000)),
-      contract.functions.mint_coins(bn(800_000)),
-      contract.functions.mint_coins(bn(900_000)),
-    ]).call();
+    const call = await contract
+      .multiCall([
+        contract.functions.mint_coins(bn(100_000)),
+        contract.functions.mint_coins(bn(200_000)),
+        contract.functions.mint_coins(bn(300_000)),
+        contract.functions.mint_coins(bn(400_000)),
+        contract.functions.mint_coins(bn(500_000)),
+        contract.functions.mint_coins(bn(600_000)),
+        contract.functions.mint_coins(bn(700_000)),
+        contract.functions.mint_coins(bn(800_000)),
+        contract.functions.mint_coins(bn(900_000)),
+      ])
+      .call();
     const res = await call.waitForResult();
 
     const summary = await getTransactionSummary({
@@ -643,7 +645,7 @@ describe('TransactionSummary', () => {
       expect(callOperation.calls?.[0].functionName).toBe('mint_coins');
       expect(callOperation.calls?.[0].functionSignature).toBe('mint_coins(u64)');
       expect(callOperation.calls?.[0].argumentsProvided).toStrictEqual({
-        mint_amount: bn(100_000 + (index * 100_000)).toHex(),
+        mint_amount: bn(100_000 + index * 100_000).toHex(),
       });
     }
 

--- a/packages/fuel-gauge/src/transaction-summary.test.ts
+++ b/packages/fuel-gauge/src/transaction-summary.test.ts
@@ -31,7 +31,13 @@ import {
   TestMessage,
 } from 'fuels/test-utils';
 
-import { MultiTokenContractFactory, TokenContractFactory, TokenContract, CallTestContractFactory, CallTestContract } from '../test/typegen';
+import {
+  MultiTokenContractFactory,
+  TokenContractFactory,
+  TokenContract,
+  CallTestContractFactory,
+  CallTestContract,
+} from '../test/typegen';
 import type { ContractIdInput, TransferParamsInput } from '../test/typegen/contracts/TokenContract';
 
 function convertBnsToHex(value: unknown): unknown {
@@ -357,9 +363,12 @@ describe('TransactionSummary', () => {
     const baseAssetId = await provider.getBaseAssetId();
     const contractId = contract.id.toB256();
 
-    const call = await contract.functions.return_context_gas().callParams({
-      forward: [bn(100_000), baseAssetId],
-    }).call();
+    const call = await contract.functions
+      .return_context_gas()
+      .callParams({
+        forward: [bn(100_000), baseAssetId],
+      })
+      .call();
     const res = await call.waitForResult();
 
     const summary = await res.transactionResponse.getTransactionSummary({


### PR DESCRIPTION
- Closes #3706 

# Release notes

In this release, we:

- Populated transaction summaries with all contract operations

# Summary

Builds on the work in #3704 but makes correct usage of the `param1` and `param2` contract call receipt properties by using them in conjunction with a calculated script data size, enabling multi-call contract operations.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
