### PR TITLE
chore: various fixes for suppressing build noise

### DIFF
--- a/.changeset/quick-moments-change.md
+++ b/.changeset/quick-moments-change.md
@@ -1,0 +1,5 @@
+---
+"fuels": patch
+---
+
+chore: various fixes for suppressing build noise

--- a/apps/docs-api/typedoc.json
+++ b/apps/docs-api/typedoc.json
@@ -25,5 +25,7 @@
   "navigationLinks": {
     "Docs": "https://docs.fuel.network/docs/intro/what-is-fuel/",
     "GitHub": "https://github.com/FuelLabs/fuels-ts"
-  }
+  },
+  // Suppress all the warnings that are being thrown by typedoc.
+  "logLevel": "Error"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,7 +9,7 @@
     "build": "run-s build:snippets build:docs",
     "preview": "run-s build:snippets build:docs-api preview:docs",
     "test": "cd ../.. && pnpm run test:filter apps/docs",
-    "build:snippets": "run-s wrap:snippets build:forc",
+    "build:snippets": "run-s clear:snippets wrap:snippets build:forc",
     "build:docs": "run-s build:docs-app build:docs-api",
     "build:docs-app": "vitepress build",
     "build:docs-api": "cd ../docs-api && pnpm build && cp -r ./src/api ../docs/dist",
@@ -17,6 +17,7 @@
     "preview:docs-api": "pnpm vite preview --port 5174 --outDir ../docs-api/src/api",
     "dev:docs": "run-p docs:dev preview:docs-api",
     "docs:dev": "vitepress dev",
+    "clear:snippets": "tsx ./scripts/clear-snippets.mts",
     "wrap:snippets": "tsx ./scripts/wrap-snippets.ts",
     "build:forc": "pnpm fuels build --deploy",
     "type:check": "pnpm tsc --noEmit --project tsconfig.emit.json"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -19,7 +19,7 @@
     "docs:dev": "vitepress dev",
     "clear:snippets": "tsx ./scripts/clear-snippets.mts",
     "wrap:snippets": "tsx ./scripts/wrap-snippets.ts",
-    "build:forc": "pnpm fuels build --deploy",
+    "build:forc": "pnpm fuels --silent build --deploy",
     "type:check": "pnpm tsc --noEmit --project tsconfig.emit.json"
   },
   "keywords": [],

--- a/apps/docs/scripts/clear-snippets.mts
+++ b/apps/docs/scripts/clear-snippets.mts
@@ -1,0 +1,27 @@
+import { execSync } from 'child_process';
+
+const { log } = console;
+
+/**
+ * Flag for debugging
+ *
+ * - `true` will delete the files
+ * - `false` will print the files
+ */
+const SHOULD_DELETE = true;
+
+/**
+ * Various variables for the command
+ */
+const guideFileDir = './src/guide';
+const testFileSuffix = '*.test.ts';
+const printOrDelete = SHOULD_DELETE ? 'delete' : 'print';
+
+// The command to find the files (and either delete or print them)
+const command = `find ${guideFileDir} -type f -name "${testFileSuffix}" -${printOrDelete}`;
+
+// Execute the command
+const output = execSync(command);
+
+// Log the output
+log(output.toString());

--- a/apps/docs/scripts/clear-snippets.mts
+++ b/apps/docs/scripts/clear-snippets.mts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync } from "child_process";
 
 const { log } = console;
 
@@ -13,9 +13,9 @@ const SHOULD_DELETE = true;
 /**
  * Various variables for the command
  */
-const guideFileDir = './src/guide';
-const testFileSuffix = '*.test.ts';
-const printOrDelete = SHOULD_DELETE ? 'delete' : 'print';
+const guideFileDir = "./src/guide";
+const testFileSuffix = "*.test.ts";
+const printOrDelete = SHOULD_DELETE ? "delete" : "print";
 
 // The command to find the files (and either delete or print them)
 const command = `find ${guideFileDir} -type f -name "${testFileSuffix}" -${printOrDelete}`;

--- a/packages/fuels/src/cli/commands/build/buildSwayProgram.test.ts
+++ b/packages/fuels/src/cli/commands/build/buildSwayProgram.test.ts
@@ -60,7 +60,7 @@ describe('buildSwayPrograms', () => {
 
   test('logs to console when logging is enabled', async () => {
     const { spawn } = mockAll();
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { log: logSpy } = mockLogger();
 
     configureLogging({ isLoggingEnabled: true, isDebugEnabled: false });
 
@@ -74,12 +74,12 @@ describe('buildSwayPrograms', () => {
 
   test('logs debug to console when debug is enabled', async () => {
     const { spawn } = mockAll();
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { debug } = mockLogger();
     configureLogging({ isLoggingEnabled: true, isDebugEnabled: true });
 
     await buildSwayProgram(fuelsConfig, '/any/workspace/path');
 
     expect(spawn).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith(debugLog);
+    expect(debug).toHaveBeenCalledWith(debugLog);
   });
 });

--- a/packages/fuels/src/cli/commands/build/buildSwayProgram.ts
+++ b/packages/fuels/src/cli/commands/build/buildSwayProgram.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'child_process';
 
 import type { FuelsConfig } from '../../types';
-import { debug, loggingConfig } from '../../utils/logger';
+import { debug, log, loggingConfig } from '../../utils/logger';
 
 import { onForcExit, onForcError } from './forcHandlers';
 
@@ -12,14 +12,12 @@ export const buildSwayProgram = async (config: FuelsConfig, path: string) => {
     const args = ['build', '-p', path].concat(config.forcBuildFlags);
     const forc = spawn(config.forcPath, args, { stdio: 'pipe' });
     if (loggingConfig.isLoggingEnabled) {
-      // eslint-disable-next-line no-console
-      forc.stderr?.on('data', (chunk) => console.log(chunk.toString()));
+      forc.stderr?.on('data', (chunk) => log(chunk.toString()));
     }
 
     if (loggingConfig.isDebugEnabled) {
       forc.stdout?.on('data', (chunk) => {
-        // eslint-disable-next-line no-console
-        console.log(chunk.toString());
+        debug(chunk.toString());
       });
     }
 

--- a/packages/fuels/src/cli/commands/init/index.ts
+++ b/packages/fuels/src/cli/commands/init/index.ts
@@ -51,6 +51,7 @@ export function init(program: Command) {
   const noneIsInformed = ![workspace, contracts, scripts, predicates].find((v) => v !== undefined);
   if (noneIsInformed) {
     // mimicking commander property validation
+    // We want to use `console.log` here to avoid the ability to turn off this command prompt.
     // eslint-disable-next-line no-console
     console.log(`error: required option '-w, --workspace <path>' not specified\r`);
     process.exit(1);
@@ -74,8 +75,7 @@ export function init(program: Command) {
       message.push(`- predicate/s detected ${predicateLength}`);
     }
 
-    // eslint-disable-next-line no-console
-    console.log(message.join('\r\n'));
+    log(message.join('\r\n'));
     process.exit(1);
   }
 

--- a/packages/fuels/test/features/init.test.ts
+++ b/packages/fuels/test/features/init.test.ts
@@ -131,7 +131,7 @@ describe('init', () => {
   });
 
   it('should run `init` command with --contracts [no matches - log error]', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { log } = mockLogger();
     const exit = vi.spyOn(process, 'exit').mockResolvedValue({} as never);
 
     await runInit({
@@ -140,8 +140,8 @@ describe('init', () => {
       output: paths.outputDir,
     });
 
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith(
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledWith(
       ['error: unable to detect program/s', '- contract/s detected 0'].join('\r\n')
     );
     expect(exit).toHaveBeenCalledTimes(1);

--- a/vitest.browser.config.mts
+++ b/vitest.browser.config.mts
@@ -52,6 +52,8 @@ const config: ViteUserConfig = {
       headless: true,
       enabled: true,
       name: "chromium",
+      // Avoids taking screenshots
+      screenshotFailures: false,
     },
   },
 };


### PR DESCRIPTION
# Summary

- Made `docs` `build:forc` command silent, so the CLI output is less noisy
- Fixed incorrect logger usage in `fuels`
- Suppress warning errors from `docs-api`
  - We get 200+ warnings, but unable to see the errors, now it's easier to see the errors.
- Added command to delete all `*.test.ts` files from the docs
  - Allows for switching branches and errors not occurring with previous test files
- Suppress screenshots from `vitest`

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
