### PR TITLE
chore!: breaking change for `fuel-core@v0.44.0`

### DIFF
--- a/.changeset/full-carpets-lose.md
+++ b/.changeset/full-carpets-lose.md
@@ -1,11 +1,11 @@
 ---
-"@internal/fuel-core": patch
-"@fuel-ts/account": patch
-"@fuel-ts/contract": patch
-"fuels": patch
-"@fuel-ts/program": patch
-"@fuel-ts/utils": patch
-"@fuel-ts/versions": patch
+"@internal/fuel-core": minor
+"@fuel-ts/account": minor
+"@fuel-ts/contract": minor
+"fuels": minor
+"@fuel-ts/program": minor
+"@fuel-ts/utils": minor
+"@fuel-ts/versions": minor
 ---
 
-chore: upgrade `fuel-core` to `0.44.0`
+chore!: upgrade `fuel-core` to `0.44.0`

--- a/.changeset/hungry-clouds-switch.md
+++ b/.changeset/hungry-clouds-switch.md
@@ -1,5 +1,0 @@
----
-"@internal/fuel-core": minor
----
-
-chore!: breaking change for `fuel-core@v0.44.0`


### PR DESCRIPTION
# Summary

- Breaking change for the following PR:
  - #3901 

# Breaking Changes

- `fuel-core` release [`v0.44.0`](https://github.com/FuelLabs/fuel-core/releases/tag/v0.44.0) is a breaking change.

# Checklist

- [X] All **changes** are **covered** by **tests** (or not applicable)
- [X] All **changes** are **documented** (or not applicable)
- [X] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [X] I **described** all **Breaking Changes** (or there's none)
