### PR TITLE
chore: remove call ops in tx summary

### DIFF
--- a/.changeset/nine-bats-fail.md
+++ b/.changeset/nine-bats-fail.md
@@ -2,4 +2,4 @@
 "@fuel-ts/account": patch
 ---
 
-feat: remove call ops in tx summary
+chore: remove call ops in tx summary

--- a/.changeset/nine-bats-fail.md
+++ b/.changeset/nine-bats-fail.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+feat: remove call ops in tx summary

--- a/packages/account/src/providers/transaction-summary/call.ts
+++ b/packages/account/src/providers/transaction-summary/call.ts
@@ -21,6 +21,12 @@ export interface FunctionCall {
   argumentsProvided: Record<string, unknown> | undefined;
 }
 
+/**
+ * Builds a FunctionCall object from a call receipt.
+ *
+ * Currently only supports the first function call, multicall is not supported.
+ * This should be https://github.com/FuelLabs/fuels-ts/issues/3733.
+ */
 export const getFunctionCall = ({
   abi,
   receipt,

--- a/packages/account/src/providers/transaction-summary/operations.ts
+++ b/packages/account/src/providers/transaction-summary/operations.ts
@@ -14,7 +14,6 @@ import type {
 } from '../transaction-response';
 
 import type { FunctionCall } from './call';
-import { getFunctionCall } from './call';
 import {
   getInputFromAssetId,
   getInputAccountAddress,
@@ -274,23 +273,20 @@ export function getWithdrawFromFuelOperations({
 function getContractCalls(
   contractInput: InputContract,
   abiMap: AbiMap | undefined,
-  receipt: TransactionResultCallReceipt,
-  rawPayload: string,
-  maxInputs: BN
+  _receipt: TransactionResultCallReceipt,
+  _rawPayload: string,
+  _maxInputs: BN
 ): FunctionCall[] {
   const abi = abiMap?.[contractInput.contractID];
   if (!abi) {
     return [];
   }
 
-  return [
-    getFunctionCall({
-      abi,
-      receipt,
-      rawPayload,
-      maxInputs,
-    }),
-  ];
+  // Until we can successfully decode all operations, including multicall we
+  // will just return an empty. This should then be reintroduced in
+  // https://github.com/FuelLabs/fuels-ts/issues/3733
+  return [];
+  // return [ getFunctionCall({ abi, receipt, rawPayload, maxInputs }) ];
 }
 
 /** @hidden */

--- a/packages/fuel-gauge/src/transaction-summary.test.ts
+++ b/packages/fuel-gauge/src/transaction-summary.test.ts
@@ -302,7 +302,38 @@ describe('TransactionSummary', () => {
     });
   });
 
-  it('should ensure getTransactionsSummaries executes just fine [w/ ABI & call op]', async () => {
+  // We can remove this test once https://github.com/FuelLabs/fuels-ts/issues/3733 has been resolved as the
+  // below tests are more verbose. But this ensures the method does not throw with an ABI map provided.
+  it('should ensure getTransactionsSummaries executes just fine [w/ ABI map]', async () => {
+    using launched = await launchTestNode({
+      contractsConfigs: [
+        {
+          factory: TokenContractFactory,
+        },
+      ],
+    });
+
+    const {
+      contracts: [contract],
+    } = launched;
+
+    const contractId = contract.id.toB256();
+
+    const call = await contract.functions.mint_coins(bn(100_000)).call();
+    const res = await call.waitForResult();
+
+    const summary = await res.transactionResponse.getTransactionSummary({
+      [contractId]: TokenContract.abi,
+    });
+
+    validateTxSummary({
+      transaction: summary,
+    });
+  });
+
+  // Test disabled due to unsupported call ops in tx summaries. We should re-enable this via
+  // https://github.com/FuelLabs/fuels-ts/issues/3733
+  it.skip('should ensure getTransactionsSummaries executes just fine [w/ ABI & call op]', async () => {
     using launched = await launchTestNode({
       contractsConfigs: [
         {
@@ -340,7 +371,9 @@ describe('TransactionSummary', () => {
     });
   });
 
-  it('should ensure getTransactionsSummaries executes just fine [w/ ABI & call w/ transfer op]', async () => {
+  // Test disabled due to unsupported call ops in tx summaries. We should re-enable this via
+  // https://github.com/FuelLabs/fuels-ts/issues/3733
+  it.skip('should ensure getTransactionsSummaries executes just fine [w/ ABI & call w/ transfer op]', async () => {
     using launched = await launchTestNode({
       contractsConfigs: [
         {
@@ -396,7 +429,9 @@ describe('TransactionSummary', () => {
     });
   });
 
-  it('should ensure getTransactionSummary fn executes just fine [w/ ABI & call op]', async () => {
+  // Test disabled due to unsupported call ops in tx summaries. We should re-enable this via
+  // https://github.com/FuelLabs/fuels-ts/issues/3733
+  it.skip('should ensure getTransactionSummary fn executes just fine [w/ ABI & call op]', async () => {
     using launched = await launchTestNode({
       contractsConfigs: [
         {
@@ -449,7 +484,9 @@ describe('TransactionSummary', () => {
     // expect(summary).toStrictEqual(responseSummary);
   });
 
-  it('should ensure getTransactionSummary fn executes just fine [w/ ABI & call w/ transfer op]', async () => {
+  // Test disabled due to unsupported call ops in tx summaries. We should re-enable this via
+  // https://github.com/FuelLabs/fuels-ts/issues/3733
+  it.skip('should ensure getTransactionSummary fn executes just fine [w/ ABI & call w/ transfer op]', async () => {
     using launched = await launchTestNode({
       contractsConfigs: [
         {


### PR DESCRIPTION
- Part of #3733

# Summary

Removes some of the work introduced by #3704 but ensures the `abiMap` param still does not throw (#3703). #3710 proposed a way to introduce multi call operations, but the solution in #3733 is more robust. This PR sets the stage for #3733.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
