### PR TITLE
docs: add contract usage example for B256 type

### DIFF
--- a/apps/docs/src/guide/types/b256.md
+++ b/apps/docs/src/guide/types/b256.md
@@ -14,6 +14,21 @@ To convert between a `B256` hexlified string and a `Uint8Array`, you can use the
 
 <<< @./snippets/b256/converting-between-b256-uint8.ts#full{ts:line-numbers}
 
+## Using `B256` with Contracts
+
+A common use case for `B256` is passing addresses or identifiers to Sway contracts. In Sway, the equivalent type is `b256`, and it is often used to represent asset IDs, contract IDs, or addresses:
+
+```typescript
+import { Provider, Wallet, Contract } from 'fuels';
+
+const provider = await Provider.create('https://mainnet.fuel.network/v1/graphql');
+const wallet = Wallet.fromPrivateKey(privateKey, provider);
+
+// Pass a B256 value to a contract method
+const assetId = '0xf8f8b6283d7fa5b672b530cbb84fcccb4ff8dc40f8176ef4544ddb1f1952ad07';
+const result = await contract.functions.get_balance(assetId).call();
+```
+
 ## Support from `Address` Class
 
 A `B256` value is also supported as part of the [`Address`](https://fuels-ts-docs-api.vercel.app/classes/_fuel_ts_address.Address.html) class, providing seamless integration with other components of your application. To create an [`Address`](https://fuels-ts-docs-api.vercel.app/classes/_fuel_ts_address.Address.html) instance from a b256 value, use the `new Address()` method:


### PR DESCRIPTION
## Summary

Addresses part of #3240 by adding a contract usage example showing how B256 values are commonly used with Sway contracts.

### Changes
- Added a section demonstrating how to pass `B256` values to contract methods
- Shows common patterns for asset IDs and contract IDs

### Checklist
- [x] Documentation updated
- [x] Addresses linked issue