### PR TITLE
fix: ci md-links check

### DIFF
--- a/apps/docs/src/guide/testing/fuel-core-options.md
+++ b/apps/docs/src/guide/testing/fuel-core-options.md
@@ -12,7 +12,7 @@ The `launchTestNode` creates a temporary snapshot directory and configurations e
 
 The default snapshot used is that of the current testnet network iteration.
 
-Click [here](https://github.com/FuelLabs/fuels-ts/blob/master/.fuel-core/configs) to see what it looks like.
+Click [here](https://github.com/FuelLabs/fuels-ts/tree/master/.fuel-core/configs) to see what it looks like.
 
 ## Custom Snapshot
 

--- a/link-check.config.json
+++ b/link-check.config.json
@@ -2,8 +2,8 @@
   "aliveStatusCodes": [200, 206],
   "timeout": "10s",
   "retryOn429": true,
-  "retryCount": 2,
-  "fallbackRetryDelay": "5s",
+  "retryCount": 10,
+  "fallbackRetryDelay": "10s",
   "ignorePatterns": [
     {
       "pattern": "^http://localhost:3000"


### PR DESCRIPTION
# Summary

Adjusted `retryOptions` to fix [GH rate-limit issue](https://www.google.com/search?q=markdown-link-check+status+429+github+links&oq=markdown-link-check+status+429+github+links&gs_lcrp=EgZjaHJvbWUyBggAEEUYOdIBCDU4MzZqMGoxqAIAsAIA&sourceid=chrome&ie=UTF-8).

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
