### PR TITLE
chore: switching from `cdnjs` to `jsdelivr`

### DIFF
--- a/apps/docs/src/guide/getting-started/cdn-usage.md
+++ b/apps/docs/src/guide/getting-started/cdn-usage.md
@@ -10,7 +10,7 @@
   import {
     Wallet,
     Provider,
-  } from "https://cdnjs.cloudflare.com/ajax/libs/fuels/{{fuels}}/browser.mjs";
+  } from "https://cdn.jsdelivr.net/npm/fuels@{{fuels}}/dist/browser.min.mjs";
 
   const main = async () => {
     const provider = new Provider(


### PR DESCRIPTION
- Close #3856

# Release notes

In this release, we:

- Switched CDN provider from `cdnjs` to `jsdelivr`

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
