### PR TITLE
fix!: enforce `predicateData` when predicate has arguments

### DIFF
--- a/.changeset/loud-bags-deny.md
+++ b/.changeset/loud-bags-deny.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": minor
+---
+
+fix!: enforce `predicateData` when predicate has arguments

--- a/apps/create-fuels-counter-guide/src/components/Predicate.tsx
+++ b/apps/create-fuels-counter-guide/src/components/Predicate.tsx
@@ -31,7 +31,10 @@ export default function Predicate() {
 
   useEffect(() => {
     if (wallet) {
-      const testPredicate = new TestPredicate(wallet);
+      const testPredicate = new TestPredicate({
+        provider: wallet.provider,
+        data: [0],
+      });
       setPredicate(testPredicate);
     }
   }, [wallet]);

--- a/apps/docs/src/guide/predicates/snippets/deploying-predicates.ts
+++ b/apps/docs/src/guide/predicates/snippets/deploying-predicates.ts
@@ -16,6 +16,7 @@ const baseAssetId = await provider.getBaseAssetId();
 // We can deploy dynamically or via `fuels deploy`
 const originalPredicate = new ConfigurablePin({
   provider,
+  data: [1337],
 });
 
 const { waitForResult: waitForDeploy } = await originalPredicate.deploy(wallet);

--- a/packages/fuel-gauge/src/blob-deploy.test.ts
+++ b/packages/fuel-gauge/src/blob-deploy.test.ts
@@ -18,7 +18,7 @@ import {
 describe('deploying blobs', () => {
   function decodeConfigurables(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    program: Predicate | Script<any, any>
+    program: Predicate<any, any> | Script<any, any>
   ): Record<string, unknown> {
     const configurables: Record<string, unknown> = {};
 
@@ -225,10 +225,6 @@ describe('deploying blobs', () => {
 
     const receiver = Wallet.generate({ provider });
 
-    const loaderPredicate = await (
-      await new PredicateWithMoreConfigurables({ provider }).deploy(wallet)
-    ).waitForResult();
-
     const configurable = {
       FEE: 99,
       ADDRESS: getRandomB256(),
@@ -237,6 +233,13 @@ describe('deploying blobs', () => {
       U64: 1000000,
       BOOL: false,
     };
+
+    const loaderPredicate = await (
+      await new PredicateWithMoreConfigurables({
+        provider,
+        data: [configurable.FEE, configurable.ADDRESS],
+      }).deploy(wallet)
+    ).waitForResult();
 
     const predicate = new Predicate({
       data: [configurable.FEE, configurable.ADDRESS],

--- a/packages/fuel-gauge/src/predicate/predicate-configurables.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-configurables.test.ts
@@ -239,6 +239,7 @@ describe('Predicate', () => {
 
       const predicate = new PredicateWithConfigurable({
         provider,
+        data: [99, getRandomB256()],
       });
 
       const destination = WalletUnlocked.generate({

--- a/packages/fuel-gauge/src/predicate/predicate-estimations.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-estimations.test.ts
@@ -46,6 +46,12 @@ describe('Predicate', () => {
         bytecode: PredicateMainArgsStruct.bytecode,
         abi: PredicateMainArgsStruct.abi,
         provider,
+        data: [
+          {
+            has_account: true,
+            total_complete: 100,
+          },
+        ],
       });
 
       await fundAccount(wallet, predicateStruct, fundingAmount);
@@ -53,13 +59,14 @@ describe('Predicate', () => {
       const tx = new ScriptTransactionRequest();
 
       // Get resources from the predicate struct
-      const ressources = await predicateStruct.getResourcesToSpend([
+      const resources = await predicateStruct.getResourcesToSpend([
         {
           assetId: await provider.getBaseAssetId(),
           amount: bn(10_000),
         },
       ]);
-      tx.addResource(ressources[0]);
+
+      tx.addResource(resources[0]);
       // Add predicate bytecode to the input predicate
       (<CoinTransactionRequestInput>tx.inputs[0]).predicate = predicateStruct.bytes;
 
@@ -167,6 +174,12 @@ describe('Predicate', () => {
         abi: PredicateMainArgsStruct.abi,
         bytecode: PredicateMainArgsStruct.bytecode,
         provider,
+        data: [
+          {
+            has_account: true,
+            total_complete: 100,
+          },
+        ],
       });
 
       await fundAccount(wallet, predicateTrue, fundingAmount);
@@ -254,6 +267,12 @@ describe('Predicate', () => {
           abi: PredicateMainArgsStruct.abi,
           bytecode: PredicateMainArgsStruct.bytecode,
           provider,
+          data: [
+            {
+              has_account: true,
+              total_complete: 100,
+            },
+          ],
         });
 
         await fundAccount(wallet, predicateStruct, fundingAmount);
@@ -288,6 +307,12 @@ describe('Predicate', () => {
           abi: PredicateMainArgsStruct.abi,
           bytecode: PredicateMainArgsStruct.bytecode,
           provider,
+          data: [
+            {
+              has_account: true,
+              total_complete: 100,
+            },
+          ],
         });
 
         await fundAccount(wallet, predicateStruct, fundingAmount);

--- a/packages/fuel-gauge/src/predicate/predicate-invalidations.test.ts
+++ b/packages/fuel-gauge/src/predicate/predicate-invalidations.test.ts
@@ -23,6 +23,12 @@ describe('Predicate', () => {
         abi: PredicateMainArgsStruct.abi,
         bytecode: PredicateMainArgsStruct.bytecode,
         provider,
+        data: [
+          {
+            has_account: true,
+            total_complete: 100,
+          },
+        ],
       });
 
       await fundAccount(wallet, predicate, 1000);
@@ -57,6 +63,12 @@ describe('Predicate', () => {
         abi: PredicateMainArgsStruct.abi,
         bytecode: PredicateMainArgsStruct.bytecode,
         provider,
+        data: [
+          {
+            has_account: true,
+            total_complete: 100,
+          },
+        ],
       });
 
       await fundAccount(wallet, predicate, 10_000);

--- a/templates/nextjs/src/components/Predicate.tsx
+++ b/templates/nextjs/src/components/Predicate.tsx
@@ -36,7 +36,10 @@ export default function Predicate() {
 
   useEffect(() => {
     if (wallet) {
-      const testPredicate = new TestPredicate(wallet);
+      const testPredicate = new TestPredicate({
+        provider: wallet.provider,
+        data: [0],
+      });
       setPredicate(testPredicate);
     }
   }, [wallet]);

--- a/templates/vite/src/components/Predicate.tsx
+++ b/templates/vite/src/components/Predicate.tsx
@@ -35,7 +35,10 @@ export default function Predicate() {
 
   useEffect(() => {
     if (wallet) {
-      const testPredicate = new TestPredicate(wallet);
+      const testPredicate = new TestPredicate({
+        provider: wallet.provider,
+        data: [0],
+      });
       setPredicate(testPredicate);
     }
   }, [wallet]);


### PR DESCRIPTION
- Closes #3771
- Closes #1552

# Release notes

In this release, we:

- Enforced Predicate's `data` property when the Predicate has arguments

# Breaking Changes

Predicates that define arguments must now be instantiated with the data property. It is no longer allowed to omit data when the predicate expects input arguments.

For example, for the given predicate:

```rs
predicate;

fn main(pin: u64) -> bool {
    return 999 == pin;
}
```

The following code would compile, even though the predicate expects arguments:

```ts
// before
const predicateNoData = new PredicatePin({ provider }) // ✅ Allowed (incorrectly)

const predicate = new PredicatePin({ provider, data: [100] }) // ✅ Correct
```

TypeScript now enforces that data must be provided:

```ts
// after
const predicateNoData = new PredicatePin({ provider }) // ❌ Error: missing required `data`

const predicate = new PredicatePin({ provider, data: [100] }) // ✅ Correct
```
 
# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
