### PR TITLE
docs: improve documentation for deployed programs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ Forc.lock
 
 FUELS_VERSION
 .aider*
+.claude/

--- a/apps/docs/src/guide/contracts/deploying-contracts.md
+++ b/apps/docs/src/guide/contracts/deploying-contracts.md
@@ -7,7 +7,34 @@
 
 # Deploying Contracts
 
-To deploy a contract using the SDK, you can use the `ContractFactory`. This process involves collecting the contract artifacts, initializing the contract factory, and deploying the contract.
+There are two ways to deploy a contract to the Fuel network:
+
+1. **CLI deployment** — Using the [Fuels CLI](../fuels-cli/index.md) via `fuels deploy`
+2. **Dynamic deployment** — Programmatically using the [`ContractFactory`](DOCS_API_URL/classes/_fuel_ts_contract.index.ContractFactory.html)
+
+Both approaches produce the same on-chain result, but serve different use cases. CLI deployment is best for standard workflows integrated with `fuels build` and `fuels deploy`, while dynamic deployment gives you full programmatic control over the deployment process.
+
+## The Sway Contract
+
+Before deploying, you need a Sway contract. Here's a simple example:
+
+<<< @/../../sway/my-contract/src/main.sw#full{rust:line-numbers}
+
+After writing your contract, compile it by running `forc build` (<a :href="indexUrl" target="_blank" rel="noreferrer">read more</a> on how to work with Sway) or by using the [Fuels CLI](../fuels-cli/index.md) with `fuels build`.
+
+## CLI Deployment
+
+The simplest way to deploy a contract is via the [Fuels CLI](../fuels-cli/index.md) using the [`fuels deploy`](../fuels-cli/commands.md#fuels-deploy) command. This will:
+
+1. Build the contract using your configured `forc` version
+2. Deploy the compiled contract to the network
+3. Generate TypeScript types you can use in your application
+
+For more information on configuring CLI deployment, see the [Fuels CLI documentation](../fuels-cli/commands.md#fuels-deploy).
+
+## Dynamic Deployment
+
+To deploy a contract programmatically, you can use the `ContractFactory`. This approach is useful when you need to deploy contracts at runtime or want fine-grained control over the deployment process.
 
 The SDK utilizes two different deployment processes, depending on the contract's size. The threshold for the contract size is dictated by the chain and can be queried:
 
@@ -23,13 +50,9 @@ The `ContractFactory` offers the following methods for the different processes:
 
 > **Note:** If the contract is deployed via blob deployments, multiple transactions will be required to deploy the contract.
 
-## Deploying a Contract Guide
-
-This guide will cover the process of deploying a contract using the `deploy` method, however all these methods can be used interchangeably dependent on the contract size. In the guide we use a contract factory that has been built using [Typegen](../fuels-cli/abi-typegen.md). This tool provided by the [Fuels CLI](../fuels-cli/index.md) provides a better developer experience and end to end type support for your smart contracts.
-
 ### 1. Setup
 
-After writing a contract in Sway you can build the necessary deployment artifacts either by running `forc build` (<a :href="indexUrl" target="_blank" rel="noreferrer">read more</a> on how to work with Sway) or by using the [Fuels CLI](../fuels-cli/index.md) and running `fuels build` using your chosen package manager. We recommend using the Fuels CLI as it provides a more comprehensive usage including end to end type support.
+In the guide we use a contract factory that has been built using [Typegen](../fuels-cli/abi-typegen.md). This tool provided by the [Fuels CLI](../fuels-cli/index.md) provides a better developer experience and end to end type support for your smart contracts.
 
 Once you have the contract artifacts, it can be passed to the `ContractFactory` for deployment, like so:
 
@@ -37,7 +60,7 @@ Once you have the contract artifacts, it can be passed to the `ContractFactory` 
 
 ### 2. Contract Deployment
 
-As mentioned earlier, there are two different processes for contract deployment handled by the `ContractFactory`. These can be used interchangeably, however, the `deploy` method is recommended as it will automatically choose the appropriate deployment process based on the contract size.
+The `deploy` method is recommended as it will automatically choose the appropriate deployment process based on the contract size.
 
 This call resolves as soon as the transaction to deploy the contract is submitted and returns three items: the `contractId`, a `waitForTransactionId` function and a `waitForResult` function.
 
@@ -60,3 +83,7 @@ In the above guide we use the recommended `deploy` method. If you are working wi
 In the above example, we also pass a `chunkSizeMultiplier` option to the deployment method. The SDK will attempt to chunk the contract to the most optimal about, however the transaction size can fluctuate and you can also be limited by request size limits against the node. By default we set a multiplier of 0.95, meaning the chunk size will be 95% of the potential maximum size, however you can adjust this to suit your needs and ensure the transaction passes. It must be set to a value between 0 and 1.
 
 > **Note:** Deploying large contracts using blob transactions will take more time. Each transaction is dependent and has to wait for a block to be produced before it gets mined. Then a create transaction is submitted as normal. So you will need to wait longer than usual for the contract to be fully deployed and can be interacted with.
+
+## Next Steps
+
+Once your contract is deployed, you can connect to it without redeploying. See [Managing Deployed Contracts](./managing-deployed-contracts.md) for how to interact with already-deployed contracts using just a contract ID and ABI.

--- a/apps/docs/src/guide/contracts/managing-deployed-contracts.md
+++ b/apps/docs/src/guide/contracts/managing-deployed-contracts.md
@@ -1,12 +1,24 @@
 # Managing Deployed Contracts
 
-To interact with a deployed contract using the SDK without redeploying it, you only need the contract ID and its JSON ABI. This allows you to bypass the deployment setup.
+Once a contract is deployed to the Fuel network, you can connect to it and interact with it using just its **contract ID** and **ABI** — there is no need to redeploy. This is the most common pattern in dApp development, where contracts are deployed once and then used by many clients.
 
-## Contract ID
+## Connecting to a Deployed Contract
 
-The `contractId` property from the [`Contract`](DOCS_API_URL/classes/_fuel_ts_program.Contract.html) class is an instance of the [`Address`](DOCS_API_URL/classes/_fuel_ts_address.Address.html) class.
+To interact with an already-deployed contract, create a [`Contract`](DOCS_API_URL/classes/_fuel_ts_program.Contract.html) instance with the contract ID, ABI, and a wallet or provider:
 
-The [`Address`](DOCS_API_URL/classes/_fuel_ts_address.Address.html) class also provides a set of utility functions for easy manipulation and conversion between address formats along with one property; `b256Address`, which is a string encoded in [`B256`](../types/b256.md) format.
+<<< @./snippets/managing-deployed-contracts.ts#with-contractId{ts:line-numbers}
+
+## Using a B256 Contract ID
+
+Some Fuel tools and Sway use the [`B256`](../types/b256.md) type format (a hex-encoded string) for contract IDs. You might have this format if you deployed your contract with `forc deploy` or copied it from a block explorer.
+
+The process of instantiating a [`Contract`](DOCS_API_URL/classes/_fuel_ts_program.Contract.html) remains the same when using a contract ID of type `B256`:
+
+<<< @./snippets/managing-deployed-contracts.ts#with-b256{ts:line-numbers}
+
+## Contract ID Format
+
+The `contractId` property from the [`Contract`](DOCS_API_URL/classes/_fuel_ts_program.Contract.html) class is an instance of the [`Address`](DOCS_API_URL/classes/_fuel_ts_address.Address.html) class, which provides utility functions for easy manipulation and conversion between address formats.
 
 When you log the `contractId` property of an instantiated Contract using `console.log`, the output appears as follows:
 
@@ -15,17 +27,3 @@ When you log the `contractId` property of an instantiated Contract using `consol
     b256Address: '0xcd16d97c5c4e18ee2e8d6428447dd9c8763cb0336718b53652d049f8ec88b3ba'
   }
 ```
-
----
-
-If you have already an instantiated and deployed contract in hands you can create another contract instance simply by using the `contractId` property and the contract JSON ABI:
-
-<<< @./snippets/managing-deployed-contracts.ts#with-contractId{ts:line-numbers}
-
-The previous example assumes that you have a [`Contract`](DOCS_API_URL/classes/_fuel_ts_program.Contract.html) instance at hand. However, some Fuel tools and Sway use the [`B256`](../types/b256.md) type format, a hex-encoded string-like type, for contract IDs.
-
-You might have this format instead, for example, if you have deployed your contract with `forc deploy`.
-
-The process of instantiating a [`Contract`](DOCS_API_URL/classes/_fuel_ts_program.Contract.html) remains the same when using a contract ID of type `B256`:
-
-<<< @./snippets/managing-deployed-contracts.ts#with-b256{ts:line-numbers}

--- a/apps/docs/src/guide/predicates/deploying-predicates.md
+++ b/apps/docs/src/guide/predicates/deploying-predicates.md
@@ -1,20 +1,31 @@
 # Deploying Predicates
 
-In order to optimize the cost of your recurring predicate executions, we recommend first deploying your predicate. This can be done using the [Fuels CLI](../fuels-cli/index.md) and running the [deploy command](../fuels-cli/commands.md#fuels-deploy).
+In order to optimize the cost of your recurring predicate executions, we recommend first deploying your predicate. Deploying stores the predicate bytecode on chain as a blob, and the SDK produces smaller bytecode that loads the blob on demand. This far reduces the repeat execution cost of the predicate.
 
-By deploying the predicate, its bytecode is stored on chain as a blob. The SDK will then produce bytecode that can load the blob on demand to execute the original predicate. This far reduces the repeat execution cost of the predicate.
+There are two ways to deploy a predicate:
 
-## How to Deploy a Predicate
+1. **CLI deployment** — Using the [Fuels CLI](../fuels-cli/index.md) via [`fuels deploy`](../fuels-cli/commands.md#fuels-deploy)
+2. **Dynamic deployment** — Programmatically using the `deploy` method on a predicate instance
 
-To deploy a predicate, we can use the [Fuels CLI](../fuels-cli/index.md) and execute the [deploy command](../fuels-cli/commands.md#fuels-deploy).
+## The Sway Predicate
 
-This will perform the following actions:
+Here's an example predicate written in Sway:
+
+<<< @/../../sway/configurable-pin/src/main.sw#full{rust:line-numbers}
+
+## CLI Deployment
+
+The simplest way to deploy a predicate is via the [Fuels CLI](../fuels-cli/index.md) using the [`fuels deploy`](../fuels-cli/commands.md#fuels-deploy) command. This will:
 
 1. Compile the predicate using your `forc` version
 1. Deploy the built predicate binary to the chain as a blob
 1. Generate a new, smaller predicate that loads the deployed predicate's blob
 1. Generate types for both the predicate and the loader that you can use in your application
 
-We can then utilize the above generated types like so:
+## Dynamic Deployment
+
+You can also deploy a predicate programmatically using the `deploy` method directly on a predicate instance. This is useful for runtime deployments or when you need more control over the process.
+
+The following example demonstrates both approaches — deploying the predicate dynamically and then using the generated loader types:
 
 <<< @./snippets/deploying-predicates.ts#full{ts:line-numbers}

--- a/apps/docs/src/guide/scripts/deploying-scripts.md
+++ b/apps/docs/src/guide/scripts/deploying-scripts.md
@@ -1,20 +1,31 @@
 # Deploying Scripts
 
-In order to optimize the cost of your recurring script executions, we recommend first deploying your script. This can be done using the [Fuels CLI](../fuels-cli/index.md) and running the [deploy command](../fuels-cli/commands.md#fuels-deploy).
+In order to optimize the cost of your recurring script executions, we recommend first deploying your script. Deploying stores the script bytecode on chain as a blob, and the SDK produces bytecode that loads the blob on demand. This far reduces the repeat execution cost of the script.
 
-By deploying the script, its bytecode is stored on chain as a blob. The SDK will then produce bytecode that can load the blob on demand to execute the original script. This far reduces the repeat execution cost of the script.
+There are two ways to deploy a script:
 
-## How to Deploy a Script
+1. **CLI deployment** — Using the [Fuels CLI](../fuels-cli/index.md) via [`fuels deploy`](../fuels-cli/commands.md#fuels-deploy)
+2. **Dynamic deployment** — Programmatically using the `deploy` method on a script instance
 
-To deploy a script, we can use the [Fuels CLI](../fuels-cli/index.md) and execute the [deploy command](../fuels-cli/commands.md#fuels-deploy).
+## The Sway Script
 
-This will perform the following actions:
+Here's an example script written in Sway:
+
+<<< @/../../sway/script-sum/src/main.sw#script-with-configurable-contants-1{rust:line-numbers}
+
+## CLI Deployment
+
+The simplest way to deploy a script is via the [Fuels CLI](../fuels-cli/index.md) using the [`fuels deploy`](../fuels-cli/commands.md#fuels-deploy) command. This will:
 
 1. Compile the script using your `forc` version
 1. Deploy the built script binary to the chain as a blob
 1. Generate a script that loads the blob that can be used to execute the script
 1. Generate types for both the script and the loader that you can use in your application
 
-We can then utilize the above generated types like so:
+## Dynamic Deployment
+
+You can also deploy a script programmatically using the `deploy` method directly on a script instance. This is useful for runtime deployments or when you need more control over the process.
+
+The following example demonstrates deploying the script dynamically and then using the generated loader types:
 
 <<< @./snippets/deploying-scripts.ts#deploying-scripts{ts:line-numbers}

--- a/apps/docs/sway/my-contract/src/main.sw
+++ b/apps/docs/sway/my-contract/src/main.sw
@@ -1,3 +1,4 @@
+// #region full
 contract;
 
 abi MyContract {
@@ -9,3 +10,4 @@ impl MyContract for Contract {
         true
     }
 }
+// #endregion full


### PR DESCRIPTION
## Summary

Closes #3800

Improves the deployment documentation for contracts, predicates, and scripts with the following enhancements:

- **Added Sway source examples** to each deployment guide so users can see the program being deployed
- **Documented both deployment mechanisms** (CLI via `fuels deploy` and dynamic/programmatic deployment) across all three program types
- **Restructured deploying-contracts.md** to clearly separate CLI vs dynamic deployment paths
- **Improved managing-deployed-contracts.md** to lead with the most common use case (connecting to an already-deployed contract)
- **Added cross-references** between deployment and managing docs for better discoverability

## Checklist

- [x] Documentation changes only
- [x] Addresses all enhancement suggestions in #3800