### PR TITLE
fix: close subscription after `Preconfirmation` status when applicable

### DIFF
--- a/.changeset/rare-kids-grab.md
+++ b/.changeset/rare-kids-grab.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+fix: close subscription after `Preconfirmation` status when applicable

--- a/packages/account/src/providers/transaction-response/transaction-response.ts
+++ b/packages/account/src/providers/transaction-response/transaction-response.ts
@@ -420,6 +420,12 @@ export class TransactionResponse {
       ) {
         this.preConfirmationStatus = statusChange;
         this.resolveStatus('preConfirmation');
+        // We should end the subscription here if we are not waiting for the confirmation status
+        const pendingConfirmationResolvers = this.statusResolvers.get('confirmation');
+        if (!pendingConfirmationResolvers) {
+          this.waitingForStreamData = false;
+          break;
+        }
       }
 
       if (statusChange.type === 'SuccessStatus' || statusChange.type === 'FailureStatus') {


### PR DESCRIPTION
- Closes #3888

# Release notes

In this release, we:

- Close subscription after `Preconfirmation` when another status is not awaited by the user

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
