### PR TITLE
fix: add js extensions to generated imports

### DIFF
--- a/packages/abi-typegen/src/templates/common/index.hbs
+++ b/packages/abi-typegen/src/templates/common/index.hbs
@@ -1,5 +1,5 @@
 {{header}}
 
 {{#each members}}
-export { {{this}} } from './{{this}}';
+export { {{this}} } from './{{this}}.js';
 {{/each}}

--- a/packages/abi-typegen/src/templates/common/index.test.ts
+++ b/packages/abi-typegen/src/templates/common/index.test.ts
@@ -18,7 +18,7 @@ describe('templates/index', () => {
     // validating
     restore();
 
-    expect(rendered).toContain(`export { Contract } from './Contract';`);
-    expect(rendered).toContain(`export { ContractFactory } from './ContractFactory';`);
+    expect(rendered).toContain(`export { Contract } from './Contract.js';`);
+    expect(rendered).toContain(`export { ContractFactory } from './ContractFactory.js';`);
   });
 });

--- a/packages/abi-typegen/src/templates/contract/factory.hbs
+++ b/packages/abi-typegen/src/templates/contract/factory.hbs
@@ -3,7 +3,7 @@
 import { ContractFactory as __ContractFactory, decompressBytecode } from "fuels";
 import type { Provider, Account, DeployContractOptions } from "fuels";
 
-import { {{capitalizedName}} } from "./{{capitalizedName}}";
+import { {{capitalizedName}} } from "./{{capitalizedName}}.js";
 
 const bytecode = decompressBytecode("{{compressedBytecode}}");
 

--- a/packages/abi-typegen/src/templates/contract/main.hbs
+++ b/packages/abi-typegen/src/templates/contract/main.hbs
@@ -14,7 +14,7 @@ import type {
 {{/if}}
 
 {{#if commonTypesInUse}}
-import type { {{commonTypesInUse}} } from "./common";
+import type { {{commonTypesInUse}} } from "./common.js";
 {{/if}}
 
 

--- a/packages/abi-typegen/src/templates/contract/main.test.ts
+++ b/packages/abi-typegen/src/templates/contract/main.test.ts
@@ -80,7 +80,7 @@ describe('templates/dts', () => {
 
     const rendered = renderMainTemplate({ abi, versions });
 
-    expect(rendered).toMatch(/^import type.+from ".\/common";$/m);
+    expect(rendered).toMatch(/^import type.+from ".\/common\.js";$/m);
   });
 
   test('should render dts cross-referencing for identical structs', () => {

--- a/packages/abi-typegen/src/templates/predicate/main.hbs
+++ b/packages/abi-typegen/src/templates/predicate/main.hbs
@@ -9,7 +9,7 @@ import {
 {{/if}}
 
 {{#if commonTypesInUse}}
-import type { {{commonTypesInUse}} } from "./common";
+import type { {{commonTypesInUse}} } from "./common.js";
 {{/if}}
 
 

--- a/packages/abi-typegen/src/templates/script/main.hbs
+++ b/packages/abi-typegen/src/templates/script/main.hbs
@@ -9,7 +9,7 @@ import {
 {{/if}}
 
 {{#if commonTypesInUse}}
-import type { {{commonTypesInUse}} } from "./common";
+import type { {{commonTypesInUse}} } from "./common.js";
 {{/if}}
 
 

--- a/packages/abi-typegen/test/fixtures/templates/contract-with-configurable/main.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/contract-with-configurable/main.hbs
@@ -21,7 +21,7 @@ import type {
   InvokeFunction,
 } from 'fuels';
 
-import type { Option } from "./common";
+import type { Option } from "./common.js";
 
 export type GenericStructInput<T1, T2> = { p1: T1, p2: T2 };
 export type GenericStructOutput<T1, T2> = GenericStructInput<T1, T2>;

--- a/packages/abi-typegen/test/fixtures/templates/contract/main.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/contract/main.hbs
@@ -27,7 +27,7 @@ import type {
   StrSlice,
 } from 'fuels';
 
-import type { Option, Enum, Vec, Result } from "./common";
+import type { Option, Enum, Vec, Result } from "./common.js";
 
 export type EnumWithVectorInput = Enum<{ num: BigNumberish, vec: Vec<BigNumberish> }>;
 export type EnumWithVectorOutput = Enum<{ num: number, vec: Vec<number> }>;

--- a/packages/abi-typegen/test/fixtures/templates/predicate/main.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/predicate/main.hbs
@@ -20,7 +20,7 @@ import {
   Provider,
 } from 'fuels';
 
-import type { Option, Enum, Vec, Result } from "./common";
+import type { Option, Enum, Vec, Result } from "./common.js";
 
 export type MyGenericEnumInput<T> = Enum<{ a: T }>;
 export type MyGenericEnumOutput<T> = MyGenericEnumInput<T>;

--- a/packages/abi-typegen/test/fixtures/templates/script/main.hbs
+++ b/packages/abi-typegen/test/fixtures/templates/script/main.hbs
@@ -18,7 +18,7 @@ import {
   Script as __Script,
 } from 'fuels';
 
-import type { Option, Enum, Vec, Result } from "./common";
+import type { Option, Enum, Vec, Result } from "./common.js";
 
 export type MyGenericEnumInput<T> = Enum<{ a: T }>;
 export type MyGenericEnumOutput<T> = MyGenericEnumInput<T>;


### PR DESCRIPTION
- Closes #3941
# Summary

Update ABI typegen output to include explicit `.js` extensions on relative imports. This makes generated TypeScript compatible with Node16 and NodeNext module resolution while preserving the existing output structure.

The change covers contract wrappers, contract factories, shared type imports for contracts, predicates, and scripts, plus generated barrel exports. Template regression expectations were updated accordingly.

# Breaking Changes

None. The generated files now use standard ESM relative import specifiers.

# Checklist

- [x] Changes are covered by updated template tests
- [ ] - [x] Generated fixtures are updated
- [ ] - [x] Reviewed the complete diff
- [ ] - [x] No breaking API changes
Validation: `git diff --check` passed. Local Vitest and TypeScript binaries were unavailable because dependencies are not installed in the sandbox.