### PR TITLE
fix: configurables constants on createTransactionRequest not been set

### DIFF
--- a/.changeset/beige-days-listen.md
+++ b/.changeset/beige-days-listen.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/contract": patch
+---
+
+fix: configurables constants on createTransactionRequest not been set

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,4 @@ Forc.lock
 /playwright/.cache/
 
 FUELS_VERSION
+.aider*

--- a/packages/contract/src/contract-factory.ts
+++ b/packages/contract/src/contract-factory.ts
@@ -149,6 +149,10 @@ export default class ContractFactory<TContract extends Contract = Contract> {
       );
     }
 
+    if (deployOptions?.configurableConstants) {
+      this.setConfigurableConstants(deployOptions.configurableConstants);
+    }
+
     const bytecode = deployOptions?.bytecode || this.bytecode;
     const stateRoot = options.stateRoot || getContractStorageRoot(options.storageSlots);
     const contractId = getContractId(bytecode, options.salt, stateRoot);


### PR DESCRIPTION
# Summary

ContractFactory.createTransactionRequest allows to pass configurableConstants, but does not use them. It is both confusing because the default ones will be used, and because the returned contract ID will not match with the one returned by the deploy method, which uses the configurables.

# Checklist

- [x] All **changes** are **covered** by **tests** (or not applicable)
- [x] All **changes** are **documented** (or not applicable)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
- [x] I **described** all **Breaking Changes** (or there's none)
