### PR TITLE
fix: added missing envs for Vercel release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,12 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_TS_DOCS_PROJECT_ID: 'prj_iBhTlkv2hj2E6BiA3GeacxgNHIEL'
+  VERCEL_TS_DOCS_API_PROJECT_ID: 'prj_hBydWalwFfqTPkpKTIy82abixInS'
+  VERCEL_TS_TEMPLATE_PROJECT_ID: 'prj_syuKtl2KTIU4OvO2mRccdbIt55BN'
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

Missed some envs for the release workflow to allow for Vercel to be deployed

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
