### PR TITLE
feat: implement methods to serialize/deserialize `TransactionResponse`

### DIFF
--- a/.changeset/nine-games-arrive.md
+++ b/.changeset/nine-games-arrive.md
@@ -2,4 +2,4 @@
 "@fuel-ts/account": patch
 ---
 
-feat: implement methods to serialize/deserialize TransactionResponse
+feat: implement methods to serialize/deserialize `TransactionResponse`

--- a/.changeset/nine-games-arrive.md
+++ b/.changeset/nine-games-arrive.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+feat: implement methods to serialize/deserialize TransactionResponse

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -31,11 +31,12 @@ import type {
   GetBalancesResponse,
   Coin,
   TransactionCostParams,
-  TransactionResponse,
   ProviderSendTxParams,
   TransactionSummaryJson,
   TransactionResult,
   TransactionType,
+  TransactionResponseJson,
+  TransactionResponse,
 } from './providers';
 import {
   withdrawScript,
@@ -54,6 +55,7 @@ import {
 } from './providers/transaction-request/helpers';
 import { mergeQuantities } from './providers/utils/merge-quantities';
 import { serializeProviderCache } from './providers/utils/serialization';
+import { deserializeTransactionResponseJson } from './providers/utils/transaction-response-serialization';
 import { AbstractAccount } from './types';
 import { assembleTransferToContractScript } from './utils/formatTransferToContractScriptData';
 import { splitCoinsIntoBatches } from './utils/split-coins-into-batches';
@@ -926,7 +928,7 @@ export class Account extends AbstractAccount implements WithAddress {
         transactionSummary: await this.prepareTransactionSummary(transactionRequest),
       };
 
-      const transaction: string | TransactionResponse = await this._connector.sendTransaction(
+      const transaction: string | TransactionResponseJson = await this._connector.sendTransaction(
         this.address.toString(),
         transactionRequest,
         params
@@ -934,7 +936,7 @@ export class Account extends AbstractAccount implements WithAddress {
 
       return typeof transaction === 'string'
         ? this.provider.getTransactionResponse(transaction)
-        : transaction;
+        : deserializeTransactionResponseJson(transaction);
     }
 
     if (estimateTxDependencies) {

--- a/packages/account/src/connectors/fuel-connector.ts
+++ b/packages/account/src/connectors/fuel-connector.ts
@@ -4,7 +4,7 @@ import type { HashableMessage } from '@fuel-ts/hasher';
 import { EventEmitter } from 'events';
 
 import type { Asset } from '../assets/types';
-import type { TransactionRequestLike, TransactionResponse } from '../providers';
+import type { TransactionRequestLike, TransactionResponseJson } from '../providers';
 
 import { FuelConnectorEventTypes } from './types';
 import type {
@@ -48,7 +48,7 @@ interface Connector {
     address: string,
     transaction: TransactionRequestLike,
     params?: FuelConnectorSendTxParams
-  ): Promise<string | TransactionResponse>;
+  ): Promise<string | TransactionResponseJson>;
   // #endregion fuel-connector-method-sendTransaction
   // #region fuel-connector-method-currentAccount
   currentAccount(): Promise<string | null>;
@@ -206,7 +206,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
     _address: string,
     _transaction: TransactionRequestLike,
     _params?: FuelConnectorSendTxParams
-  ): Promise<string | TransactionResponse> {
+  ): Promise<string | TransactionResponseJson> {
     throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 

--- a/packages/account/src/providers/transaction-request/transaction-request.ts
+++ b/packages/account/src/providers/transaction-request/transaction-request.ts
@@ -88,6 +88,8 @@ export interface BaseTransactionRequestLike {
   outputs?: TransactionRequestOutput[];
   /** List of witnesses */
   witnesses?: TransactionRequestWitness[];
+  /** The state of the transaction */
+  flag?: TransactionStateFlag;
 }
 
 type ToBaseTransactionResponse = Pick<
@@ -134,8 +136,6 @@ export abstract class BaseTransactionRequest implements BaseTransactionRequestLi
   witnesses: TransactionRequestWitness[] = [];
 
   /**
-   * @hidden
-   *
    * The current status of the transaction
    */
   flag: TransactionStateFlag = { state: undefined, transactionId: undefined, summary: undefined };
@@ -154,6 +154,7 @@ export abstract class BaseTransactionRequest implements BaseTransactionRequestLi
     inputs,
     outputs,
     witnesses,
+    flag,
   }: BaseTransactionRequestLike = {}) {
     this.tip = tip ? bn(tip) : undefined;
     this.maturity = maturity && maturity > 0 ? maturity : undefined;
@@ -163,6 +164,7 @@ export abstract class BaseTransactionRequest implements BaseTransactionRequestLi
     this.inputs = inputs ?? [];
     this.outputs = outputs ?? [];
     this.witnesses = witnesses ?? [];
+    this.flag = flag ?? { state: undefined, transactionId: undefined, summary: undefined };
   }
 
   static getPolicyMeta(req: BaseTransactionRequest) {

--- a/packages/account/src/providers/transaction-response/transaction-response.ts
+++ b/packages/account/src/providers/transaction-response/transaction-response.ts
@@ -591,22 +591,22 @@ export class TransactionResponse {
     };
   }
 
-  static async fromJson(json: TransactionResponseJson): Promise<TransactionResponse> {
+  static fromJson(json: TransactionResponseJson): TransactionResponse {
     const {
       id,
-      gqlTransaction,
-      status,
-      preConfirmationStatus,
       abis,
-      providerCache,
+      status,
       providerUrl,
       requestJson,
+      providerCache,
+      gqlTransaction,
+      preConfirmationStatus,
     } = json;
 
     const provider = new Provider(providerUrl, { cache: providerCache });
-    const chainId = await provider.getChainId();
+    const { chainId } = providerCache.chain.consensusParameters;
 
-    const response = new TransactionResponse(id, provider, chainId, abis);
+    const response = new TransactionResponse(id, provider, Number(chainId), abis);
 
     if (requestJson) {
       response.request = JSON.parse(requestJson);

--- a/packages/account/src/providers/utils/transaction-response-serialization.test.ts
+++ b/packages/account/src/providers/utils/transaction-response-serialization.test.ts
@@ -49,10 +49,7 @@ describe('Transaction Response Serialization', () => {
     expect(deserialized.preConfirmationStatus).toBeDefined();
     expect(deserialized.request).toBeDefined();
 
-    delete request.abis;
-    delete request.maturity;
-
-    expect(request).toStrictEqual(deserialized.request);
+    expect(request.toJSON()).toEqual(deserialized.request?.toJSON());
   });
 
   it('should serialize and deserialize a transaction response correctly [W/O TX REQUEST]', async () => {
@@ -134,5 +131,7 @@ describe('Transaction Response Serialization', () => {
 
     expect(deserialized.preConfirmationStatus).toBeUndefined();
     expect(deserialized.gqlTransaction).toBeUndefined();
+
+    expect(request.toJSON()).toEqual(deserialized.request?.toJSON());
   });
 });

--- a/packages/account/src/providers/utils/transaction-response-serialization.test.ts
+++ b/packages/account/src/providers/utils/transaction-response-serialization.test.ts
@@ -1,0 +1,138 @@
+import { setupTestProviderAndWallets } from '../../test-utils';
+import { TransactionResponse } from '../transaction-response';
+
+import {
+  serializeTransactionResponseJson,
+  deserializeTransactionResponseJson,
+} from './transaction-response-serialization';
+
+describe('Transaction Response Serialization', () => {
+  it('should serialize and deserialize a transaction response correctly [W/ TX REQUEST]', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const {
+      provider,
+      wallets: [wallet],
+    } = launched;
+
+    const baseAssetId = await provider.getBaseAssetId();
+    const request = await wallet.createTransfer(wallet.address, 100_000, baseAssetId, {
+      expiration: 200,
+      tip: 1,
+      witnessLimit: 3000,
+    });
+    const response = await wallet.sendTransaction(request);
+    await response.waitForResult();
+
+    // Serialize the response
+    const serialized = await serializeTransactionResponseJson(response);
+
+    // Verify serialized data
+    expect(serialized.id).toBe(response.id);
+    expect(serialized.status).toBe(response.status);
+    expect(serialized.abis).toBe(response.abis);
+    expect(serialized.providerUrl).toBe(provider.url);
+    expect(serialized.preConfirmationStatus).toBeDefined();
+    expect(serialized.requestJson).toBeDefined();
+
+    // Undefined because fetch was never called
+    expect(serialized.gqlTransaction).toBeUndefined();
+
+    // Deserialize the response
+    const deserialized = deserializeTransactionResponseJson(serialized);
+
+    // Verify deserialized data
+    expect(deserialized.id).toBe(response.id);
+    expect(deserialized.status).toBe(response.status);
+    expect(deserialized.abis).toBe(response.abis);
+    expect(deserialized.provider.url).toBe(provider.url);
+    expect(deserialized.gqlTransaction).toBeUndefined();
+    expect(deserialized.preConfirmationStatus).toBeDefined();
+    expect(deserialized.request).toBeDefined();
+
+    delete request.abis;
+    delete request.maturity;
+
+    expect(request).toStrictEqual(deserialized.request);
+  });
+
+  it('should serialize and deserialize a transaction response correctly [W/O TX REQUEST]', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const {
+      provider,
+      wallets: [wallet],
+    } = launched;
+
+    const { id } = await wallet.transfer(wallet.address, 100_000);
+
+    const response = new TransactionResponse(id, provider, await provider.getChainId());
+    await response.waitForResult();
+
+    // Serialize the response
+    const serialized = await serializeTransactionResponseJson(response);
+
+    // Verify serialized data
+    expect(serialized.id).toBe(response.id);
+    expect(serialized.status).toBe(response.status);
+    expect(serialized.abis).toBe(response.abis);
+    expect(serialized.providerUrl).toBe(provider.url);
+    expect(serialized.gqlTransaction).toBeDefined();
+
+    // Undefined because it was not provided at the constructor
+    expect(serialized.requestJson).toBeUndefined();
+    expect(serialized.preConfirmationStatus).toBeUndefined();
+
+    // Deserialize the response
+    const deserialized = deserializeTransactionResponseJson(serialized);
+
+    // Verify deserialized data
+    expect(deserialized.id).toBe(response.id);
+    expect(deserialized.status).toBe(response.status);
+    expect(deserialized.abis).toBe(response.abis);
+    expect(deserialized.provider.url).toBe(provider.url);
+    expect(deserialized.gqlTransaction).toBeDefined();
+
+    expect(deserialized.preConfirmationStatus).toBeUndefined();
+    expect(deserialized.request).toBeUndefined();
+  });
+
+  it('should serialize and deserialize a transaction response correctly [W/ TX REQUEST AND NEW TX RESPONSE]', async () => {
+    using launched = await setupTestProviderAndWallets();
+    const {
+      provider,
+      wallets: [wallet],
+    } = launched;
+
+    const request = await wallet.createTransfer(wallet.address, 100_000);
+    await wallet.sendTransaction(request);
+
+    const response = new TransactionResponse(request, provider, await provider.getChainId());
+    await response.waitForResult();
+
+    // Serialize the response
+    const serialized = await serializeTransactionResponseJson(response);
+
+    // Verify serialized data
+    expect(serialized.id).toBe(response.id);
+    expect(serialized.status).toBe(response.status);
+    expect(serialized.abis).toBe(response.abis);
+    expect(serialized.providerUrl).toBe(provider.url);
+    expect(serialized.requestJson).toBeDefined();
+
+    // 'gqlTransaction' will be undefined because the TX request was provided
+    expect(serialized.gqlTransaction).toBeUndefined();
+    expect(serialized.preConfirmationStatus).toBeUndefined();
+
+    // Deserialize the response
+    const deserialized = deserializeTransactionResponseJson(serialized);
+
+    // Verify deserialized data
+    expect(deserialized.id).toBe(response.id);
+    expect(deserialized.status).toBe(response.status);
+    expect(deserialized.abis).toBe(response.abis);
+    expect(deserialized.provider.url).toBe(provider.url);
+    expect(deserialized.request).toBeDefined();
+
+    expect(deserialized.preConfirmationStatus).toBeUndefined();
+    expect(deserialized.gqlTransaction).toBeUndefined();
+  });
+});

--- a/packages/account/src/providers/utils/transaction-response-serialization.test.ts
+++ b/packages/account/src/providers/utils/transaction-response-serialization.test.ts
@@ -6,6 +6,10 @@ import {
   deserializeTransactionResponseJson,
 } from './transaction-response-serialization';
 
+/**
+ * @group node
+ * @group browser
+ */
 describe('Transaction Response Serialization', () => {
   it('should serialize and deserialize a transaction response correctly [W/ TX REQUEST]', async () => {
     using launched = await setupTestProviderAndWallets();

--- a/packages/account/src/providers/utils/transaction-response-serialization.ts
+++ b/packages/account/src/providers/utils/transaction-response-serialization.ts
@@ -1,0 +1,53 @@
+import Provider from '../provider';
+import type { TransactionResponseJson } from '../transaction-response';
+import { TransactionResponse } from '../transaction-response';
+
+import { serializeProviderCache } from './serialization';
+
+/**
+ * NOTE: This is defined within a new file to avoid circular dependencies.
+ */
+
+export const serializeTransactionResponseJson = async (
+  response: TransactionResponse
+): Promise<TransactionResponseJson> => {
+  const { id, status, abis, request, provider, gqlTransaction, preConfirmationStatus } = response;
+  return {
+    id,
+    status,
+    abis,
+    requestJson: JSON.stringify(request),
+    providerUrl: provider.url,
+    providerCache: await serializeProviderCache(provider),
+    gqlTransaction,
+    preConfirmationStatus,
+  };
+};
+
+export const deserializeTransactionResponseJson = (json: TransactionResponseJson) => {
+  const {
+    id,
+    abis,
+    status,
+    providerUrl,
+    requestJson,
+    providerCache,
+    gqlTransaction,
+    preConfirmationStatus,
+  } = json;
+
+  const provider = new Provider(providerUrl, { cache: providerCache });
+  const { chainId } = providerCache.chain.consensusParameters;
+
+  const response = new TransactionResponse(id, provider, Number(chainId), abis);
+
+  if (requestJson) {
+    response.request = JSON.parse(requestJson);
+  }
+
+  response.status = status;
+  response.gqlTransaction = gqlTransaction;
+  response.preConfirmationStatus = preConfirmationStatus;
+
+  return response;
+};

--- a/packages/account/src/providers/utils/transaction-response-serialization.ts
+++ b/packages/account/src/providers/utils/transaction-response-serialization.ts
@@ -1,4 +1,5 @@
 import Provider from '../provider';
+import { transactionRequestify } from '../transaction-request';
 import type { TransactionResponseJson } from '../transaction-response';
 import { TransactionResponse } from '../transaction-response';
 
@@ -16,7 +17,7 @@ export const serializeTransactionResponseJson = async (
     id,
     status,
     abis,
-    requestJson: JSON.stringify(request),
+    requestJson: request ? JSON.stringify(request.toJSON()) : undefined,
     providerUrl: provider.url,
     providerCache: await serializeProviderCache(provider),
     gqlTransaction,
@@ -42,7 +43,7 @@ export const deserializeTransactionResponseJson = (json: TransactionResponseJson
   const response = new TransactionResponse(id, provider, Number(chainId), abis);
 
   if (requestJson) {
-    response.request = JSON.parse(requestJson);
+    response.request = transactionRequestify(JSON.parse(requestJson));
   }
 
   response.status = status;

--- a/packages/account/test/fixtures/mocked-connector.ts
+++ b/packages/account/test/fixtures/mocked-connector.ts
@@ -11,7 +11,7 @@ import type {
   Network,
   SelectNetworkArguments,
   AccountSendTxParams,
-  TransactionResponse,
+  TransactionResponseJson,
 } from '../../src';
 import type { Asset } from '../../src/assets/types';
 import { FuelConnector } from '../../src/connectors/fuel-connector';
@@ -112,7 +112,7 @@ export class MockConnector extends FuelConnector {
     _address: string,
     _transaction: TransactionRequestLike,
     _params: AccountSendTxParams
-  ): Promise<string | TransactionResponse> {
+  ): Promise<string | TransactionResponseJson> {
     const wallet = this._wallets.find((w) => w.address.toString() === _address);
     if (!wallet) {
       throw new Error('Wallet is not found!');

--- a/packages/account/test/fixtures/mocked-send-transaction-connector.ts
+++ b/packages/account/test/fixtures/mocked-send-transaction-connector.ts
@@ -4,7 +4,7 @@ import type {
   AccountSendTxParams,
   ScriptTransactionRequest,
   TransactionStateFlag,
-  TransactionResponse,
+  TransactionResponseJson,
 } from '../../src';
 
 import { MockConnector } from './mocked-connector';
@@ -14,7 +14,7 @@ export class MockSendTransactionConnector extends MockConnector {
     _address: string,
     _transaction: TransactionRequestLike,
     _params: AccountSendTxParams
-  ): Promise<string | TransactionResponse> {
+  ): Promise<string | TransactionResponseJson> {
     const wallet = this._wallets.find((w) => w.address.toString() === _address);
     if (!wallet) {
       throw new Error('Wallet is not found!');


### PR DESCRIPTION
- Closes #3877

# Release notes

In this release, we:

- Implemented helpers to serialize/deserialize `TransactionResponse`

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
