### PR TITLE
docs: add merkle tree usage documentation

### DIFF
--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -427,6 +427,10 @@ export default defineConfig({
                 text: 'Asset API',
                 link: '/guide/utilities/asset-api',
               },
+              {
+                text: 'Merkle Tree',
+                link: '/guide/utilities/merkle-tree',
+              },
             ],
           },
           {

--- a/apps/docs/src/guide/utilities/merkle-tree.md
+++ b/apps/docs/src/guide/utilities/merkle-tree.md
@@ -1,0 +1,31 @@
+# Merkle Tree
+
+A Merkle tree is a hash-based data structure that allows efficient verification of data integrity. Each leaf node contains a hash of a data block, and each non-leaf node contains a hash of its children. This makes it possible to prove that a specific piece of data is part of a set without revealing the entire set.
+
+The `@fuel-ts/merkle` package provides utilities for working with binary Merkle trees.
+
+## Creating a Merkle Tree
+
+You can construct a full Merkle tree from an array of hex-encoded data, or compute just the root hash:
+
+<<< @./snippets/merkle/index.ts#create-tree{ts:line-numbers}
+
+For multiple leaves, you can hash your data first and then build the tree:
+
+<<< @./snippets/merkle/index.ts#multi-leaf{ts:line-numbers}
+
+## Generating Proofs
+
+A Merkle proof is the set of sibling hashes needed to reconstruct the path from a leaf to the root. This is useful for proving membership in a set:
+
+<<< @./snippets/merkle/index.ts#get-proof{ts:line-numbers}
+
+## Hashing Leaves
+
+The `hashLeaf` function applies the Merkle leaf-prefix (`0x00`) before hashing, which prevents second-preimage attacks:
+
+<<< @./snippets/merkle/index.ts#hash-leaf{ts:line-numbers}
+
+## Full Example
+
+<<< @./snippets/merkle/index.ts#full{ts:line-numbers}

--- a/apps/docs/src/guide/utilities/snippets/merkle/index.ts
+++ b/apps/docs/src/guide/utilities/snippets/merkle/index.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// #region full
+import { calcRoot, constructTree, getProof, hashLeaf } from '@fuel-ts/merkle';
+import { hash } from 'fuels';
+
+// #region create-tree
+// Prepare your data as hex strings
+const data = ['0xd5579c46dfcc7f18207013e65b44e4cb4e2c2298f4ac457ba8f82743f31e930b'];
+
+// Construct the full Merkle tree
+const tree = constructTree(data);
+
+// Compute the Merkle root directly
+const root = calcRoot(data);
+// #endregion create-tree
+
+// #region multi-leaf
+// Create a tree with multiple leaves
+const leaves = [
+  hash(new Uint8Array([1])),
+  hash(new Uint8Array([2])),
+  hash(new Uint8Array([3])),
+  hash(new Uint8Array([4])),
+  hash(new Uint8Array([5])),
+];
+
+const multiTree = constructTree(leaves);
+const multiRoot = calcRoot(leaves);
+// #endregion multi-leaf
+
+// #region get-proof
+// Get the proof for leaf at index 0
+const proof = getProof(multiTree, 0);
+// proof is an array of sibling hashes needed to reconstruct the root
+// #endregion get-proof
+
+// #region hash-leaf
+// Hash a single leaf using the Merkle leaf prefix (0x00)
+const leafHash = hashLeaf(leaves[0]);
+// #endregion hash-leaf
+
+// #endregion full


### PR DESCRIPTION
Closes #3374

Adds documentation for merkle tree usage including:
- Overview and concepts
- Creating merkle trees from data
- Generating proofs
- Hashing leaves
- Code examples with region markers

New files:
- `apps/docs/src/guide/utilities/merkle-tree.md`
- `apps/docs/src/guide/utilities/snippets/merkle/index.ts`
- Sidebar entry in `.vitepress/config.ts`