### PR TITLE
feat: inverted submission flow

### DIFF
--- a/apps/docs/src/guide/wallets/connectors.md
+++ b/apps/docs/src/guide/wallets/connectors.md
@@ -199,7 +199,7 @@ It requires two arguments:
 - `address` (`string`)
 - `transaction` ([`TransactionRequestLike`](DOCS_API_URL/types/_fuel_ts_account.TransactionRequestLike.html))
 
-It will return the transaction signature (as a `string`) if it is successfully signed.
+This method will return a promise that either resolves to the submitted transaction id or a [`TransactionResponse`](DOCS_API_URL/types/_fuel_ts_account.TransactionResponse.html). 
 
 <<< @/../../../packages/account/src/connectors/fuel-connector.ts#fuel-connector-method-sendTransaction{ts:line-numbers}
 

--- a/packages/account/test/fixtures/mocked-send-transaction-connector.ts
+++ b/packages/account/test/fixtures/mocked-send-transaction-connector.ts
@@ -34,8 +34,9 @@ export class MockSendTransactionConnector extends MockConnector {
       await transaction.updateWitnessByOwner(wallet.address, signature);
     }
 
-    // Send transaction
-    const { id } = await wallet.provider.sendTransaction(_transaction, _params);
-    return id;
+    // Send transaction and return as transaction response
+    const response = await wallet.provider.sendTransaction(_transaction, _params);
+
+    return response;
   }
 }

--- a/packages/fuel-gauge/test/fixtures/connectors/mock-connector.ts
+++ b/packages/fuel-gauge/test/fixtures/connectors/mock-connector.ts
@@ -11,6 +11,7 @@ import type {
   AccountSendTxParams,
   TransactionResponse,
   Asset,
+  AssembleTxParams,
 } from 'fuels';
 import { Address, FuelConnector, FuelConnectorEventTypes } from 'fuels';
 import { setTimeout } from 'timers/promises';
@@ -106,6 +107,10 @@ export class MockConnector extends FuelConnector {
       throw new Error('Wallet is not found!');
     }
     return wallet.signMessage(_message);
+  }
+
+  override async onBeforeAssembleTx(params: AssembleTxParams): Promise<AssembleTxParams> {
+    return params;
   }
 
   override async sendTransaction(

--- a/packages/fuel-gauge/test/fixtures/connectors/mock-connector.ts
+++ b/packages/fuel-gauge/test/fixtures/connectors/mock-connector.ts
@@ -123,8 +123,9 @@ export class MockConnector extends FuelConnector {
       throw new Error('Wallet is not found!');
     }
 
-    const { id } = await wallet.sendTransaction(_transaction, _params);
-    return id;
+    const response = await wallet.sendTransaction(_transaction, _params);
+
+    return response;
   }
 
   override async currentAccount() {

--- a/packages/fuel-gauge/test/fixtures/connectors/mock-predicate-connector.ts
+++ b/packages/fuel-gauge/test/fixtures/connectors/mock-predicate-connector.ts
@@ -1,20 +1,19 @@
 import type {
   AccountSendTxParams,
-  Predicate,
   TransactionRequestLike,
   TransactionResponse,
   AssembleTxParams,
   Provider,
   ScriptTransactionRequest,
 } from 'fuels';
-import { transactionRequestify } from 'fuels';
-
-import { PredicateSigning } from '../../typegen';
+import { transactionRequestify, Predicate } from 'fuels';
 
 import { MockConnector } from './mock-connector';
 
-export class MockPredicateSignerConnector extends MockConnector {
-  override name = 'Mock Preicate Signer Connector';
+import { PredicateSigning } from '../../typegen';
+
+export class MockPredicateConnector extends MockConnector {
+  override name = 'Mock Predicate Connector';
 
   override async onBeforeAssembleTx(params: AssembleTxParams): Promise<AssembleTxParams> {
     const currentAccount = await this.currentAccount();
@@ -45,7 +44,6 @@ export class MockPredicateSignerConnector extends MockConnector {
     }
     const transaction = transactionRequestify(_transaction) as ScriptTransactionRequest;
 
-    // Only index could have changed, so we need to re-populate the predicate data
     const index = transaction.addEmptyWitness();
     const predicate = this.getPredicate(wallet.provider, currentAccount, index);
     predicate.populateTransactionPredicateData(transaction);

--- a/packages/fuel-gauge/test/fixtures/connectors/mock-predicate-signer-connector.ts
+++ b/packages/fuel-gauge/test/fixtures/connectors/mock-predicate-signer-connector.ts
@@ -55,8 +55,9 @@ export class MockPredicateSignerConnector extends MockConnector {
 
     await wallet.provider.estimatePredicates(transaction);
 
-    const { id } = await wallet.provider.sendTransaction(transaction, _params);
-    return id;
+    const response = await wallet.provider.sendTransaction(transaction, _params);
+
+    return response;
   }
 
   private getPredicate(provider: Provider, address: string, index: number = 0): Predicate {

--- a/packages/fuel-gauge/test/fixtures/connectors/mock-solana-connector.ts
+++ b/packages/fuel-gauge/test/fixtures/connectors/mock-solana-connector.ts
@@ -1,0 +1,80 @@
+import type {
+  AccountSendTxParams,
+  Predicate,
+  TransactionRequestLike,
+  TransactionResponse,
+  AssembleTxParams,
+  Provider,
+  ScriptTransactionRequest,
+} from 'fuels';
+import { hash, hexlify, transactionRequestify } from 'fuels';
+
+import { PredicateSol, PredicateSolScript } from '../../typegen';
+
+import { MockConnector } from './mock-connector';
+
+export class MockSolanaConnector extends MockConnector {
+  override name = 'Mock Solana Connector';
+
+  override async onBeforeAssembleTx(params: AssembleTxParams): Promise<AssembleTxParams> {
+    const currentAccount = await this.currentAccount();
+    const wallet = this._wallets.find((w) => w.address.toString() === currentAccount);
+    if (!wallet) {
+      throw new Error('Wallet is not found!');
+    }
+
+    const transaction = transactionRequestify(params.request) as ScriptTransactionRequest;
+    const predicate = this.getPredicate(wallet.provider, currentAccount);
+    return {
+      ...params,
+      feePayerAccount: predicate,
+      request: transaction,
+      estimatePredicates: false,
+    };
+  }
+
+  override async sendTransaction(
+    _address: string,
+    _transaction: TransactionRequestLike,
+    _params: AccountSendTxParams
+  ): Promise<string | TransactionResponse> {
+    const currentAccount = await this.currentAccount();
+    const wallet = this._wallets.find((w) => w.address.toString() === currentAccount);
+    if (!wallet) {
+      throw new Error('Wallet is not found!');
+    }
+    const transaction = transactionRequestify(_transaction) as ScriptTransactionRequest;
+
+    // Only index could have changed, so we need to re-populate the predicate data
+    const index = transaction.addEmptyWitness();
+    const predicate = this.getPredicate(wallet.provider, currentAccount, index);
+    predicate.populateTransactionPredicateData(transaction);
+
+    const chainId = await wallet.provider.getChainId();
+    const txId = transaction.getTransactionId(chainId);
+    const txIdEncoded = new TextEncoder().encode(txId);
+    const message = hexlify(txIdEncoded).slice(2);
+    const signature = await wallet.signMessage(message);
+    transaction.updateWitness(index, signature);
+
+    await wallet.provider.estimatePredicates(transaction);
+
+    const response = await wallet.provider.sendTransaction(transaction, _params);
+
+    return response;
+  }
+
+  private getPredicate(provider: Provider, address: string, index: number = 0): Predicate {
+    return new PredicateSol({
+      provider,
+      data: [index],
+      configurableConstants: {
+        SIGNER: address,
+      },
+    });
+  }
+
+  public getPredicateAddress(provider: Provider, address: string): string {
+    return this.getPredicate(provider, address).address.toString();
+  }
+}

--- a/packages/fuel-gauge/test/fixtures/forc-projects/Forc.toml
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/Forc.toml
@@ -44,6 +44,7 @@ members = [
   "predicate-with-configurable",
   "predicate-with-more-configurables",
   "predicate-false-configurable",
+  "predicate-sol",
   "proxy-contract",
   "raw-slice-contract",
   "reentrant-bar",

--- a/packages/fuel-gauge/test/fixtures/forc-projects/predicate-sol/Forc.toml
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/predicate-sol/Forc.toml
@@ -1,0 +1,7 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "predicate-sol"
+
+[dependencies]

--- a/packages/fuel-gauge/test/fixtures/forc-projects/predicate-sol/src/main.sw
+++ b/packages/fuel-gauge/test/fixtures/forc-projects/predicate-sol/src/main.sw
@@ -1,0 +1,53 @@
+predicate;
+
+use std::{
+    b512::B512,
+    bytes::Bytes,
+    constants::ZERO_B256,
+    ecr::{
+        EcRecoverError,
+        ed_verify,
+    },
+    hash::{
+        Hash,
+        sha256,
+    },
+    tx::{
+        tx_id,
+        tx_witness_data,
+    },
+};
+
+const ASCII_MAP: [u8; 16] = [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 97, 98, 99, 100, 101, 102];
+
+pub fn b256_to_ascii_bytes(val: b256) -> Bytes {
+    let bytes = Bytes::from(val);
+    let mut ascii_bytes = Bytes::with_capacity(64);
+    let mut idx = 0;
+
+    while idx < 32 {
+        let b = bytes.get(idx).unwrap();
+        ascii_bytes.push(ASCII_MAP[(b >> 4).as_u64()]);
+        ascii_bytes.push(ASCII_MAP[(b & 15).as_u64()]);
+        idx = idx + 1;
+    }
+
+    ascii_bytes
+}
+
+configurable {
+    SIGNER: b256 = ZERO_B256,
+}
+
+fn main(witness_index: u64) -> bool {
+    let signature: B512 = tx_witness_data(witness_index).unwrap();
+    let encoded = b256_to_ascii_bytes(tx_id());
+    let result = ed_verify(SIGNER, signature, encoded);
+
+    if result.is_ok() {
+        return true;
+    }
+
+    // Otherwise, an invalid signature has been passed and we invalidate the Tx.
+    false
+}


### PR DESCRIPTION
- Closes #3665

# Release notes

In this release, we:

- Enabled a snappier transaction summary generation for connectors

# Summary

In #3669 we altered the connector `sendTransaction` signature to now return `string | TransactionResponse`:

https://github.com/FuelLabs/fuels-ts/blob/e8494fa488848ba215e339e2dd12364ab5b3a1a1/packages/account/src/connectors/fuel-connector.ts#L47-L51

This approach enables #3665 to enable connector transactions to submit and generate a transaction summary in apps in a single request.

<img width="853" alt="Image" src="https://github.com/user-attachments/assets/2f73d57e-db64-4cfd-8ddb-30cea99f0052" />

This PR enforces this approach in tests and docs so that in can be implemented by connectors.

> We may look to introduce another approach (such as that proposed by #3761) that encourages the Fuel Wallet to utilise this flow, however for now the above will enable non-native connectors.

# Checklist

- [ ] All **changes** are **covered** by **tests** (or not applicable)
- [ ] All **changes** are **documented** (or not applicable)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [ ] I **described** all **Breaking Changes** (or there's none)
