### PR TITLE
chore: add pr release message

### DIFF
--- a/.changeset/bright-sides-camp.md
+++ b/.changeset/bright-sides-camp.md
@@ -1,0 +1,5 @@
+---
+"@internal/check-imports": patch
+---
+
+chore: add temp release message

--- a/.changeset/bright-sides-camp.md
+++ b/.changeset/bright-sides-camp.md
@@ -1,5 +1,4 @@
 ---
-"@internal/check-imports": patch
 ---
 
 chore: add pr release message

--- a/.changeset/bright-sides-camp.md
+++ b/.changeset/bright-sides-camp.md
@@ -2,4 +2,4 @@
 "@internal/check-imports": patch
 ---
 
-chore: add temp release message
+chore: add pr release message

--- a/.github/workflows/publish-to-next.yaml
+++ b/.github/workflows/publish-to-next.yaml
@@ -60,7 +60,7 @@ jobs:
           npm_config_registry: "https://fuel-024848458133.d.codeartifact.us-east-1.amazonaws.com/npm/npm/"
 
       - name: Add PR comment
-      uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@v2
         with:
           refresh-message-position: true
           message: |

--- a/.github/workflows/publish-to-next.yaml
+++ b/.github/workflows/publish-to-next.yaml
@@ -66,12 +66,9 @@ jobs:
           message: |
             # Temporary PR
 
-            This PR is published in AWS CodeArtifact with version:
-            - `pr-3792`
+            This PR is published in AWS CodeArtifact with version: `pr-3792`
 
-            Install using the below commands.
-
-            > `create-fuels` variations are commented out.
+            Install using the below commands — `create-fuels` variations are commented out.
 
             ## PNPM
 

--- a/.github/workflows/publish-to-next.yaml
+++ b/.github/workflows/publish-to-next.yaml
@@ -59,7 +59,8 @@ jobs:
           HOME: ${{ github.workspace }}
           npm_config_registry: "https://fuel-024848458133.d.codeartifact.us-east-1.amazonaws.com/npm/npm/"
 
-      - uses: mshick/add-pr-comment@v2
+      - name: Add PR comment
+      uses: mshick/add-pr-comment@v2
         with:
           refresh-message-position: true
           message: |
@@ -85,7 +86,7 @@ jobs:
 
             # NPM
             npm --registry=https://npm-packages.fuel.network/ create fuels@${{ env.NPM_DIST_TAG }}
-            
+
             # Bun
             npm_config_registry=https://npm-packages.fuel.network/ bun create fuels@${{ env.NPM_DIST_TAG }}
             ```

--- a/.github/workflows/publish-to-next.yaml
+++ b/.github/workflows/publish-to-next.yaml
@@ -64,29 +64,33 @@ jobs:
         with:
           refresh-message-position: true
           message: |
-            This PR is published in AWS CodeArtifact with version **${{ env.NPM_DIST_TAG }}**
+            # Temporary PR
 
-            Install using the following command:
+            This PR is published in AWS CodeArtifact with version:
+            - `pr-3792`
+
+            Install using the below commands.
+
+            > `create-fuels` variations are commented out.
+
+            ## PNPM
+
             ```bash
-            # PNPM
             pnpm config set registry https://npm-packages.fuel.network/ --global
-            pnpm install fuels@${{ env.NPM_DIST_TAG }}
-
-            # NPM
-            npm --registry=https://npm-packages.fuel.network/ install fuels@${{ env.NPM_DIST_TAG }}
-
-            # Bun
-            npm_config_registry=https://npm-packages.fuel.network/ bun install fuels@${{ env.NPM_DIST_TAG }}
+            pnpm install fuels@pr-3792
+            # pnpm create fuels@pr-3792
             ```
-            Or using `create-fuels`:
+
+            ## NPM
+
             ```bash
-            # PNPM
-            pnpm config set registry https://npm-packages.fuel.network/ --global
-            pnpm create fuels@${{ env.NPM_DIST_TAG }}
+            npm --registry=https://npm-packages.fuel.network/ install fuels@pr-3792
+            # npm --registry=https://npm-packages.fuel.network/ create fuels@pr-3792
+            ```
 
-            # NPM
-            npm --registry=https://npm-packages.fuel.network/ create fuels@${{ env.NPM_DIST_TAG }}
+            ## Bun
 
-            # Bun
-            npm_config_registry=https://npm-packages.fuel.network/ bun create fuels@${{ env.NPM_DIST_TAG }}
+            ```bash
+            npm_config_registry=https://npm-packages.fuel.network/ bun install fuels@pr-3792
+            # npm_config_registry=https://npm-packages.fuel.network/ bun create fuels@pr-3792
             ```

--- a/.github/workflows/publish-to-next.yaml
+++ b/.github/workflows/publish-to-next.yaml
@@ -63,24 +63,24 @@ jobs:
         with:
           refresh-message-position: true
           message: |
-            This PR is published in AWS CodeArtifact with version **${{ NPM_DIST_TAG }}**
+            This PR is published in AWS CodeArtifact with version **$NPM_DIST_TAG**
             Install using the following command:
             ```bash
             # PNPM
             pnpm config set registry https://npm-packages.fuel.network/ --global
-            pnpm install fuels@${{ NPM_DIST_TAG }}
+            pnpm install fuels@$NPM_DIST_TAG
             # NPM
-            npm --registry=https://npm-packages.fuel.network/ install fuels@${{ NPM_DIST_TAG }}
+            npm --registry=https://npm-packages.fuel.network/ install fuels@$NPM_DIST_TAG
             # Bun
-            npm_config_registry=https://npm-packages.fuel.network/ bun install fuels@${{ NPM_DIST_TAG }}
+            npm_config_registry=https://npm-packages.fuel.network/ bun install fuels@$NPM_DIST_TAG
             ```
             Or using `create-fuels`:
             ```bash
             # PNPM
             pnpm config set registry https://npm-packages.fuel.network/ --global
-            pnpm create fuels@${{ NPM_DIST_TAG }}
+            pnpm create fuels@$NPM_DIST_TAG
             # NPM
-            npm --registry=https://npm-packages.fuel.network/ create fuels@${{ NPM_DIST_TAG }}
+            npm --registry=https://npm-packages.fuel.network/ create fuels@$NPM_DIST_TAG
             # Bun
-            npm_config_registry=https://npm-packages.fuel.network/ bun create fuels@${{ NPM_DIST_TAG }}
+            npm_config_registry=https://npm-packages.fuel.network/ bun create fuels@$NPM_DIST_TAG
             ```

--- a/.github/workflows/publish-to-next.yaml
+++ b/.github/workflows/publish-to-next.yaml
@@ -58,3 +58,29 @@ jobs:
         env:
           HOME: ${{ github.workspace }}
           npm_config_registry: "https://fuel-024848458133.d.codeartifact.us-east-1.amazonaws.com/npm/npm/"
+
+      - uses: mshick/add-pr-comment@v2
+        with:
+          refresh-message-position: true
+          message: |
+            This PR is published in AWS CodeArtifact with version **${{ NPM_DIST_TAG }}**
+            Install using the following command:
+            ```bash
+            # PNPM
+            pnpm config set registry https://npm-packages.fuel.network/ --global
+            pnpm install fuels@${{ NPM_DIST_TAG }}
+            # NPM
+            npm --registry=https://npm-packages.fuel.network/ install fuels@${{ NPM_DIST_TAG }}
+            # Bun
+            npm_config_registry=https://npm-packages.fuel.network/ bun install fuels@${{ NPM_DIST_TAG }}
+            ```
+            Or using `create-fuels`:
+            ```bash
+            # PNPM
+            pnpm config set registry https://npm-packages.fuel.network/ --global
+            pnpm create fuels@${{ NPM_DIST_TAG }}
+            # NPM
+            npm --registry=https://npm-packages.fuel.network/ create fuels@${{ NPM_DIST_TAG }}
+            # Bun
+            npm_config_registry=https://npm-packages.fuel.network/ bun create fuels@${{ NPM_DIST_TAG }}
+            ```

--- a/.github/workflows/publish-to-next.yaml
+++ b/.github/workflows/publish-to-next.yaml
@@ -63,24 +63,29 @@ jobs:
         with:
           refresh-message-position: true
           message: |
-            This PR is published in AWS CodeArtifact with version **$NPM_DIST_TAG**
+            This PR is published in AWS CodeArtifact with version **${{ env.NPM_DIST_TAG }}**
+
             Install using the following command:
             ```bash
             # PNPM
             pnpm config set registry https://npm-packages.fuel.network/ --global
-            pnpm install fuels@$NPM_DIST_TAG
+            pnpm install fuels@${{ env.NPM_DIST_TAG }}
+
             # NPM
-            npm --registry=https://npm-packages.fuel.network/ install fuels@$NPM_DIST_TAG
+            npm --registry=https://npm-packages.fuel.network/ install fuels@${{ env.NPM_DIST_TAG }}
+
             # Bun
-            npm_config_registry=https://npm-packages.fuel.network/ bun install fuels@$NPM_DIST_TAG
+            npm_config_registry=https://npm-packages.fuel.network/ bun install fuels@${{ env.NPM_DIST_TAG }}
             ```
             Or using `create-fuels`:
             ```bash
             # PNPM
             pnpm config set registry https://npm-packages.fuel.network/ --global
-            pnpm create fuels@$NPM_DIST_TAG
+            pnpm create fuels@${{ env.NPM_DIST_TAG }}
+
             # NPM
-            npm --registry=https://npm-packages.fuel.network/ create fuels@$NPM_DIST_TAG
+            npm --registry=https://npm-packages.fuel.network/ create fuels@${{ env.NPM_DIST_TAG }}
+            
             # Bun
-            npm_config_registry=https://npm-packages.fuel.network/ bun create fuels@$NPM_DIST_TAG
+            npm_config_registry=https://npm-packages.fuel.network/ bun create fuels@${{ env.NPM_DIST_TAG }}
             ```

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: fuel-fuels-ts-bot
+    environment: npm-deploy
     permissions: write-all
     # First check ensures that the workflow runs only when the changesets PR commit is pushed into the branch.
     # Second check ensures that the workflow runs only after a commit is pushed into the branch,


### PR DESCRIPTION
# Summary

We lost the `pr`/`next` release message when we deleted the old pr release workflow in #3735, that message is still useful.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
