### PR TITLE
chore!: breaking change for `fuel-core@v0.44.0`

### DIFF
--- a/.changeset/hungry-clouds-switch.md
+++ b/.changeset/hungry-clouds-switch.md
@@ -1,27 +1,5 @@
 ---
-"@internal/check-imports": minor
-"@internal/check-tests": minor
-"@internal/forc": minor
 "@internal/fuel-core": minor
-"@fuel-ts/abi-coder": minor
-"@fuel-ts/abi-typegen": minor
-"@fuel-ts/account": minor
-"@fuel-ts/address": minor
-"@fuel-ts/contract": minor
-"create-fuels": minor
-"@fuel-ts/crypto": minor
-"@fuel-ts/errors": minor
-"fuels": minor
-"@fuel-ts/hasher": minor
-"@fuel-ts/logger": minor
-"@fuel-ts/math": minor
-"@fuel-ts/merkle": minor
-"@fuel-ts/program": minor
-"@fuel-ts/recipes": minor
-"@fuel-ts/script": minor
-"@fuel-ts/transactions": minor
-"@fuel-ts/utils": minor
-"@fuel-ts/versions": minor
 ---
 
 chore!: breaking change for `fuel-core@v0.44.0`

--- a/.changeset/hungry-clouds-switch.md
+++ b/.changeset/hungry-clouds-switch.md
@@ -1,0 +1,27 @@
+---
+"@internal/check-imports": minor
+"@internal/check-tests": minor
+"@internal/forc": minor
+"@internal/fuel-core": minor
+"@fuel-ts/abi-coder": minor
+"@fuel-ts/abi-typegen": minor
+"@fuel-ts/account": minor
+"@fuel-ts/address": minor
+"@fuel-ts/contract": minor
+"create-fuels": minor
+"@fuel-ts/crypto": minor
+"@fuel-ts/errors": minor
+"fuels": minor
+"@fuel-ts/hasher": minor
+"@fuel-ts/logger": minor
+"@fuel-ts/math": minor
+"@fuel-ts/merkle": minor
+"@fuel-ts/program": minor
+"@fuel-ts/recipes": minor
+"@fuel-ts/script": minor
+"@fuel-ts/transactions": minor
+"@fuel-ts/utils": minor
+"@fuel-ts/versions": minor
+---
+
+chore!: breaking change for `fuel-core@v0.44.0`


### PR DESCRIPTION
# Summary

- Breaking change for the following PR:
  - #3901 

# Breaking Changes

- `fuel-core` release [`v0.44.0`](https://github.com/FuelLabs/fuel-core/releases/tag/v0.44.0) is a breaking change.

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
