### PR TITLE
docs: add documentation for predicate `toNewInstance` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ Forc.lock
 
 FUELS_VERSION
 .aider*
+.claude/

--- a/apps/docs/src/guide/predicates/methods.md
+++ b/apps/docs/src/guide/predicates/methods.md
@@ -26,6 +26,14 @@ You may want to use this method when using a predicate in an existing transactio
 
 ## Transactions
 
+### `toNewInstance`
+
+The `toNewInstance` method creates a new `Predicate` instance from an existing one, preserving the original bytecode, ABI, and provider. You can optionally override the `data` (predicate arguments) and/or `configurableConstants`. If no overrides are provided, the new instance will be a copy with the same data and configurable constants.
+
+This is useful when you need multiple predicate instances that share the same bytecode and provider but differ in their input data or configurable constants—for example, when working with different users or configurations.
+
+<<< @./snippets/methods/to-new-instance.ts#to-new-instance{ts:line-numbers}
+
 ### `setData`
 
 The `setData` method can be used to update the predicate data (i.e., predicate arguments) after the predicate has already been instantiated. Since the predicate data is initially set during instantiation, `setData` provides a way to modify it afterward if needed.

--- a/apps/docs/src/guide/predicates/snippets/methods/to-new-instance.ts
+++ b/apps/docs/src/guide/predicates/snippets/methods/to-new-instance.ts
@@ -1,0 +1,39 @@
+import { Provider } from 'fuels';
+
+import { LOCAL_NETWORK_URL } from '../../../../env';
+import { ConfigurablePin } from '../../../../typegend';
+
+const provider = new Provider(LOCAL_NETWORK_URL);
+
+// #region to-new-instance
+const basePredicate = new ConfigurablePin({
+  provider,
+  data: [1000],
+  configurableConstants: {
+    PIN: 1337,
+  },
+});
+
+// Create a new predicate instance with different data
+const predicateWithNewData = basePredicate.toNewInstance({
+  data: [2000],
+});
+
+// Create a new predicate instance with different configurable constants
+const predicateWithNewConstants = basePredicate.toNewInstance({
+  configurableConstants: {
+    PIN: 9999,
+  },
+});
+
+// Create a new predicate instance with both new data and configurable constants
+const predicateWithBothOverrides = basePredicate.toNewInstance({
+  data: [3000],
+  configurableConstants: {
+    PIN: 5555,
+  },
+});
+
+// Create a copy with the same data and configurable constants
+const predicateCopy = basePredicate.toNewInstance();
+// #endregion to-new-instance


### PR DESCRIPTION
## Summary

Adds documentation for the `Predicate.toNewInstance()` method to the existing predicate methods guide.

## Changes

- Added a new `toNewInstance` section to `apps/docs/src/guide/predicates/methods.md` explaining the method's purpose and usage
- Created a code snippet at `apps/docs/src/guide/predicates/snippets/methods/to-new-instance.ts` demonstrating:
  - Creating a new instance with different data
  - Creating a new instance with different configurable constants
  - Creating a new instance with both overrides
  - Creating a copy with the same parameters

Closes #3799