### PR TITLE
chore: support Node 24 - depreciate Node 18

### DIFF
--- a/.changeset/fresh-kings-matter.md
+++ b/.changeset/fresh-kings-matter.md
@@ -1,0 +1,23 @@
+---
+"create-fuels": patch
+"@fuel-ts/transactions": patch
+"@fuel-ts/abi-typegen": patch
+"@fuel-ts/abi-coder": patch
+"@fuel-ts/contract": patch
+"@fuel-ts/versions": patch
+"@fuel-ts/account": patch
+"@fuel-ts/address": patch
+"@fuel-ts/program": patch
+"@fuel-ts/recipes": patch
+"@fuel-ts/crypto": patch
+"@fuel-ts/errors": patch
+"@fuel-ts/hasher": patch
+"@fuel-ts/logger": patch
+"@fuel-ts/merkle": patch
+"@fuel-ts/script": patch
+"fuels": patch
+"@fuel-ts/utils": patch
+"@fuel-ts/math": patch
+---
+
+chore: support Node 24 - depreciate Node 18

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         env:
           [
-            { name: node, version: 18.20.3, display-name: "node@18" },
             { name: node, version: 20.14.0, display-name: "node@20" },
             { name: node, version: 22.3.0, display-name: "node@22" },
             { name: browser, display-name: "browser" },

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         env:
           [
-            { name: node, version: 20.14.0, display-name: "node@20" },
-            { name: node, version: 22.3.0, display-name: "node@22" },
+            { name: node, version: 20.19.2, display-name: "node@20" },
+            { name: node, version: 22.16.0, display-name: "node@22" },
             { name: node, version: 24.1.0, display-name: "node@24" },
             { name: browser, display-name: "browser" },
           ]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ jobs:
           [
             { name: node, version: 20.14.0, display-name: "node@20" },
             { name: node, version: 22.3.0, display-name: "node@22" },
+            { name: node, version: 24.1.0, display-name: "node@24" },
             { name: browser, display-name: "browser" },
           ]
     timeout-minutes: 25

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "private": true,
   "engines": {
-    "node": "^20.0.0 || ^22.0.0",
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0",
     "pnpm": "^9.4.0"
   },
   "packageManager": "pnpm@9.4.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Fuel Labs <contact@fuel.sh> (https://fuel.network/)",
   "private": true,
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0",
+    "node": "^20.0.0 || ^22.0.0",
     "pnpm": "^9.4.0"
   },
   "packageManager": "pnpm@9.4.0",

--- a/packages/abi-coder/package.json
+++ b/packages/abi-coder/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/abi-coder/package.json
+++ b/packages/abi-coder/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/abi-typegen/package.json
+++ b/packages/abi-typegen/package.json
@@ -10,7 +10,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/abi-typegen/package.json
+++ b/packages/abi-typegen/package.json
@@ -10,7 +10,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/create-fuels/package.json
+++ b/packages/create-fuels/package.json
@@ -11,7 +11,7 @@
     "templates"
   ],
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/create-fuels/package.json
+++ b/packages/create-fuels/package.json
@@ -11,7 +11,7 @@
     "templates"
   ],
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "browser": {
     "./dist/index.mjs": "./dist/index.browser.mjs"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "browser": {
     "./dist/index.mjs": "./dist/index.browser.mjs"

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -10,7 +10,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/fuels/package.json
+++ b/packages/fuels/package.json
@@ -10,7 +10,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/hasher/package.json
+++ b/packages/hasher/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/FuelLabs/fuels-ts/issues"
   },
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/FuelLabs/fuels-ts/issues"
   },
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/merkle/package.json
+++ b/packages/merkle/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/merkle/package.json
+++ b/packages/merkle/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/program/package.json
+++ b/packages/program/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/program/package.json
+++ b/packages/program/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/recipes/package.json
+++ b/packages/recipes/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/recipes/package.json
+++ b/packages/recipes/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/script/package.json
+++ b/packages/script/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,7 +7,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -10,7 +10,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^18.20.3 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/versions/package.json
+++ b/packages/versions/package.json
@@ -10,7 +10,7 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
- Related to #3524 

# Release notes

In this release, we:

- Deprecated Node 18 - upgrade to a newer version of Node.

# Summary

Removed support for Node 18 due to the version no longer being maintained.

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
