### PR TITLE
feat: ensure that undecodable logs no longer throw

### DIFF
--- a/.changeset/shiny-laws-agree.md
+++ b/.changeset/shiny-laws-agree.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/account": patch
+---
+
+feat: ensure that undecodable logs no longer throw

--- a/packages/account/src/providers/transaction-response/getAllDecodedLogs.ts
+++ b/packages/account/src/providers/transaction-response/getAllDecodedLogs.ts
@@ -65,10 +65,17 @@ export function getAllDecodedLogs<T = unknown>(opts: {
               ? new BigNumberCoder('u64').encode(receipt.ra)
               : receipt.data;
 
-          const [decodedLog] = interfaceToUse.decodeLog(data, receipt.rb.toString());
-          logs.push(decodedLog);
+          let logEntry: unknown;
+
+          try {
+            [logEntry] = interfaceToUse.decodeLog(data, receipt.rb.toString());
+          } catch (error) {
+            logEntry = { __decoded: false, data, logId: receipt.rb.toString() }
+          }
+
+          logs.push(logEntry as T);
           // eslint-disable-next-line no-param-reassign
-          groupedLogs[receipt.id] = [...(groupedLogs[receipt.id] || []), decodedLog];
+          groupedLogs[receipt.id] = [...(groupedLogs[receipt.id] || []), logEntry as T];
         }
       }
 

--- a/packages/account/src/providers/transaction-response/getDecodedLogs.ts
+++ b/packages/account/src/providers/transaction-response/getDecodedLogs.ts
@@ -57,8 +57,15 @@ export function getDecodedLogs<T = unknown>(
             ? new BigNumberCoder('u64').encode(receipt.ra)
             : receipt.data;
 
-        const [decodedLog] = interfaceToUse.decodeLog(data, receipt.rb.toString());
-        logs.push(decodedLog);
+        let logEntry: unknown;
+
+        try {
+          [logEntry] = interfaceToUse.decodeLog(data, receipt.rb.toString());
+        } catch (error) {
+          logEntry = { __decoded: false, data, logId: receipt.rb.toString() }
+        }
+
+        logs.push(logEntry as T);
       }
     }
 

--- a/packages/account/src/providers/utils/extract-tx-error.ts
+++ b/packages/account/src/providers/utils/extract-tx-error.ts
@@ -222,5 +222,9 @@ export const extractTxError = (params: IExtractTxError): FuelError => {
   if (isPanic) {
     return assemblePanicError(statusReason, metadata);
   }
-  return assembleRevertError(receipts, logs, metadata, statusReason, abis);
+  const decodedLogs = logs.filter((l: unknown) => {
+    const log = l as unknown as { __decoded: boolean };
+    return !(typeof log === 'object' && '__decoded' in log && log.__decoded === false);
+  });
+  return assembleRevertError(receipts, decodedLogs, metadata, statusReason, abis);
 };


### PR DESCRIPTION
- Closes #3932

# Release notes

In this release, we:

- Undecodable logs will no longer throw errors on program calls

# Summary

When we encounter an undecodable log, we will put the raw format within the logs in the following structure:
  ```ts
  {
    __decoded: false,
    data: '0xff',
    logId: '14454674236531057292',
  }
  ```

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
