### PR TITLE
fix: `fuel-core` and `forc` git branch installation error

### DIFF
--- a/.changeset/solid-roses-battle.md
+++ b/.changeset/solid-roses-battle.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix: `fuel-core` and `forc` git branch installation error

--- a/internal/forc/lib/shared.js
+++ b/internal/forc/lib/shared.js
@@ -94,5 +94,5 @@ export const buildFromGitBranch = (branchName) => {
   binaries.forEach((binaryFileName) => {
     cpSync(join(from, binaryFileName), join(to, binaryFileName));
   });
-  cpSync(versionFilePath, to);
+  cpSync(versionFilePath, join(to, 'VERSION'));
 };

--- a/internal/fuel-core/lib/shared.js
+++ b/internal/fuel-core/lib/shared.js
@@ -81,5 +81,5 @@ export const buildFromGitBranch = (branchName) => {
   mkdirSync(to, { recursive: true });
 
   cpSync(join(from, 'fuel-core'), join(to, 'fuel-core'));
-  cpSync(versionFilePath, to);
+  cpSync(versionFilePath, join(to, 'VERSION'));
 };


### PR DESCRIPTION
# Summary

Fixes `ERR_FS_CP_NON_DIR_TO_DIR` error when installing from `git:` branches.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
