### PR TITLE
chore: eliminate chain requests across concurrent provider instances

### DIFF
--- a/.changeset/nice-camels-marry.md
+++ b/.changeset/nice-camels-marry.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+chore: eliminate chain requests across concurrent provider instances

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -14,6 +14,8 @@ import type { GraphQLClientResponse, GraphQLResponse } from 'graphql-request/src
 import gql from 'graphql-tag';
 import { clone } from 'ramda';
 
+import { deferPromise } from '../connectors/utils/promises';
+
 import { getSdk as getOperationsSdk } from './__generated__/operations';
 import type {
   GqlReceiptFragment as TransactionReceiptJson,
@@ -406,6 +408,7 @@ export default class Provider {
 
   /** @hidden */
   static clearChainAndNodeCaches() {
+    Provider.inflightFetchChainAndNodeInfoRequests = {};
     Provider.nodeInfoCache = {};
     Provider.chainInfoCache = {};
   }
@@ -420,6 +423,8 @@ export default class Provider {
     amount128: false,
   };
 
+  /** @hidden */
+  private static inflightFetchChainAndNodeInfoRequests: Record<string, Promise<number>> = {};
   /** @hidden */
   private static chainInfoCache: ChainInfoCache = {};
   /** @hidden */
@@ -613,7 +618,9 @@ export default class Provider {
    * @param ignoreCache - If true, ignores the cache and re-fetch configs.
    * @returns A promise that resolves to the Chain and NodeInfo.
    */
-  async fetchChainAndNodeInfo(ignoreCache: boolean = false) {
+  async fetchChainAndNodeInfo(
+    ignoreCache: boolean = false
+  ): Promise<{ chain: ChainInfo; nodeInfo: NodeInfo }> {
     let nodeInfo: NodeInfo;
     let chain: ChainInfo;
 
@@ -627,18 +634,32 @@ export default class Provider {
         throw new Error(`Jumps to the catch block and re-fetch`);
       }
     } catch (_err) {
+      const inflightRequest: Promise<number> =
+        Provider.inflightFetchChainAndNodeInfoRequests[this.urlWithoutAuth];
+
+      // When an inflight is request is available, wait for it to complete
+      // Then fetch (which will hit the cached values)
+      if (inflightRequest) {
+        const now = await inflightRequest;
+        this.consensusParametersTimestamp = now;
+        return this.fetchChainAndNodeInfo();
+      }
+
+      const { promise, resolve } = deferPromise<number>();
+      Provider.inflightFetchChainAndNodeInfoRequests[this.urlWithoutAuth] = promise;
+
       const data = await this.operations.getChainAndNodeInfo();
-
       nodeInfo = deserializeNodeInfo(data.nodeInfo);
-
-      Provider.setIncompatibleNodeVersionMessage(nodeInfo);
-
       chain = deserializeChain(data.chain);
 
+      Provider.setIncompatibleNodeVersionMessage(nodeInfo);
       Provider.chainInfoCache[this.urlWithoutAuth] = chain;
       Provider.nodeInfoCache[this.urlWithoutAuth] = nodeInfo;
 
-      this.consensusParametersTimestamp = Date.now();
+      const now = Date.now();
+      this.consensusParametersTimestamp = now;
+      resolve(now);
+      delete Provider.inflightFetchChainAndNodeInfoRequests[this.urlWithoutAuth];
     }
 
     return {


### PR DESCRIPTION
- Closes #3766

# Release notes

In this release, we:

- Eliminated duplicate chain requests across multiple concurrent provider instances

# Summary

- Multiple instances of a provider could request the chain info simultaneously, causing the cached values to be missing. This ensures that only a single request is made across multiple provider instances.

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
