### PR TITLE
docs: use repo-relative local file links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ In-depth docs:
 
 # Contribute
 
-- [./CONTRIBUTING.md](https://github.com/FuelLabs/fuels-ts/blob/master/CONTRIBUTING.md)
+- [./CONTRIBUTING.md](./CONTRIBUTING.md)
 
 
 # License
 
-The primary license for this repo is `Apache 2.0`, see [`LICENSE`](https://github.com/FuelLabs/fuels-ts/blob/master/LICENSE).
+The primary license for this repo is `Apache 2.0`, see [`LICENSE`](LICENSE).


### PR DESCRIPTION
## Summary
- replace the branch-pinned GitHub links for `CONTRIBUTING.md` and `LICENSE` in the root README with repo-relative links
- keep local repository file links branch-agnostic while preserving the existing external docs links

## Testing
- not run (README-only change)