### PR TITLE
feat: remove `usePrepareForSend` from connectors

### DIFF
--- a/apps/docs/src/guide/wallets/connectors.md
+++ b/apps/docs/src/guide/wallets/connectors.md
@@ -192,7 +192,7 @@ Providing the message signing flow is successful, it will return the message sig
 
 #### `sendTransaction`
 
-The `signTransaction` method initiates the send transaction flow for the current connection.
+The `sendTransaction` method initiates the send transaction flow for the current connection.
 
 It requires two arguments:
 
@@ -216,13 +216,7 @@ It will return the prepared transaction (as a [`TransactionRequestLike`](DOCS_AP
 
 <<< @/../../../packages/account/src/connectors/fuel-connector.ts#fuel-connector-method-prepareForSend{ts:line-numbers}
 
-It can be used in tandem with `Account.sendTransaction` to prepare and send a transaction in one go.
-
-This is enabled by setting the `usePrepareForSend` property to `true` on the connector.
-
-<<< @./snippets/connectors.ts#fuel-connector-method-usePrepareForSend{ts:line-numbers}
-
-This can be beneficial for performance and user experience, as it reduces the number of round trips between the dApp and the network.
+When used in conjunction with `Account.sendTransaction`, this can be beneficial for performance and user experience, as it reduces the number of round trips between the dApp and the network.
 
 #### `assets`
 

--- a/apps/docs/src/guide/wallets/snippets/connectors.ts
+++ b/apps/docs/src/guide/wallets/snippets/connectors.ts
@@ -45,10 +45,6 @@ class WalletConnector extends FuelConnector {
   };
   // #endregion fuel-connector-metadata
 
-  // #region fuel-connector-method-usePrepareForSend
-  public override usePrepareForSend = true;
-  // #endregion fuel-connector-method-usePrepareForSend
-
   private eventsConnectorEvents(): void {
     // #region fuel-connector-events-accounts
     const accounts: Array<string> = ['0x1234567890abcdef'];

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -661,7 +661,7 @@ export class Account extends AbstractAccount implements WithAddress {
       // If the connector is using prepareForSend, the connector will prepare the transaction for the dapp,
       // and submission is owned by the dapp. This reduces network requests to submit and create the
       // summary for a tx.
-      if (this._connector.usePrepareForSend) {
+      if (await this._connector.hasPrepareForSend()) {
         const preparedTransaction = await this._connector.prepareForSend(
           this.address.toString(),
           transactionRequestLike,

--- a/packages/account/src/connectors/fuel.ts
+++ b/packages/account/src/connectors/fuel.ts
@@ -370,7 +370,6 @@ export class Fuel extends FuelConnector implements FuelSdk {
     const { installed } = await this.fetchConnectorStatus(connector);
     if (installed) {
       this._currentConnector = connector;
-      this.usePrepareForSend = connector.usePrepareForSend;
       this.emit(this.events.currentConnector, connector);
       this.setupConnectorEvents(Object.values(FuelConnectorEventTypes));
       await this._storage?.setItem(Fuel.STORAGE_KEY, connector.name);

--- a/packages/account/test/fixtures/mocked-prep-connector.ts
+++ b/packages/account/test/fixtures/mocked-prep-connector.ts
@@ -3,8 +3,6 @@ import { transactionRequestify, type TransactionRequestLike } from '../../src';
 import { MockConnector } from './mocked-connector';
 
 export class MockedPrepConnector extends MockConnector {
-  override usePrepareForSend = true;
-
   override async prepareForSend(
     address: string,
     transaction: TransactionRequestLike


### PR DESCRIPTION
<!--
List the issues this PR closes (if any) in a bullet list format, e.g.:
- Closes #ABCD
- Closes #EFGH
-->

# Summary

Removes the `usePrepareForSend` flag, so the `prepareForSend` submission flow that reduces round trips is initiated by the presence of a valid preparation method.

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
