### PR TITLE
chore: made connector returns `TransactionResponse` type

### DIFF
--- a/.changeset/cyan-oranges-smash.md
+++ b/.changeset/cyan-oranges-smash.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+chore: made connector returns `TransactionResponse` type

--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -35,7 +35,6 @@ import type {
   TransactionSummaryJson,
   TransactionResult,
   TransactionType,
-  TransactionResponseJson,
   TransactionResponse,
 } from './providers';
 import {
@@ -55,7 +54,6 @@ import {
 } from './providers/transaction-request/helpers';
 import { mergeQuantities } from './providers/utils/merge-quantities';
 import { serializeProviderCache } from './providers/utils/serialization';
-import { deserializeTransactionResponseJson } from './providers/utils/transaction-response-serialization';
 import { AbstractAccount } from './types';
 import { assembleTransferToContractScript } from './utils/formatTransferToContractScriptData';
 import { splitCoinsIntoBatches } from './utils/split-coins-into-batches';
@@ -928,7 +926,7 @@ export class Account extends AbstractAccount implements WithAddress {
         transactionSummary: await this.prepareTransactionSummary(transactionRequest),
       };
 
-      const transaction: string | TransactionResponseJson = await this._connector.sendTransaction(
+      const transaction: string | TransactionResponse = await this._connector.sendTransaction(
         this.address.toString(),
         transactionRequest,
         params
@@ -936,7 +934,7 @@ export class Account extends AbstractAccount implements WithAddress {
 
       return typeof transaction === 'string'
         ? this.provider.getTransactionResponse(transaction)
-        : deserializeTransactionResponseJson(transaction);
+        : transaction;
     }
 
     if (estimateTxDependencies) {

--- a/packages/account/src/connectors/fuel-connector.ts
+++ b/packages/account/src/connectors/fuel-connector.ts
@@ -4,7 +4,7 @@ import type { HashableMessage } from '@fuel-ts/hasher';
 import { EventEmitter } from 'events';
 
 import type { Asset } from '../assets/types';
-import type { TransactionRequestLike, TransactionResponseJson } from '../providers';
+import type { TransactionRequestLike, TransactionResponse } from '../providers';
 
 import { FuelConnectorEventTypes } from './types';
 import type {
@@ -48,7 +48,7 @@ interface Connector {
     address: string,
     transaction: TransactionRequestLike,
     params?: FuelConnectorSendTxParams
-  ): Promise<string | TransactionResponseJson>;
+  ): Promise<string | TransactionResponse>;
   // #endregion fuel-connector-method-sendTransaction
   // #region fuel-connector-method-currentAccount
   currentAccount(): Promise<string | null>;
@@ -206,7 +206,7 @@ export abstract class FuelConnector extends EventEmitter implements Connector {
     _address: string,
     _transaction: TransactionRequestLike,
     _params?: FuelConnectorSendTxParams
-  ): Promise<string | TransactionResponseJson> {
+  ): Promise<string | TransactionResponse> {
     throw new FuelError(FuelError.CODES.NOT_IMPLEMENTED, 'Method not implemented.');
   }
 

--- a/packages/account/src/providers/index.ts
+++ b/packages/account/src/providers/index.ts
@@ -12,3 +12,4 @@ export * from './transaction-summary';
 export * from './utils';
 export * from './chains';
 export * from './assemble-tx-helpers';
+export * from './utils/transaction-response-serialization'; // NOTE: we export this here to avoid circular dependencies.

--- a/packages/account/src/providers/utils/transaction-response-serialization.ts
+++ b/packages/account/src/providers/utils/transaction-response-serialization.ts
@@ -1,12 +1,13 @@
 import Provider from '../provider';
 import { transactionRequestify } from '../transaction-request';
-import type { TransactionResponseJson } from '../transaction-response';
 import { TransactionResponse } from '../transaction-response';
+import type { TransactionResponseJson } from '../transaction-response';
 
 import { serializeProviderCache } from './serialization';
 
 /**
- * NOTE: This is defined within a new file to avoid circular dependencies.
+ * NOTE: These helpers are defined here instead of in "serialization.ts"
+ * to avoid circular dependencies.
  */
 
 export const serializeTransactionResponseJson = async (

--- a/packages/account/test/fixtures/mocked-connector.ts
+++ b/packages/account/test/fixtures/mocked-connector.ts
@@ -11,7 +11,7 @@ import type {
   Network,
   SelectNetworkArguments,
   AccountSendTxParams,
-  TransactionResponseJson,
+  TransactionResponse,
 } from '../../src';
 import type { Asset } from '../../src/assets/types';
 import { FuelConnector } from '../../src/connectors/fuel-connector';
@@ -112,7 +112,7 @@ export class MockConnector extends FuelConnector {
     _address: string,
     _transaction: TransactionRequestLike,
     _params: AccountSendTxParams
-  ): Promise<string | TransactionResponseJson> {
+  ): Promise<string | TransactionResponse> {
     const wallet = this._wallets.find((w) => w.address.toString() === _address);
     if (!wallet) {
       throw new Error('Wallet is not found!');

--- a/packages/account/test/fixtures/mocked-send-transaction-connector.ts
+++ b/packages/account/test/fixtures/mocked-send-transaction-connector.ts
@@ -4,7 +4,7 @@ import type {
   AccountSendTxParams,
   ScriptTransactionRequest,
   TransactionStateFlag,
-  TransactionResponseJson,
+  TransactionResponse,
 } from '../../src';
 
 import { MockConnector } from './mocked-connector';
@@ -14,7 +14,7 @@ export class MockSendTransactionConnector extends MockConnector {
     _address: string,
     _transaction: TransactionRequestLike,
     _params: AccountSendTxParams
-  ): Promise<string | TransactionResponseJson> {
+  ): Promise<string | TransactionResponse> {
     const wallet = this._wallets.find((w) => w.address.toString() === _address);
     if (!wallet) {
       throw new Error('Wallet is not found!');


### PR DESCRIPTION
# Release notes

In this release, we:

- Made connector `sendTransaction` return `TransactionResponse` instead `TransactionResponseJson`

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
