### PR TITLE
fix(abi-coder): encode String and str length prefix as UTF-8 byte count

### DIFF
--- a/.changeset/string-coder-utf8-length-prefix.md
+++ b/.changeset/string-coder-utf8-length-prefix.md
@@ -1,0 +1,5 @@
+---
+"@fuel-ts/abi-coder": patch
+---
+
+fix: encode `String` and `str` length prefix using UTF-8 byte length

--- a/packages/abi-coder/src/encoding/coders/StdStringCoder.test.ts
+++ b/packages/abi-coder/src/encoding/coders/StdStringCoder.test.ts
@@ -44,6 +44,24 @@ describe('StdStringCoder', () => {
     expect(actual).toStrictEqual(expected);
   });
 
+  it('should encode a multi-byte string using its utf-8 byte length', () => {
+    // 'é' is a single JS character but two UTF-8 bytes (0xC3 0xA9),
+    // so the u64 length prefix must be 2, not the JS string length of 1.
+    const expected = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 2, 195, 169]);
+
+    const actual = coder.encode('é');
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('round-trips a multi-byte string', () => {
+    const value = 'Héllo, wörld! 👋';
+    const encoded = coder.encode(value);
+    const [decoded, newOffset] = coder.decode(encoded, 0);
+
+    expect(decoded).toEqual(value);
+    expect(newOffset).toEqual(encoded.length);
+  });
+
   it('decodes a string', () => {
     const input = [0, 0, 0, 0, 0, 0, 0, 4, 102, 117, 101, 108];
     const expected = 'fuel';

--- a/packages/abi-coder/src/encoding/coders/StdStringCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/StdStringCoder.ts
@@ -15,7 +15,7 @@ export class StdStringCoder extends Coder<string, string> {
 
   encode(value: string): Uint8Array {
     const bytes = toUtf8Bytes(value);
-    const lengthBytes = new BigNumberCoder('u64').encode(value.length);
+    const lengthBytes = new BigNumberCoder('u64').encode(bytes.length);
 
     return new Uint8Array([...lengthBytes, ...bytes]);
   }

--- a/packages/abi-coder/src/encoding/coders/StrSliceCoder.test.ts
+++ b/packages/abi-coder/src/encoding/coders/StrSliceCoder.test.ts
@@ -34,6 +34,24 @@ describe('StrSliceCoder', () => {
     expect(actual).toStrictEqual(expected);
   });
 
+  it('should encode a multi-byte string using its utf-8 byte length', () => {
+    // 'é' is a single JS character but two UTF-8 bytes (0xC3 0xA9),
+    // so the u64 length prefix must be 2, not the JS string length of 1.
+    const expected = new Uint8Array([0, 0, 0, 0, 0, 0, 0, 2, 195, 169]);
+
+    const actual = coder.encode('é');
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('round-trips a multi-byte string', () => {
+    const value = 'Héllo, wörld! 👋';
+    const encoded = coder.encode(value);
+    const [decoded, newOffset] = coder.decode(encoded, 0);
+
+    expect(decoded).toEqual(value);
+    expect(newOffset).toEqual(encoded.length);
+  });
+
   it('decodes a string slice', () => {
     const input = [0, 0, 0, 0, 0, 0, 0, 4, 102, 117, 101, 108];
     const expected = 'fuel';

--- a/packages/abi-coder/src/encoding/coders/StrSliceCoder.ts
+++ b/packages/abi-coder/src/encoding/coders/StrSliceCoder.ts
@@ -15,7 +15,7 @@ export class StrSliceCoder extends Coder<string, string> {
 
   encode(value: string): Uint8Array {
     const bytes = toUtf8Bytes(value);
-    const lengthBytes = new BigNumberCoder('u64').encode(value.length);
+    const lengthBytes = new BigNumberCoder('u64').encode(bytes.length);
 
     return new Uint8Array([...lengthBytes, ...bytes]);
   }


### PR DESCRIPTION
## Summary

`StdStringCoder` and `StrSliceCoder` write the u64 length prefix from `value.length`, which is the number of JS UTF-16 code units, while the payload is the UTF-8 byte encoding produced by `toUtf8Bytes(value)`. These two counts only match for ASCII. For any string containing a non-ASCII character the prefix under-counts the payload.

```ts
const bytes = toUtf8Bytes(value);
const lengthBytes = new BigNumberCoder('u64').encode(value.length); // UTF-16 units, not UTF-8 bytes
return new Uint8Array([...lengthBytes, ...bytes]);
```

`decode` reads exactly `length` bytes and then runs `toUtf8String`, so a short prefix truncates the payload. The value is corrupted, and because the encoded output still carries the full byte payload, the leftover bytes shift every following argument in a tuple or struct.

## Reproduction

```ts
const coder = new StdStringCoder();
const encoded = coder.encode('é'); // 'é'.length === 1, toUtf8Bytes('é') === [0xC3, 0xA9]
// the prefix is written as 1, but two payload bytes follow
const [decoded] = coder.decode(encoded, 0);
// decoded is the replacement character, not 'é'
```

With two consecutive string arguments such as `['é', 'OK']`, the leftover `0xA9` byte also desyncs the second argument.

## Fix

Use `bytes.length` so the prefix matches the UTF-8 payload that is actually written. One line in each coder.

## Tests

Added to both `StdStringCoder.test.ts` and `StrSliceCoder.test.ts`:

- an explicit encode assertion for `'é'` (prefix `2`, bytes `195 169`)
- a round-trip test for a multi-byte string that also contains an emoji surrogate pair

Existing ASCII tests are unchanged and still pass, since for ASCII the byte length equals the string length.
