### PR TITLE
feat: add tx summary to send tx JSON RPC

### DIFF
--- a/packages/account/src/connectors/types/data-type.ts
+++ b/packages/account/src/connectors/types/data-type.ts
@@ -59,8 +59,6 @@ export type FuelConnectorSendTxParams = {
     url: string;
     cache?: ProviderCacheJson;
   };
-  data?: {
-    transactionSummary?: TransactionSummaryJson;
-  };
   transactionState?: TransactionStateFlag['state'];
+  transactionSummary?: TransactionSummaryJson;
 };

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -243,7 +243,7 @@ export type TransactionCost = {
   addedSignatures: number;
   dryRunStatus?: DryRunStatus;
   updateMaxFee?: boolean;
-  transactionSummary: TransactionSummaryJsonPartial;
+  transactionSummary?: TransactionSummaryJsonPartial;
 };
 // #endregion cost-estimation-1
 

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -68,7 +68,7 @@ import type { RetryOptions } from './utils/auto-retry-fetch';
 import { autoRetryFetch } from './utils/auto-retry-fetch';
 import { assertGqlResponseHasNoErrors } from './utils/handle-gql-error-message';
 import { adjustResourcesToExclude } from './utils/helpers';
-import type { ProviderCacheJson } from './utils/serialization';
+import type { ProviderCacheJson, TransactionSummaryJsonPartial } from './utils/serialization';
 import {
   deserializeChain,
   deserializeNodeInfo,
@@ -243,6 +243,7 @@ export type TransactionCost = {
   addedSignatures: number;
   dryRunStatus?: DryRunStatus;
   updateMaxFee?: boolean;
+  transactionSummary: TransactionSummaryJsonPartial;
 };
 // #endregion cost-estimation-1
 
@@ -1448,6 +1449,11 @@ export default class Provider {
       }));
     }
 
+    const transactionSummary: TransactionSummaryJsonPartial = {
+      gasPrice: gasPrice.toString(),
+      receipts: rawReceipts,
+    };
+
     return {
       rawReceipts,
       receipts,
@@ -1463,6 +1469,7 @@ export default class Provider {
       estimatedPredicates: txRequestClone.inputs,
       dryRunStatus,
       updateMaxFee,
+      transactionSummary,
     };
   }
 

--- a/packages/account/src/providers/transaction-request/transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/transaction-request.ts
@@ -32,7 +32,7 @@ import { isMessageCoin, type Message, type MessageCoin } from '../message';
 import type { ChainInfo, GasCosts } from '../provider';
 import type { Resource } from '../resource';
 import { isCoin } from '../resource';
-import { normalizeJSON } from '../utils';
+import { normalizeJSON, TransactionSummaryJsonPartial } from '../utils';
 import { getMaxGas, getMinGas } from '../utils/gas';
 
 import { NoWitnessAtIndexError } from './errors';
@@ -102,10 +102,11 @@ type ToBaseTransactionResponse = Pick<
 >;
 
 export type TransactionStateFlag =
-  | { state: undefined; transactionId: undefined }
+  | { state: undefined; transactionId: undefined; summary: undefined }
   | {
       state: 'funded';
       transactionId: string;
+      summary: TransactionSummaryJsonPartial | undefined;
     };
 
 /**
@@ -136,7 +137,7 @@ export abstract class BaseTransactionRequest implements BaseTransactionRequestLi
    *
    * The current status of the transaction
    */
-  flag: TransactionStateFlag = { state: undefined, transactionId: undefined };
+  flag: TransactionStateFlag = { state: undefined, transactionId: undefined, summary: undefined };
 
   /**
    * Constructor for initializing a base transaction request.
@@ -738,13 +739,17 @@ export abstract class BaseTransactionRequest implements BaseTransactionRequestLi
    *
    * @param state - The state to update.
    */
-  public updateState(chainId: number, state?: TransactionStateFlag['state']) {
+  public updateState(
+    chainId: number,
+    state?: TransactionStateFlag['state'],
+    summary?: TransactionSummaryJsonPartial
+  ) {
     if (!state) {
-      this.flag = { state: undefined, transactionId: undefined };
+      this.flag = { state: undefined, transactionId: undefined, summary: undefined };
       return;
     }
 
     const transactionId = this.getTransactionId(chainId);
-    this.flag = { state, transactionId };
+    this.flag = { state, transactionId, summary };
   }
 }

--- a/packages/account/src/providers/transaction-request/transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/transaction-request.ts
@@ -32,7 +32,8 @@ import { isMessageCoin, type Message, type MessageCoin } from '../message';
 import type { ChainInfo, GasCosts } from '../provider';
 import type { Resource } from '../resource';
 import { isCoin } from '../resource';
-import { normalizeJSON, TransactionSummaryJsonPartial } from '../utils';
+import type { TransactionSummaryJsonPartial } from '../utils';
+import { normalizeJSON } from '../utils';
 import { getMaxGas, getMinGas } from '../utils/gas';
 
 import { NoWitnessAtIndexError } from './errors';

--- a/packages/account/src/providers/utils/serialization.ts
+++ b/packages/account/src/providers/utils/serialization.ts
@@ -49,6 +49,8 @@ export interface TransactionSummaryJson {
   gasPrice: string;
 }
 
+export type TransactionSummaryJsonPartial = Omit<TransactionSummaryJson, 'id' | 'transactionBytes'>;
+
 /** @hidden */
 export const deserializeChain = (chain: ChainInfoJson): ChainInfo => {
   const { name, daHeight, consensusParameters } = chain;

--- a/packages/account/test/fuel-wallet-connector.test.ts
+++ b/packages/account/test/fuel-wallet-connector.test.ts
@@ -19,13 +19,14 @@ import { Fuel } from '../src/connectors/fuel';
 import type { FuelConnectorSendTxParams } from '../src/connectors/types';
 import { FuelConnectorEventType } from '../src/connectors/types';
 import { Provider, ScriptTransactionRequest, TransactionStatus } from '../src/providers';
-import type { TransactionSummaryJson } from '../src/providers/utils/serialization';
 import { serializeProviderCache } from '../src/providers/utils/serialization';
 import { setupTestProviderAndWallets, TestMessage } from '../src/test-utils';
 import { Wallet } from '../src/wallet';
 
 import { MockConnector } from './fixtures/mocked-connector';
 import { promiseCallback } from './fixtures/promise-callback';
+import { TransactionCoder } from '@fuel-ts/transactions';
+import { clone } from 'ramda';
 
 /**
  * @group node
@@ -679,11 +680,11 @@ describe('Fuel Connector', () => {
     );
   });
 
-  it('should ensure sendTransaction works just fine [defaults]', async () => {
+  it('should ensure sendTransaction works just fine [state: funded]', async () => {
     using launched = await setupTestProviderAndWallets();
     const {
       provider,
-      wallets: [connectorWallet],
+      wallets: [connectorWallet, receiverWallet],
     } = launched;
     const connector = new MockConnector({
       wallets: [connectorWallet],
@@ -697,32 +698,43 @@ describe('Fuel Connector', () => {
     const sendTransactionSpy = vi.spyOn(connectorWallet, 'sendTransaction');
 
     const request = new ScriptTransactionRequest();
-    const resources = await connectorWallet.getResourcesToSpend([
-      { assetId: await provider.getBaseAssetId(), amount: 1000 },
-    ]);
-    request.addResources(resources);
+    request.addCoinOutput(receiverWallet.address, 1000, await provider.getBaseAssetId());
     await request.estimateAndFund(connectorWallet);
 
-    const expectedParams: FuelConnectorSendTxParams = {
-      onBeforeSend: undefined,
-      skipCustomFee: false,
-      provider: {
-        url: provider.url,
-        cache: await serializeProviderCache(provider),
-      },
-      transactionState: 'funded',
-    };
+    // Store the initial transaction bytes for the assertion
+    // as these get modified (signed) by the connector
+    const initialTxBytes = request.toTransactionBytes();
+
     const response = await account.sendTransaction(request);
     expect(response).toBeDefined();
     // transaction prepared and sent via connector
+
+    const { rawReceipts, gasPrice } = await provider.getTransactionCost(request);
+    const chainId = await provider.getChainId();
+    const expectedParams: FuelConnectorSendTxParams = {
+      onBeforeSend: undefined,
+      skipCustomFee: false,
+      provider: {
+        url: provider.url,
+        cache: await serializeProviderCache(provider),
+      },
+      transactionState: 'funded',
+      transactionSummary: {
+        id: request.getTransactionId(chainId),
+        transactionBytes: initialTxBytes,
+        receipts: rawReceipts,
+        gasPrice: gasPrice.toString(),
+      },
+    };
+
     expect(sendTransactionSpy).toHaveBeenCalledWith(request, expectedParams);
   });
 
-  it('should ensure sendTransaction works [w/ transaction summary]', async () => {
+  it('should ensure sendTransaction works just fine [state: undefined]', async () => {
     using launched = await setupTestProviderAndWallets();
     const {
       provider,
-      wallets: [connectorWallet],
+      wallets: [connectorWallet, receiverWallet],
     } = launched;
     const connector = new MockConnector({
       wallets: [connectorWallet],
@@ -736,25 +748,12 @@ describe('Fuel Connector', () => {
     const sendTransactionSpy = vi.spyOn(connectorWallet, 'sendTransaction');
 
     const request = new ScriptTransactionRequest();
-    const resources = await connectorWallet.getResourcesToSpend([
-      { assetId: await provider.getBaseAssetId(), amount: 1000 },
-    ]);
-    request.addResources(resources);
-
-    // Estimate and fund
-    const txCost = await account.getTransactionCost(request);
-    request.maxFee = txCost.maxFee;
-    request.gasLimit = txCost.gasUsed;
-    await account.fund(request, txCost);
-
-    // Create summary
-    const chainId = await provider.getChainId();
-    const transactionSummary: TransactionSummaryJson = {
-      id: request.getTransactionId(chainId),
-      transactionBytes: request.toTransactionBytes(),
-      receipts: txCost.rawReceipts,
-      gasPrice: txCost.gasPrice.toString(),
-    };
+    request.addCoinOutput(receiverWallet.address, 1000, await provider.getBaseAssetId());
+    await request.estimateAndFund(connectorWallet);
+    request.addVariableOutputs(2);
+    const response = await account.sendTransaction(request);
+    expect(response).toBeDefined();
+    // transaction prepared and sent via connector
 
     const expectedParams: FuelConnectorSendTxParams = {
       onBeforeSend: undefined,
@@ -763,53 +762,10 @@ describe('Fuel Connector', () => {
         url: provider.url,
         cache: await serializeProviderCache(provider),
       },
-      data: { transactionSummary },
-      transactionState: 'funded',
+      transactionState: undefined,
+      transactionSummary: undefined,
     };
-    const response = await account.sendTransaction(request, {
-      data: { transactionSummary },
-    });
-    expect(response).toBeDefined();
-    // transaction prepared and sent via connector
+
     expect(sendTransactionSpy).toHaveBeenCalledWith(request, expectedParams);
-  });
-
-  it('should ensure sendTransaction works just fine', async () => {
-    using launched = await setupTestProviderAndWallets();
-    const {
-      provider,
-      wallets: [connectorWallet],
-    } = launched;
-    const connector = new MockConnector({
-      wallets: [connectorWallet],
-    });
-    const fuel = await new Fuel({
-      connectors: [connector],
-    });
-
-    const sendTransactionSpy = vi.spyOn(connectorWallet, 'sendTransaction');
-
-    const request = new ScriptTransactionRequest();
-    const resources = await connectorWallet.getResourcesToSpend([
-      { assetId: await provider.getBaseAssetId(), amount: 1000 },
-    ]);
-    request.addResources(resources);
-    await request.estimateAndFund(connectorWallet);
-
-    const params: AccountSendTxParams = {
-      onBeforeSend: vi.fn(),
-      skipCustomFee: true,
-      provider: {
-        url: provider.url,
-        cache: await serializeProviderCache(provider),
-      },
-    };
-    const response = await fuel.sendTransaction(
-      connectorWallet.address.toString(),
-      request,
-      params
-    );
-    expect(response).toBeDefined();
-    expect(sendTransactionSpy).toHaveBeenCalledWith(request, params);
   });
 });

--- a/packages/account/test/fuel-wallet-connector.test.ts
+++ b/packages/account/test/fuel-wallet-connector.test.ts
@@ -7,13 +7,7 @@ import { bn } from '@fuel-ts/math';
 import type { BytesLike } from '@fuel-ts/utils';
 import { EventEmitter } from 'events';
 
-import {
-  Account,
-  type AccountSendTxParams,
-  type Network,
-  type ProviderOptions,
-  type SelectNetworkArguments,
-} from '../src';
+import { Account, type Network, type ProviderOptions, type SelectNetworkArguments } from '../src';
 import { TESTNET_NETWORK_URL } from '../src/configs';
 import { Fuel } from '../src/connectors/fuel';
 import type { FuelConnectorSendTxParams } from '../src/connectors/types';
@@ -25,8 +19,6 @@ import { Wallet } from '../src/wallet';
 
 import { MockConnector } from './fixtures/mocked-connector';
 import { promiseCallback } from './fixtures/promise-callback';
-import { TransactionCoder } from '@fuel-ts/transactions';
-import { clone } from 'ramda';
 
 /**
  * @group node


### PR DESCRIPTION
- Part of #3669

# Summary

Uses receipts from estimation in tandem with the current logic around transaction state to pass a partial transaction summary via JSON RPC to the wallet. A full summary can then be assembled via `assembleTransactionSummaryFromJson()`.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
