### PR TITLE
fix: skip decoding external contract logs without JSON ABI

### DIFF
--- a/.changeset/fancy-cooks-doubt.md
+++ b/.changeset/fancy-cooks-doubt.md
@@ -1,0 +1,6 @@
+---
+"@fuel-ts/account": patch
+"@fuel-ts/program": patch
+---
+
+fix: skip decoding external contract logs without JSON ABI

--- a/packages/account/src/providers/transaction-response/getDecodedLogs.ts
+++ b/packages/account/src/providers/transaction-response/getDecodedLogs.ts
@@ -1,8 +1,12 @@
 import type { JsonAbi } from '@fuel-ts/abi-coder';
 import { Interface, BigNumberCoder } from '@fuel-ts/abi-coder';
+import { ZeroBytes32 } from '@fuel-ts/address/configs';
 import { ReceiptType } from '@fuel-ts/transactions';
 
-import type { TransactionResultReceipt } from './transaction-response';
+import type {
+  TransactionResultCallReceipt,
+  TransactionResultReceipt,
+} from './transaction-response';
 
 /** @hidden */
 export function getDecodedLogs<T = unknown>(
@@ -26,17 +30,33 @@ export function getDecodedLogs<T = unknown>(
    * @param externalAbis - The record of external contract ABIs.
    * @returns An array of decoded logs from Sway projects.
    */
+  let mainContract = '';
+  if (mainAbi.programType === 'contract') {
+    const firstCallReceipt = receipts.find(
+      (r) => r.type === ReceiptType.Call && r.id === ZeroBytes32
+    ) as TransactionResultCallReceipt;
+
+    mainContract = firstCallReceipt.to;
+  }
+
   return receipts.reduce((logs: T[], receipt) => {
     if (receipt.type === ReceiptType.LogData || receipt.type === ReceiptType.Log) {
-      const interfaceToUse = new Interface(externalAbis[receipt.id] || mainAbi);
+      const isLogFromMainAbi = receipt.id === ZeroBytes32 || mainContract === receipt.id;
+      const isDecodable = isLogFromMainAbi || externalAbis[receipt.id];
 
-      const data =
-        receipt.type === ReceiptType.Log
-          ? new BigNumberCoder('u64').encode(receipt.ra)
-          : receipt.data;
+      if (isDecodable) {
+        const interfaceToUse = isLogFromMainAbi
+          ? new Interface(mainAbi)
+          : new Interface(externalAbis[receipt.id]);
 
-      const [decodedLog] = interfaceToUse.decodeLog(data, receipt.rb.toString());
-      logs.push(decodedLog);
+        const data =
+          receipt.type === ReceiptType.Log
+            ? new BigNumberCoder('u64').encode(receipt.ra)
+            : receipt.data;
+
+        const [decodedLog] = interfaceToUse.decodeLog(data, receipt.rb.toString());
+        logs.push(decodedLog);
+      }
     }
 
     return logs;

--- a/packages/fuel-gauge/test/fixtures/forc-projects/Forc.toml
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/Forc.toml
@@ -52,6 +52,7 @@ members = [
   "revert-error",
   "script-bytes",
   "script-call-contract",
+  "script-call-logging-contracts",
   "script-main-arg-bool",
   "script-main-args",
   "script-main-return-struct",

--- a/packages/fuel-gauge/test/fixtures/forc-projects/script-call-logging-contracts/Forc.toml
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/script-call-logging-contracts/Forc.toml
@@ -1,0 +1,9 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "script-call-logging-contracts"
+
+[dependencies]
+advanced-logging-abi = { path = "../advanced-logging-abi" }
+advanced-logging-other-contract-abi = { path = "../advanced-logging-other-contract-abi" }

--- a/packages/fuel-gauge/test/fixtures/forc-projects/script-call-logging-contracts/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/script-call-logging-contracts/src/main.sw
@@ -1,0 +1,16 @@
+script;
+
+use advanced_logging_abi::AdvancedLogging;
+use advanced_logging_other_contract_abi::AdvancedLoggingOtherContract;
+
+fn main(contract_a_id: b256, contract_b_id: b256) -> bool {
+    log("log from script 1");
+
+    let contract_a = abi(AdvancedLogging, contract_a_id);
+
+    contract_a.test_log_from_other_contract(10, contract_b_id);
+
+    log("log from script 2");
+
+    true
+}

--- a/packages/program/src/functions/base-invocation-scope.ts
+++ b/packages/program/src/functions/base-invocation-scope.ts
@@ -293,10 +293,14 @@ export class BaseInvocationScope<TReturn = any> {
    * @param contracts - An array of contracts to add.
    * @returns The current instance of the class.
    */
-  addContracts(contracts: Array<AbstractContract>) {
+  addContracts(contracts: Array<AbstractContract | string>) {
     contracts.forEach((contract) => {
-      this.transactionRequest.addContractInputAndOutput(contract.id);
-      this.externalAbis[contract.id.toB256()] = contract.interface.jsonAbi;
+      if (typeof contract === 'string') {
+        this.transactionRequest.addContractInputAndOutput(new Address(contract));
+      } else {
+        this.transactionRequest.addContractInputAndOutput(contract.id);
+        this.externalAbis[contract.id.toB256()] = contract.interface.jsonAbi;
+      }
     });
     return this;
   }


### PR DESCRIPTION
- Closes #3789
- Closes #3780

# Release notes

In this release, we:

- Avoid decoding logs from inter-called contracts without a JSON ABI

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
