### PR TITLE
fix: update txId for contract input in tx summary

### DIFF
--- a/.changeset/pink-memes-notice.md
+++ b/.changeset/pink-memes-notice.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+fix: update txId for contract input in tx summary

--- a/packages/account/src/providers/transaction-response/transaction-response.ts
+++ b/packages/account/src/providers/transaction-response/transaction-response.ts
@@ -33,12 +33,7 @@ import type {
   GqlSubmitAndAwaitStatusSubscription,
 } from '../__generated__/operations';
 import type Provider from '../provider';
-import type {
-  ContractTransactionRequestInput,
-  JsonAbisFromAllCalls,
-  TransactionRequest,
-  TransactionRequestInput,
-} from '../transaction-request';
+import type { JsonAbisFromAllCalls, TransactionRequest } from '../transaction-request';
 import { assembleTransactionSummary } from '../transaction-summary/assemble-transaction-summary';
 import { processGqlReceipt } from '../transaction-summary/receipt';
 import { getTotalFeeFromStatus } from '../transaction-summary/status';
@@ -46,7 +41,6 @@ import type { TransactionSummary, GqlTransaction, AbiMap } from '../transaction-
 import { extractTxError } from '../utils';
 
 import { getDecodedLogs } from './getDecodedLogs';
-import { getInputsContract } from '../transaction-summary';
 
 /** @hidden */
 export type TransactionResultCallReceipt = ReceiptCall;
@@ -231,6 +225,7 @@ export class TransactionResponse {
 
     tx.inputs.forEach((input) => {
       if (input.type === InputType.Contract) {
+        // eslint-disable-next-line no-param-reassign
         input.txID = this.id;
       }
     });

--- a/packages/fuel-gauge/src/transaction-summary.test.ts
+++ b/packages/fuel-gauge/src/transaction-summary.test.ts
@@ -481,9 +481,7 @@ describe('TransactionSummary', () => {
 
     expect(summary.operations).toStrictEqual(responseSummary.operations);
 
-    // TODO: Contract txId not set correctly in`transactionResponse.getTransactionSummary`
-    // https://github.com/FuelLabs/fuels-ts/issues/3708
-    // expect(summary).toStrictEqual(responseSummary);
+    expect(summary).toStrictEqual(responseSummary);
   });
 
   // Test disabled due to unsupported call ops in tx summaries. We should re-enable this via
@@ -553,9 +551,7 @@ describe('TransactionSummary', () => {
 
     expect(summary.operations).toStrictEqual(responseSummary.operations);
 
-    // TODO: Contract txId not set correctly in`transactionResponse.getTransactionSummary`
-    // https://github.com/FuelLabs/fuels-ts/issues/3708
-    // expect(summary).toStrictEqual(responseSummary);
+    expect(summary).toStrictEqual(responseSummary);
   });
 
   // Tx summary with multicall does not set contract operations correctly
@@ -633,7 +629,7 @@ describe('TransactionSummary', () => {
     });
   });
 
-  it('creates a transaction summary with updated txIds', async () => {
+  it('should ensure getTransactionSummary updates txIds', async () => {
     using launched = await launchTestNode({
       contractsConfigs: [
         {

--- a/packages/fuel-gauge/src/transaction-summary.test.ts
+++ b/packages/fuel-gauge/src/transaction-summary.test.ts
@@ -23,7 +23,6 @@ import {
   TRANSACTIONS_PAGE_SIZE_LIMIT,
   FuelError,
   ErrorCode,
-  InputType,
 } from 'fuels';
 import {
   ASSET_A,


### PR DESCRIPTION
- Closes #3708

# Release notes

In this release, we:

- Fixed some scenarios where a transaction summary contract input contained a zeroed transaction ID

# Summary

In a scenario where a transaction summary is built from a transaction request, we do not update the transaction ID for the input, meaning the summary is not valid as opposed to if the transaction was fetched from the node.

This PR updates that value when the summary is built from a passed transaction request object.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
