### PR TITLE
feat: add TestCoin helper class

### DIFF
--- a/packages/account/src/test-utils.ts
+++ b/packages/account/src/test-utils.ts
@@ -3,3 +3,4 @@ export * from './test-utils/setup-test-provider-and-wallets';
 export * from './test-utils/wallet-config';
 export * from './test-utils/test-message';
 export * from './test-utils/test-asset-id';
+export * from './test-utils/test-coin';

--- a/packages/account/src/test-utils/test-coin.test.ts
+++ b/packages/account/src/test-utils/test-coin.test.ts
@@ -1,0 +1,79 @@
+import { Address } from '@fuel-ts/address';
+import { randomBytes } from '@fuel-ts/crypto';
+import { hexlify } from '@fuel-ts/utils';
+
+import { TestCoin } from './test-coin';
+
+/**
+ * @group node
+ */
+describe('test-coin', () => {
+  test('has default values', () => {
+    const coin = new TestCoin().toChainCoin();
+
+    expect(coin.amount).toBeDefined();
+    expect(coin.asset_id).toBeDefined();
+    expect(coin.owner).toBeDefined();
+    expect(coin.tx_id).toBeDefined();
+    expect(coin.tx_pointer_block_height).toBeDefined();
+    expect(coin.tx_pointer_tx_idx).toBeDefined();
+    expect(coin.output_index).toBeDefined();
+  });
+
+  test('accepts custom values', () => {
+    const owner = Address.fromRandom();
+    const amount = 500;
+    const assetId = hexlify(randomBytes(32));
+    const txId = hexlify(randomBytes(32));
+
+    const testCoin = new TestCoin({
+      owner,
+      amount,
+      asset_id: assetId,
+      tx_id: txId,
+      tx_pointer_block_height: 1,
+      tx_pointer_tx_idx: 2,
+      output_index: 3,
+    });
+
+    const coin = testCoin.toChainCoin();
+    expect(coin.amount).toEqual('500');
+    expect(coin.asset_id).toEqual(assetId);
+    expect(coin.owner).toEqual(owner.toHexString());
+    expect(coin.tx_id).toEqual(txId);
+    expect(coin.tx_pointer_block_height).toEqual(1);
+    expect(coin.tx_pointer_tx_idx).toEqual(2);
+    expect(coin.output_index).toEqual(3);
+  });
+
+  test('toChainCoin accepts owner override', () => {
+    const originalOwner = Address.fromRandom();
+    const overrideOwner = Address.fromRandom();
+
+    const testCoin = new TestCoin({ owner: originalOwner });
+    const coin = testCoin.toChainCoin(overrideOwner);
+
+    expect(coin.owner).toEqual(overrideOwner.toHexString());
+  });
+
+  test('many creates multiple coins', () => {
+    const owner = Address.fromRandom();
+    const coins = TestCoin.many({ owner }, 4);
+
+    expect(coins).toHaveLength(4);
+    coins.forEach((coin) => {
+      expect(coin.owner).toEqual(owner);
+      // Each coin should have a unique tx_id
+      expect(coin.tx_id).toBeDefined();
+    });
+
+    // Verify all tx_ids are unique
+    const txIds = coins.map((c) => c.tx_id);
+    expect(new Set(txIds).size).toEqual(4);
+  });
+
+  test('many with default count creates one coin', () => {
+    const coins = TestCoin.many();
+    expect(coins).toHaveLength(1);
+  });
+});

--- a/packages/account/src/test-utils/test-coin.ts
+++ b/packages/account/src/test-utils/test-coin.ts
@@ -1,0 +1,70 @@
+import { Address } from '@fuel-ts/address';
+import { randomBytes } from '@fuel-ts/crypto';
+import { bn, type BigNumberish } from '@fuel-ts/math';
+import type { SnapshotConfigs } from '@fuel-ts/utils';
+import { hexlify } from '@fuel-ts/utils';
+
+interface TestCoinSpecs {
+  owner: Address;
+  amount: BigNumberish;
+  asset_id: string;
+  tx_pointer_block_height: number;
+  tx_pointer_tx_idx: number;
+  output_index: number;
+  tx_id: string;
+}
+
+export type ChainCoin = SnapshotConfigs['stateConfig']['coins'][0];
+
+export class TestCoin {
+  public readonly owner: Address;
+  public readonly amount: BigNumberish;
+  public readonly asset_id: string;
+  public readonly tx_pointer_block_height: number;
+  public readonly tx_pointer_tx_idx: number;
+  public readonly output_index: number;
+  public readonly tx_id: string;
+
+  /**
+   * A helper class to create coins for testing purposes.
+   *
+   * Used in tandem with `WalletsConfig`.
+   * It can also be used standalone and passed into the initial state of a chain via the `.toChainCoin` method.
+   */
+  constructor({
+    owner = Address.fromRandom(),
+    amount = 1_000_000,
+    asset_id = '0xf8f8b6283d7fa5b672b530cbb84fcccb4ff8dc40f8176ef4544ddb1f1952ad07',
+    tx_pointer_block_height = 0,
+    tx_pointer_tx_idx = 0,
+    output_index = 0,
+    tx_id = hexlify(randomBytes(32)),
+  }: Partial<TestCoinSpecs> = {}) {
+    this.owner = owner;
+    this.amount = amount;
+    this.asset_id = asset_id;
+    this.tx_pointer_block_height = tx_pointer_block_height;
+    this.tx_pointer_tx_idx = tx_pointer_tx_idx;
+    this.output_index = output_index;
+    this.tx_id = tx_id;
+  }
+
+  /**
+   * Creates multiple test coins with the same base configuration.
+   */
+  static many(specs: Partial<TestCoinSpecs> = {}, count: number = 1): TestCoin[] {
+    return Array.from({ length: count }, () => new TestCoin(specs));
+  }
+
+  toChainCoin(owner?: Address): ChainCoin {
+    return {
+      owner: owner?.toHexString() ?? this.owner.toHexString(),
+      amount: bn(this.amount).toString(),
+      asset_id: this.asset_id,
+      tx_pointer_block_height: this.tx_pointer_block_height,
+      tx_pointer_tx_idx: this.tx_pointer_tx_idx,
+      output_index: this.output_index,
+      tx_id: this.tx_id,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `TestCoin` helper class, similar to the existing `TestMessage` class, for creating coins in tests.

Closes #3445

## Changes

- **`packages/account/src/test-utils/test-coin.ts`** — New `TestCoin` class with:
  - Constructor with sensible defaults (random owner, 1M amount, base asset ID)
  - `toChainCoin()` method to convert to chain snapshot format
  - Static `many()` method to generate multiple test coins at once
- **`packages/account/src/test-utils/test-coin.test.ts`** — Unit tests covering defaults, custom values, owner override, and `many()`
- **`packages/account/src/test-utils.ts`** — Re-export `TestCoin`

## Usage

```ts
import { TestCoin } from @fuel-ts/account/test-utils;

// Single coin with defaults
const coin = new TestCoin();

// Multiple coins for a specific owner
const coins = TestCoin.many({ owner: myAddress }, 4);

// Convert to chain format for snapshot configs
const chainCoin = coin.toChainCoin();
```