### PR TITLE
fix: `changesets-pr` workflow condition

### DIFF
--- a/.github/workflows/changesets-pr.yaml
+++ b/.github/workflows/changesets-pr.yaml
@@ -18,7 +18,7 @@ jobs:
     # and not when the branch is created.
     # This is to avoid running the workflow when a release/* branch is created.
     if: |
-      startsWith(github.event.head_commit.message, 'ci(release):') &&
+      startsWith(github.event.head_commit.message, 'ci(release):') != true &&
       github.event.before != '0000000000000000000000000000000000000000'
 
     steps:


### PR DESCRIPTION
# Summary

Fixes wrong `changesets-pr` workflow condition.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
