### PR TITLE
feat(provider): support custom graphql queries

### DIFF
--- a/packages/account/src/providers/provider.test.ts
+++ b/packages/account/src/providers/provider.test.ts
@@ -9,6 +9,7 @@ import { InputType, OutputType, ReceiptType } from '@fuel-ts/transactions';
 import { DateTime, arrayify, hexlify, sleep } from '@fuel-ts/utils';
 import { ASSET_A, ASSET_B } from '@fuel-ts/utils/test-utils';
 import { versions } from '@fuel-ts/versions';
+import gql from 'graphql-tag';
 
 import type { CoinQuantity } from '..';
 import { Wallet } from '..';
@@ -83,6 +84,32 @@ const createBasicAuth = (launchNodeUrl: string) => {
 describe('Provider', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('supports custom GraphQL queries with variables', async () => {
+    const provider = new Provider('http://127.0.0.1:4000/graphql', {
+      fetch: async (_url, requestInit) => {
+        const body = JSON.parse(requestInit?.body as string);
+        expect(body.variables).toEqual({ limit: 2 });
+        expect(body.query).toContain('customBlocks');
+        return new Response(JSON.stringify({ data: { customBlocks: { count: 2 } } }), {
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    });
+
+    const result = await provider.operations.customQuery<{ customBlocks: { count: number } }>(
+      gql`
+        query customBlocks($limit: Int!) {
+          customBlocks(limit: $limit) {
+            count
+          }
+        }
+      `,
+      { limit: 2 }
+    );
+
+    expect(result).toEqual({ customBlocks: { count: 2 } });
   });
 
   it('should ensure supports basic auth', async () => {

--- a/packages/account/src/providers/provider.ts
+++ b/packages/account/src/providers/provider.ts
@@ -443,6 +443,10 @@ type NodeInfoCache = Record<string, NodeInfo>;
 type Operations = ReturnType<typeof getOperationsSdk>;
 
 type SdkOperations = Omit<Operations, 'statusChange' | 'submitAndAwaitStatus'> & {
+  customQuery: <T = unknown>(
+    query: DocumentNode,
+    variables?: Record<string, unknown>
+  ) => Promise<T>;
   statusChange: (
     ...args: Parameters<Operations['statusChange']>
   ) => Promise<ReturnType<Operations['statusChange']>>;
@@ -943,6 +947,10 @@ export default class Provider {
     };
 
     const customOperations = (requester: Requester) => ({
+      customQuery<T = unknown>(query: DocumentNode, variables: Record<string, unknown> = {}) {
+        return requester<T>(query, variables);
+      },
+
       getBlobs(variables: { blobIds: string[] }) {
         const queryParams = variables.blobIds.map((_, i) => `$blobId${i}: BlobId!`).join(', ');
         const blobParams = variables.blobIds


### PR DESCRIPTION
- Closes #3095
# Summary

Expose `provider.operations.customQuery(query, variables)` through the existing GraphQL requester. SDK consumers can now submit custom GraphQL documents without bypassing Provider internals or losing the configured endpoint, headers, retry behavior, and response error handling.

# Breaking Changes

None.

# Checklist

- [x] The change includes focused test coverage.
- [ ] - [x] The public method is documented through its TypeScript signature.
- [ ] - [x] The complete diff was reviewed.
- [ ] - [x] No breaking changes were introduced.
Validation performed:

- `git diff --check` passed.
- - Local Prettier and Vitest binaries were unavailable in the sandbox.